### PR TITLE
feat: MiniClaw CLI command + comprehensive docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Security auditor for AI agent configurations (Claude Code, MCP servers, hooks, a
 
 ```bash
 npm run build      # tsc + tsup → dist/
-npm test           # vitest (82 tests)
+npm test           # vitest (342 tests)
 npm run dev        # tsx watch mode
 ```
 
@@ -36,6 +36,14 @@ src/
     pipeline.ts     # Opus 4.6 three-agent adversarial pipeline
     render.ts       # Opus analysis terminal + markdown rendering
     index.ts        # Pipeline entry point
+  miniclaw/
+    types.ts        # Core types (immutable, readonly)
+    sandbox.ts      # Sandbox lifecycle + path validation
+    router.ts       # Prompt sanitization + output filtering
+    tools.ts        # Whitelist-based tool authorization
+    server.ts       # HTTP server with rate limiting + CORS
+    dashboard.tsx   # React dashboard component
+    index.ts        # Entry point + startMiniClaw()
 ```
 
 ## Key Patterns
@@ -64,6 +72,8 @@ agentshield scan [path]              # Static analysis
 agentshield scan --opus              # + Opus 4.6 adversarial pipeline
 agentshield scan --format json|md    # Output format
 agentshield scan --fix               # Show auto-fix suggestions
+agentshield miniclaw start           # Launch MiniClaw secure agent server
+agentshield miniclaw start --port N  # Custom port
 ```
 
 ## Testing

--- a/package.json
+++ b/package.json
@@ -6,8 +6,18 @@
   "bin": {
     "agentshield": "./dist/index.js"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./miniclaw": {
+      "import": "./dist/miniclaw/index.js",
+      "types": "./dist/miniclaw/index.d.ts"
+    }
+  },
   "scripts": {
-    "build": "tsup src/index.ts src/action.ts --format esm --dts --clean",
+    "build": "tsup src/index.ts src/action.ts src/miniclaw/index.ts --format esm --dts --clean",
     "prepublishOnly": "npm run build",
     "dev": "tsx src/index.ts",
     "test": "vitest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { renderHtmlReport } from "./reporter/html.js";
 import { runOpusPipeline, renderOpusAnalysis } from "./opus/index.js";
 import { applyFixes, renderFixSummary } from "./fixer/index.js";
 import { runInit, renderInitSummary } from "./init/index.js";
+import { startMiniClaw } from "./miniclaw/index.js";
 
 const program = new Command();
 
@@ -111,6 +112,92 @@ program
   .action((options) => {
     const initResult = runInit(options.path);
     console.log(renderInitSummary(initResult));
+  });
+
+// ─── MiniClaw Commands ───────────────────────────────────
+
+const miniclaw = program
+  .command("miniclaw")
+  .description("MiniClaw — minimal secure sandboxed AI agent runtime");
+
+miniclaw
+  .command("start")
+  .description("Start the MiniClaw server")
+  .option("-p, --port <port>", "Port to listen on", "3847")
+  .option("-H, --hostname <hostname>", "Hostname to bind to", "localhost")
+  .option("--network <policy>", "Network policy: none, localhost, allowlist", "none")
+  .option("--rate-limit <limit>", "Max requests per minute per IP", "10")
+  .option("--sandbox-root <path>", "Root path for sandbox directories", "/tmp/miniclaw-sandboxes")
+  .option("--max-duration <ms>", "Max session duration in milliseconds", "300000")
+  .action((options) => {
+    const port = parseInt(options.port, 10);
+    const rateLimit = parseInt(options.rateLimit, 10);
+    const maxDuration = parseInt(options.maxDuration, 10);
+
+    if (isNaN(port) || port < 1 || port > 65535) {
+      console.error("Error: Invalid port number. Must be between 1 and 65535.");
+      process.exit(1);
+    }
+
+    if (isNaN(rateLimit) || rateLimit < 1) {
+      console.error("Error: Invalid rate limit. Must be a positive integer.");
+      process.exit(1);
+    }
+
+    const networkPolicy = options.network as "none" | "localhost" | "allowlist";
+    if (!["none", "localhost", "allowlist"].includes(networkPolicy)) {
+      console.error("Error: Invalid network policy. Must be: none, localhost, or allowlist.");
+      process.exit(1);
+    }
+
+    console.log(`\n  MiniClaw — Secure Agent Runtime\n`);
+    console.log(`  Starting server...`);
+    console.log(`  Port:           ${port}`);
+    console.log(`  Hostname:       ${options.hostname}`);
+    console.log(`  Network policy: ${networkPolicy}`);
+    console.log(`  Rate limit:     ${rateLimit} req/min`);
+    console.log(`  Sandbox root:   ${options.sandboxRoot}`);
+    console.log(`  Max duration:   ${maxDuration}ms\n`);
+
+    const { server } = startMiniClaw({
+      server: {
+        port,
+        hostname: options.hostname,
+        corsOrigins: [
+          `http://${options.hostname}:${port}`,
+          "http://localhost:3000",
+        ],
+        rateLimit,
+        maxRequestSize: 10_240,
+      },
+      sandbox: {
+        rootPath: options.sandboxRoot,
+        maxFileSize: 10_485_760,
+        allowedExtensions: [
+          ".ts", ".tsx", ".js", ".jsx", ".json", ".md", ".txt",
+          ".css", ".html", ".yaml", ".yml", ".toml", ".xml",
+          ".csv", ".svg", ".env.example",
+        ],
+        networkPolicy,
+        maxDuration,
+      },
+    });
+
+    server.on("listening", () => {
+      console.log(`  Listening on http://${options.hostname}:${port}`);
+      console.log(`  Health check: http://${options.hostname}:${port}/api/health`);
+      console.log(`\n  Press Ctrl+C to stop.\n`);
+    });
+
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        console.error(`\n  Error: Port ${port} is already in use.`);
+        console.error(`  Try a different port: agentshield miniclaw start --port 4000\n`);
+      } else {
+        console.error(`\n  Server error: ${err.message}\n`);
+      }
+      process.exit(1);
+    });
   });
 
 program.parse();


### PR DESCRIPTION
## Summary

- Add `agentshield miniclaw start` CLI command that launches the MiniClaw secure agent server with full configuration options (port, hostname, network policy, rate limiting, sandbox root, session duration)
- Update `package.json` with `exports` map so consumers can deep-import via `ecc-agentshield/miniclaw`
- Expand README MiniClaw section with CLI quick start, `curl` API examples, security model flow diagram, tool authorization tier table, and architecture overview
- Update CLAUDE.md with MiniClaw architecture tree and CLI reference

## Changes

| File | Change |
|------|--------|
| `src/index.ts` | Add `miniclaw` command group with `start` subcommand (Commander.js) |
| `package.json` | Add `exports` map for `./miniclaw` entry point, include miniclaw in build |
| `README.md` | Comprehensive MiniClaw docs: CLI usage, curl examples, security model diagram, tool tiers |
| `CLAUDE.md` | Add miniclaw to architecture tree, CLI reference, update test count |

## CLI Usage

```bash
# Start with defaults (localhost:3847, no network, safe tools)
npx ecc-agentshield miniclaw start

# Custom configuration
npx ecc-agentshield miniclaw start --port 4000 --network localhost --rate-limit 20
```

## Test plan

- [x] All 342 tests pass
- [x] Build succeeds with miniclaw entry point
- [x] `agentshield miniclaw --help` shows subcommand
- [x] `agentshield miniclaw start --help` shows all options
- [x] Server starts and responds to health check at `/api/health`
- [x] Port validation rejects invalid values
- [x] EADDRINUSE error shows helpful message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added MiniClaw subsystem with a new CLI command `miniclaw start` supporting configurable port, hostname, network policy, rate limiting, sandbox root, and maximum duration settings.

* **Documentation**
  * Comprehensive README updates including architecture diagrams, security model details, API endpoints, configuration defaults, and usage examples for CLI and library integration.

* **Tests**
  * Expanded test suite from 202 to 342 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->