### PR TITLE
feat: PR security gate with baseline comparison (#16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:batch:analysis": "vitest run tests/integration.test.ts tests/injection.test.ts tests/action.test.ts",
     "test:batch:miniclaw-a": "vitest run tests/miniclaw/index.test.ts tests/miniclaw/server.test.ts",
     "test:batch:miniclaw-b": "vitest run tests/miniclaw/cli.test.ts tests/miniclaw/sandbox.test.ts",
-    "test:batch:misc": "vitest run tests/corpus.test.ts tests/logger.test.ts tests/init/init.test.ts tests/taint/taint.test.ts tests/opus/*.test.ts tests/fixer/*.test.ts tests/types.test.ts tests/skills/*.test.ts tests/miniclaw/router.test.ts tests/miniclaw/tools.test.ts tests/miniclaw/types.test.ts tests/sandbox/sandbox.test.ts tests/threat-intel/*.test.ts tests/watch/*.test.ts tests/runtime/*.test.ts",
+    "test:batch:misc": "vitest run tests/corpus.test.ts tests/logger.test.ts tests/init/init.test.ts tests/taint/taint.test.ts tests/opus/*.test.ts tests/fixer/*.test.ts tests/types.test.ts tests/skills/*.test.ts tests/miniclaw/router.test.ts tests/miniclaw/tools.test.ts tests/miniclaw/types.test.ts tests/sandbox/sandbox.test.ts tests/threat-intel/*.test.ts tests/watch/*.test.ts tests/runtime/*.test.ts tests/baseline/*.test.ts",
     "test:coverage": "vitest --coverage",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit",

--- a/src/action.ts
+++ b/src/action.ts
@@ -90,6 +90,8 @@ async function run(): Promise<void> {
   const minSeverity = getInput("min-severity", "medium");
   const failOnFindings = getInput("fail-on-findings", "true") === "true";
   const format = getInput("format", "terminal");
+  const baselinePath = getInput("baseline", "");
+  const saveBaselinePath = getInput("save-baseline", "");
 
   // Resolve and validate path
   const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
@@ -140,6 +142,48 @@ async function run(): Promise<void> {
   console.log(`  Medium: ${report.summary.medium}`);
   console.log(`  Low: ${report.summary.low}`);
   console.log(`  Info: ${report.summary.info}`);
+
+  // Save baseline if requested
+  if (saveBaselinePath) {
+    const { saveBaseline } = await import("./baseline/index.js");
+    const savePath = resolve(workspace, saveBaselinePath);
+    saveBaseline(filteredResult.findings, report.score, savePath);
+    setOutput("baseline-path", savePath);
+    console.log(`Baseline saved to: ${savePath}`);
+  }
+
+  // Compare against baseline if provided
+  if (baselinePath) {
+    const { loadBaseline, compareBaseline, evaluateGate } = await import("./baseline/index.js");
+    const baseline = loadBaseline(resolve(workspace, baselinePath));
+
+    if (baseline) {
+      const comparison = compareBaseline(baseline, filteredResult.findings, report.score);
+
+      setOutput("new-findings", String(comparison.newFindings.length));
+      setOutput("resolved-findings", String(comparison.resolvedFindings.length));
+      setOutput("score-delta", String(comparison.scoreDelta));
+
+      // Emit annotations only for NEW findings (regression-only mode)
+      if (comparison.newFindings.length > 0) {
+        console.log("");
+        console.log(`Baseline comparison: ${comparison.newFindings.length} new, ${comparison.resolvedFindings.length} resolved`);
+        emitAnnotations(comparison.newFindings);
+      }
+
+      const gateResult = evaluateGate(comparison);
+      if (!gateResult.passed) {
+        console.log("");
+        console.log(`::error::AgentShield gate FAILED: ${gateResult.reasons.join("; ")}`);
+        process.exitCode = 1;
+        return;
+      } else {
+        console.log("Baseline gate: PASSED");
+      }
+    } else {
+      console.log(`::warning::Could not load baseline from ${baselinePath}. Skipping comparison.`);
+    }
+  }
 
   // Fail if requested and findings exist
   if (failOnFindings && filteredResult.findings.length > 0) {

--- a/src/baseline/compare.ts
+++ b/src/baseline/compare.ts
@@ -1,0 +1,236 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+import type { Finding, SecurityScore } from "../types.js";
+import type {
+  SerializedBaseline,
+  SerializedFinding,
+  BaselineComparison,
+  GateConfig,
+  GateResult,
+} from "./types.js";
+import { DEFAULT_GATE_CONFIG } from "./types.js";
+
+/**
+ * Create a fingerprint for a finding (stable across scans).
+ */
+export function fingerprintFinding(finding: Finding): string {
+  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
+}
+
+/**
+ * Save current scan results as a baseline file.
+ */
+export function saveBaseline(
+  findings: ReadonlyArray<Finding>,
+  score: SecurityScore,
+  outputPath: string
+): void {
+  const serialized: SerializedBaseline = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    score,
+    findings: findings.map((f) => ({
+      id: f.id,
+      severity: f.severity,
+      category: f.category,
+      title: f.title,
+      file: f.file,
+      evidence: f.evidence,
+      fingerprint: fingerprintFinding(f),
+    })),
+  };
+
+  const dir = dirname(outputPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  writeFileSync(outputPath, JSON.stringify(serialized, null, 2));
+}
+
+/**
+ * Load a baseline from a JSON file.
+ */
+export function loadBaseline(baselinePath: string): SerializedBaseline | null {
+  if (!existsSync(baselinePath)) return null;
+
+  try {
+    const raw = readFileSync(baselinePath, "utf-8");
+    const parsed = JSON.parse(raw);
+
+    if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
+      return null;
+    }
+
+    return parsed as SerializedBaseline;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare current scan results against a stored baseline.
+ */
+export function compareBaseline(
+  baseline: SerializedBaseline,
+  currentFindings: ReadonlyArray<Finding>,
+  currentScore: SecurityScore
+): BaselineComparison {
+  const baselineFingerprints = new Set(
+    baseline.findings.map((f) => f.fingerprint)
+  );
+  const currentFingerprints = new Set(
+    currentFindings.map(fingerprintFinding)
+  );
+
+  const newFindings = currentFindings.filter(
+    (f) => !baselineFingerprints.has(fingerprintFinding(f))
+  );
+
+  const resolvedFindings = baseline.findings.filter(
+    (f) => !currentFingerprints.has(f.fingerprint)
+  );
+
+  const unchangedCount =
+    currentFindings.length - newFindings.length;
+
+  const scoreDelta =
+    currentScore.numericScore - baseline.score.numericScore;
+
+  const newCriticalCount = newFindings.filter(
+    (f) => f.severity === "critical"
+  ).length;
+  const newHighCount = newFindings.filter(
+    (f) => f.severity === "high"
+  ).length;
+
+  const isRegression =
+    newFindings.length > 0 || scoreDelta < 0;
+
+  return {
+    timestamp: new Date().toISOString(),
+    baselineTimestamp: baseline.timestamp,
+    newFindings,
+    resolvedFindings,
+    unchangedCount,
+    scoreDelta,
+    baselineScore: baseline.score.numericScore,
+    currentScore: currentScore.numericScore,
+    isRegression,
+    newCriticalCount,
+    newHighCount,
+  };
+}
+
+/**
+ * Evaluate a baseline comparison against gate configuration.
+ * Returns pass/fail and reasons.
+ */
+export function evaluateGate(
+  comparison: BaselineComparison,
+  config: GateConfig = DEFAULT_GATE_CONFIG
+): GateResult {
+  const reasons: string[] = [];
+
+  if (config.failOnNewCritical && comparison.newCriticalCount > 0) {
+    reasons.push(
+      `${comparison.newCriticalCount} new critical finding(s) introduced`
+    );
+  }
+
+  if (config.failOnNewHigh && comparison.newHighCount > 0) {
+    reasons.push(
+      `${comparison.newHighCount} new high finding(s) introduced`
+    );
+  }
+
+  if (comparison.newFindings.length > config.maxNewFindings) {
+    reasons.push(
+      `${comparison.newFindings.length} new finding(s) exceed threshold of ${config.maxNewFindings}`
+    );
+  }
+
+  if (comparison.scoreDelta < -config.maxScoreDrop) {
+    reasons.push(
+      `Score dropped by ${Math.abs(comparison.scoreDelta)} points (max allowed: ${config.maxScoreDrop})`
+    );
+  }
+
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    comparison,
+  };
+}
+
+/**
+ * Render a baseline comparison for the terminal.
+ */
+export function renderComparison(comparison: BaselineComparison): string {
+  const lines: string[] = [];
+  const divider = "─".repeat(60);
+
+  lines.push("");
+  lines.push(`  ${divider}`);
+  lines.push("  Baseline Comparison Report");
+  lines.push(`  ${divider}`);
+  lines.push("");
+
+  const direction = comparison.scoreDelta > 0 ? "+" : "";
+  const label = comparison.scoreDelta > 0
+    ? "IMPROVED"
+    : comparison.scoreDelta < 0
+      ? "REGRESSED"
+      : "UNCHANGED";
+
+  lines.push(
+    `  Score: ${comparison.baselineScore} → ${comparison.currentScore} (${direction}${comparison.scoreDelta}) [${label}]`
+  );
+  lines.push(
+    `  Baseline from: ${comparison.baselineTimestamp}`
+  );
+  lines.push("");
+
+  if (comparison.newFindings.length > 0) {
+    lines.push(`  NEW FINDINGS (${comparison.newFindings.length}):`);
+    for (const f of comparison.newFindings) {
+      lines.push(`    [${f.severity.toUpperCase().padEnd(8)}] ${f.title}`);
+      lines.push(`               ${f.file}`);
+    }
+    lines.push("");
+  }
+
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push(`  RESOLVED FINDINGS (${comparison.resolvedFindings.length}):`);
+    for (const f of comparison.resolvedFindings) {
+      lines.push(`    [RESOLVED] ${f.title}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(`  Unchanged: ${comparison.unchangedCount} finding(s)`);
+  lines.push(`  ${divider}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/**
+ * Render gate result for terminal output.
+ */
+export function renderGateResult(result: GateResult): string {
+  const lines: string[] = [];
+
+  if (result.passed) {
+    lines.push("  Gate: PASSED — No regressions detected.");
+  } else {
+    lines.push("  Gate: FAILED — Security regressions detected:");
+    for (const reason of result.reasons) {
+      lines.push(`    - ${reason}`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/baseline/index.ts
+++ b/src/baseline/index.ts
@@ -1,0 +1,17 @@
+export {
+  fingerprintFinding,
+  saveBaseline,
+  loadBaseline,
+  compareBaseline,
+  evaluateGate,
+  renderComparison,
+  renderGateResult,
+} from "./compare.js";
+export { DEFAULT_GATE_CONFIG } from "./types.js";
+export type {
+  SerializedBaseline,
+  SerializedFinding,
+  BaselineComparison,
+  GateConfig,
+  GateResult,
+} from "./types.js";

--- a/src/baseline/types.ts
+++ b/src/baseline/types.ts
@@ -1,0 +1,60 @@
+import type { Finding, SecurityScore, Severity } from "../types.js";
+
+// ─── Serialized Baseline ────────────────────────────────────
+
+export interface SerializedBaseline {
+  readonly version: 1;
+  readonly timestamp: string;
+  readonly score: SecurityScore;
+  readonly findings: ReadonlyArray<SerializedFinding>;
+}
+
+export interface SerializedFinding {
+  readonly id: string;
+  readonly severity: Severity;
+  readonly category: string;
+  readonly title: string;
+  readonly file: string;
+  readonly evidence?: string;
+  readonly fingerprint: string;
+}
+
+// ─── Comparison Result ──────────────────────────────────────
+
+export interface BaselineComparison {
+  readonly timestamp: string;
+  readonly baselineTimestamp: string;
+  readonly newFindings: ReadonlyArray<Finding>;
+  readonly resolvedFindings: ReadonlyArray<SerializedFinding>;
+  readonly unchangedCount: number;
+  readonly scoreDelta: number;
+  readonly baselineScore: number;
+  readonly currentScore: number;
+  readonly isRegression: boolean;
+  readonly newCriticalCount: number;
+  readonly newHighCount: number;
+}
+
+// ─── Gate Configuration ─────────────────────────────────────
+
+export interface GateConfig {
+  readonly maxNewFindings: number;
+  readonly maxScoreDrop: number;
+  readonly failOnNewCritical: boolean;
+  readonly failOnNewHigh: boolean;
+}
+
+export const DEFAULT_GATE_CONFIG: GateConfig = {
+  maxNewFindings: 0,
+  maxScoreDrop: 5,
+  failOnNewCritical: true,
+  failOnNewHigh: true,
+};
+
+// ─── Gate Result ────────────────────────────────────────────
+
+export interface GateResult {
+  readonly passed: boolean;
+  readonly reasons: ReadonlyArray<string>;
+  readonly comparison: BaselineComparison;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,9 @@ program
   .option("--log <path>", "Write structured scan log to file")
   .option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson")
   .option("--corpus", "Run scanner validation against built-in attack corpus", false)
+  .option("--baseline <path>", "Compare against a baseline file and report regressions")
+  .option("--save-baseline <path>", "Save current scan results as a baseline file")
+  .option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false)
   .option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info")
   .option("-v, --verbose", "Show detailed output", false)
   .action(async (options) => {
@@ -268,6 +271,40 @@ program
         break;
       default:
         console.log(renderTerminalReport(report));
+    }
+
+    // ── Phase 1b: Baseline save/compare ───────────────────
+    if (options.saveBaseline) {
+      const { saveBaseline } = await import("./baseline/index.js");
+      saveBaseline(filteredResult.findings, report.score, options.saveBaseline);
+      console.log(`\n  Baseline saved to: ${options.saveBaseline}\n`);
+      logger.log({ level: "info", phase: "baseline", message: `Baseline saved to ${options.saveBaseline}` });
+    }
+
+    if (options.baseline) {
+      const { loadBaseline, compareBaseline, evaluateGate, renderComparison, renderGateResult } =
+        await import("./baseline/index.js");
+      const baseline = loadBaseline(options.baseline);
+      if (!baseline) {
+        console.error(`\n  Error: Could not load baseline from ${options.baseline}\n`);
+      } else {
+        const comparison = compareBaseline(baseline, filteredResult.findings, report.score);
+        console.log(renderComparison(comparison));
+        logger.log({
+          level: comparison.isRegression ? "warn" : "info",
+          phase: "baseline",
+          message: `Baseline comparison: ${comparison.newFindings.length} new, ${comparison.resolvedFindings.length} resolved, score delta ${comparison.scoreDelta}`,
+        });
+
+        if (options.gate) {
+          const gateResult = evaluateGate(comparison);
+          console.log(renderGateResult(gateResult));
+          if (!gateResult.passed) {
+            logger.log({ level: "error", phase: "gate", message: `Gate FAILED: ${gateResult.reasons.join("; ")}` });
+            process.exit(3);
+          }
+        }
+      }
     }
 
     // ── Phase 2: Auto-fix (if enabled) ──────────────────────

--- a/tests/baseline/compare.test.ts
+++ b/tests/baseline/compare.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  fingerprintFinding,
+  saveBaseline,
+  loadBaseline,
+  compareBaseline,
+  evaluateGate,
+  renderComparison,
+  renderGateResult,
+} from "../../src/baseline/compare.js";
+import type { Finding, SecurityScore } from "../../src/types.js";
+import type { SerializedBaseline } from "../../src/baseline/types.js";
+
+const FIXTURES_DIR = join(process.cwd(), "tests", "baseline", "__fixtures__");
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "test-rule",
+    severity: "medium",
+    category: "permissions",
+    title: "Test finding",
+    description: "A test finding",
+    file: "settings.json",
+    evidence: "some evidence",
+    ...overrides,
+  };
+}
+
+function makeScore(overrides: Partial<SecurityScore> = {}): SecurityScore {
+  return {
+    grade: "B",
+    numericScore: 80,
+    breakdown: { secrets: 0, permissions: 1, hooks: 0, mcp: 0, agents: 0 },
+    ...overrides,
+  };
+}
+
+function makeBaseline(overrides: Partial<SerializedBaseline> = {}): SerializedBaseline {
+  return {
+    version: 1,
+    timestamp: "2026-03-20T10:00:00.000Z",
+    score: makeScore({ numericScore: 80 }),
+    findings: [
+      {
+        id: "R1",
+        severity: "medium",
+        category: "permissions",
+        title: "Finding 1",
+        file: "a.json",
+        evidence: "ev1",
+        fingerprint: "R1::a.json::ev1",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function setup(): void {
+  if (existsSync(FIXTURES_DIR)) {
+    rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  }
+  mkdirSync(FIXTURES_DIR, { recursive: true });
+}
+
+function cleanup(): void {
+  if (existsSync(FIXTURES_DIR)) {
+    rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  }
+}
+
+afterEach(cleanup);
+
+describe("fingerprintFinding", () => {
+  it("generates stable fingerprint", () => {
+    const f = makeFinding({ id: "X", file: "y.json", evidence: "z" });
+    expect(fingerprintFinding(f)).toBe("X::y.json::z");
+  });
+
+  it("handles missing evidence", () => {
+    const f = makeFinding({ id: "X", file: "y.json", evidence: undefined });
+    expect(fingerprintFinding(f)).toBe("X::y.json::");
+  });
+});
+
+describe("saveBaseline / loadBaseline", () => {
+  it("round-trips correctly", () => {
+    setup();
+    const path = join(FIXTURES_DIR, "baseline.json");
+    const findings = [makeFinding({ id: "R1", file: "a.json", evidence: "ev1" })];
+    const score = makeScore({ numericScore: 85 });
+
+    saveBaseline(findings, score, path);
+    const loaded = loadBaseline(path);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.version).toBe(1);
+    expect(loaded!.score.numericScore).toBe(85);
+    expect(loaded!.findings).toHaveLength(1);
+    expect(loaded!.findings[0].fingerprint).toBe("R1::a.json::ev1");
+  });
+
+  it("creates parent directories", () => {
+    setup();
+    const path = join(FIXTURES_DIR, "deep", "nested", "baseline.json");
+    saveBaseline([], makeScore(), path);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("returns null for non-existent file", () => {
+    expect(loadBaseline("/tmp/nonexistent-baseline-test-12345.json")).toBeNull();
+  });
+
+  it("returns null for invalid JSON", () => {
+    setup();
+    const path = join(FIXTURES_DIR, "bad.json");
+    writeFileSync(path, "not json{{");
+    expect(loadBaseline(path)).toBeNull();
+  });
+
+  it("returns null for wrong version", () => {
+    setup();
+    const path = join(FIXTURES_DIR, "v2.json");
+    writeFileSync(path, JSON.stringify({ version: 2, findings: [] }));
+    expect(loadBaseline(path)).toBeNull();
+  });
+});
+
+describe("compareBaseline", () => {
+  it("detects new findings", () => {
+    const baseline = makeBaseline();
+    const currentFindings = [
+      makeFinding({ id: "R1", file: "a.json", evidence: "ev1" }),
+      makeFinding({ id: "R2", file: "b.json", evidence: "ev2", severity: "high" }),
+    ];
+    const currentScore = makeScore({ numericScore: 70 });
+
+    const result = compareBaseline(baseline, currentFindings, currentScore);
+
+    expect(result.newFindings).toHaveLength(1);
+    expect(result.newFindings[0].id).toBe("R2");
+    expect(result.resolvedFindings).toHaveLength(0);
+    expect(result.isRegression).toBe(true);
+    expect(result.scoreDelta).toBe(-10);
+    expect(result.newHighCount).toBe(1);
+  });
+
+  it("detects resolved findings", () => {
+    const baseline = makeBaseline({
+      findings: [
+        { id: "R1", severity: "medium", category: "permissions", title: "F1", file: "a.json", evidence: "ev1", fingerprint: "R1::a.json::ev1" },
+        { id: "R2", severity: "high", category: "hooks", title: "F2", file: "b.json", evidence: "ev2", fingerprint: "R2::b.json::ev2" },
+      ],
+    });
+    const currentFindings = [makeFinding({ id: "R1", file: "a.json", evidence: "ev1" })];
+    const currentScore = makeScore({ numericScore: 90 });
+
+    const result = compareBaseline(baseline, currentFindings, currentScore);
+
+    expect(result.resolvedFindings).toHaveLength(1);
+    expect(result.resolvedFindings[0].id).toBe("R2");
+    expect(result.isRegression).toBe(false);
+  });
+
+  it("reports no changes", () => {
+    const baseline = makeBaseline();
+    const currentFindings = [makeFinding({ id: "R1", file: "a.json", evidence: "ev1" })];
+    const currentScore = makeScore({ numericScore: 80 });
+
+    const result = compareBaseline(baseline, currentFindings, currentScore);
+
+    expect(result.newFindings).toHaveLength(0);
+    expect(result.resolvedFindings).toHaveLength(0);
+    expect(result.isRegression).toBe(false);
+    expect(result.unchangedCount).toBe(1);
+  });
+
+  it("detects critical regressions", () => {
+    const baseline = makeBaseline();
+    const currentFindings = [
+      makeFinding({ id: "R1", file: "a.json", evidence: "ev1" }),
+      makeFinding({ id: "CRIT", file: "x.json", evidence: "e", severity: "critical" }),
+    ];
+    const currentScore = makeScore({ numericScore: 50 });
+
+    const result = compareBaseline(baseline, currentFindings, currentScore);
+
+    expect(result.newCriticalCount).toBe(1);
+    expect(result.isRegression).toBe(true);
+  });
+});
+
+describe("evaluateGate", () => {
+  it("passes when no regressions", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "then",
+      newFindings: [],
+      resolvedFindings: [],
+      unchangedCount: 1,
+      scoreDelta: 0,
+      baselineScore: 80,
+      currentScore: 80,
+      isRegression: false,
+      newCriticalCount: 0,
+      newHighCount: 0,
+    };
+
+    const result = evaluateGate(comparison);
+    expect(result.passed).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it("fails on new critical findings", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "then",
+      newFindings: [makeFinding({ severity: "critical" })],
+      resolvedFindings: [],
+      unchangedCount: 0,
+      scoreDelta: -25,
+      baselineScore: 100,
+      currentScore: 75,
+      isRegression: true,
+      newCriticalCount: 1,
+      newHighCount: 0,
+    };
+
+    const result = evaluateGate(comparison);
+    expect(result.passed).toBe(false);
+    expect(result.reasons.some((r) => r.includes("critical"))).toBe(true);
+  });
+
+  it("fails on new high findings", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "then",
+      newFindings: [makeFinding({ severity: "high" })],
+      resolvedFindings: [],
+      unchangedCount: 0,
+      scoreDelta: -15,
+      baselineScore: 100,
+      currentScore: 85,
+      isRegression: true,
+      newCriticalCount: 0,
+      newHighCount: 1,
+    };
+
+    const result = evaluateGate(comparison);
+    expect(result.passed).toBe(false);
+    expect(result.reasons.some((r) => r.includes("high"))).toBe(true);
+  });
+
+  it("fails on score drop exceeding threshold", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "then",
+      newFindings: [],
+      resolvedFindings: [],
+      unchangedCount: 1,
+      scoreDelta: -10,
+      baselineScore: 80,
+      currentScore: 70,
+      isRegression: true,
+      newCriticalCount: 0,
+      newHighCount: 0,
+    };
+
+    const result = evaluateGate(comparison, {
+      maxNewFindings: 0,
+      maxScoreDrop: 5,
+      failOnNewCritical: true,
+      failOnNewHigh: true,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reasons.some((r) => r.includes("Score dropped"))).toBe(true);
+  });
+
+  it("respects custom gate config", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "then",
+      newFindings: [makeFinding({ severity: "high" })],
+      resolvedFindings: [],
+      unchangedCount: 0,
+      scoreDelta: -3,
+      baselineScore: 80,
+      currentScore: 77,
+      isRegression: true,
+      newCriticalCount: 0,
+      newHighCount: 1,
+    };
+
+    // Allow high findings
+    const result = evaluateGate(comparison, {
+      maxNewFindings: 5,
+      maxScoreDrop: 10,
+      failOnNewCritical: true,
+      failOnNewHigh: false,
+    });
+    expect(result.passed).toBe(true);
+  });
+});
+
+describe("renderComparison", () => {
+  it("renders comparison with new findings", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "2026-03-19T10:00:00Z",
+      newFindings: [makeFinding({ severity: "high", title: "New issue" })],
+      resolvedFindings: [],
+      unchangedCount: 1,
+      scoreDelta: -10,
+      baselineScore: 90,
+      currentScore: 80,
+      isRegression: true,
+      newCriticalCount: 0,
+      newHighCount: 1,
+    };
+
+    const output = renderComparison(comparison);
+    expect(output).toContain("Baseline Comparison");
+    expect(output).toContain("90 → 80");
+    expect(output).toContain("REGRESSED");
+    expect(output).toContain("NEW FINDINGS (1)");
+    expect(output).toContain("New issue");
+  });
+
+  it("renders resolved findings", () => {
+    const comparison = {
+      timestamp: "now",
+      baselineTimestamp: "2026-03-19T10:00:00Z",
+      newFindings: [],
+      resolvedFindings: [
+        { id: "R1", severity: "medium" as const, category: "permissions", title: "Fixed", file: "a.json", fingerprint: "R1::a.json::" },
+      ],
+      unchangedCount: 0,
+      scoreDelta: 10,
+      baselineScore: 70,
+      currentScore: 80,
+      isRegression: false,
+      newCriticalCount: 0,
+      newHighCount: 0,
+    };
+
+    const output = renderComparison(comparison);
+    expect(output).toContain("IMPROVED");
+    expect(output).toContain("RESOLVED FINDINGS (1)");
+  });
+});
+
+describe("renderGateResult", () => {
+  it("renders passed gate", () => {
+    const output = renderGateResult({
+      passed: true,
+      reasons: [],
+      comparison: {} as any,
+    });
+    expect(output).toContain("PASSED");
+  });
+
+  it("renders failed gate with reasons", () => {
+    const output = renderGateResult({
+      passed: false,
+      reasons: ["1 new critical finding(s)", "Score dropped by 15"],
+      comparison: {} as any,
+    });
+    expect(output).toContain("FAILED");
+    expect(output).toContain("critical");
+    expect(output).toContain("Score dropped");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `--save-baseline <path>` to save scan results as a JSON baseline
- Adds `--baseline <path>` to compare current scan against a stored baseline
- Adds `--gate` flag to fail (exit 3) on new critical/high findings or score drops
- GitHub Action integration: `baseline` and `save-baseline` inputs with inline annotations for new-only findings
- Fingerprint-based diffing (`id::file::evidence`) for stable comparisons across scans

## Usage
```bash
# Save baseline on main branch
agentshield scan --save-baseline .agentshield/baseline.json

# Compare on PR branch
agentshield scan --baseline .agentshield/baseline.json --gate
```

## New Files
- `src/baseline/types.ts` — SerializedBaseline, BaselineComparison, GateConfig types
- `src/baseline/compare.ts` — Baseline save/load/compare/gate evaluation
- `src/baseline/index.ts` — Barrel exports
- `tests/baseline/compare.test.ts` — 20 tests

## Test plan
- [x] 20 new tests pass
- [x] Full suite passes (439 tests)
- [x] Build succeeds

Closes #16

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PR security gate with baseline comparison to block security regressions and annotate new findings in CI. Adds CLI flags and Action inputs to save/compare baselines, render diffs, and fail on new critical/high issues or score drops.

- **New Features**
  - CLI: `--save-baseline <path>`, `--baseline <path>`, `--gate` (exit 3 on gate fail); renders comparison and gate summary in terminal.
  - Gate policy: fail on any new critical/high findings, score drop > 5, or > 0 new findings; fingerprint diff (`id::file::evidence`) for stable comparisons.
  - GitHub Action: `baseline` and `save-baseline` inputs; outputs `new-findings`, `resolved-findings`, `score-delta`, `baseline-path`; inline annotations for new-only findings.

- **Migration**
  - On main: `agentshield scan --save-baseline .agentshield/baseline.json`
  - On PRs: `agentshield scan --baseline .agentshield/baseline.json --gate`
  - In CI: set Action inputs `baseline`/`save-baseline` to enable comparison and gating.

<sup>Written for commit 16f007394621f0ea87d7d83e156f1b9866ab2e7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

