### PR TITLE
feat: detect `npx -c` / `--call` shell execution in MCP servers

### DIFF
--- a/dist/action.js
+++ b/dist/action.js
@@ -5198,6 +5198,86 @@ var rawMcpRules = [
       }
       return findings;
     }
+  },
+  {
+    id: "mcp-npx-shell-exec",
+    name: "MCP npx shell-exec flag",
+    description: "Checks for MCP servers using `npx -c` / `--call` (including `--call=\u2026`) \u2014 these pass the argument to the user's shell, giving RCE equivalent to `sh -c`.",
+    severity: "high",
+    category: "mcp",
+    check(file) {
+      if (file.type !== "mcp-json" && file.type !== "settings-json") return [];
+      const findings = [];
+      function isNpxCommand(cmd) {
+        if (!cmd) return false;
+        const basename3 = cmd.split(/[\\/]/).pop() ?? "";
+        return basename3 === "npx" || basename3 === "npx.cmd" || basename3 === "npx.exe";
+      }
+      const npxValueTakingOptions = /* @__PURE__ */ new Set([
+        "-p",
+        "--package",
+        "-w",
+        "--workspace",
+        "--workspaces",
+        "--registry",
+        "--loglevel",
+        "--userconfig",
+        "--globalconfig",
+        "--prefix"
+      ]);
+      function findShellExecFlag(args) {
+        let i = 0;
+        while (i < args.length) {
+          const raw = args[i];
+          if (typeof raw !== "string") return void 0;
+          if (raw === "-c" || raw === "--call") return raw;
+          if (raw.startsWith("--call=")) return "--call";
+          if (raw.startsWith("--") && raw.includes("=")) {
+            i++;
+            continue;
+          }
+          if (npxValueTakingOptions.has(raw)) {
+            i += 2;
+            continue;
+          }
+          if (raw.startsWith("-")) {
+            i++;
+            continue;
+          }
+          return void 0;
+        }
+        return void 0;
+      }
+      try {
+        const config = JSON.parse(file.content);
+        const servers = config.mcpServers ?? {};
+        for (const [name, server] of Object.entries(servers)) {
+          const serverConfig = server;
+          const command = serverConfig.command;
+          const args = serverConfig.args ?? [];
+          if (!isNpxCommand(command) || !Array.isArray(args)) continue;
+          const matchedFlag = findShellExecFlag(args);
+          if (!matchedFlag) continue;
+          findings.push({
+            id: `mcp-npx-shell-exec-${name}`,
+            severity: "high",
+            category: "mcp",
+            title: `MCP server "${name}" uses npx ${matchedFlag} (shell execution)`,
+            description: `The MCP server "${name}" invokes \`npx ${matchedFlag}\` which passes the next argument to the user's shell \u2014 identical RCE primitive to \`sh -c\`. This is the Flowise bypass pattern (Ox Security "Mother of All AI Supply Chains", Family 2).`,
+            file: file.path,
+            evidence: `command: ${command}, args: ${JSON.stringify(args)}`,
+            fix: {
+              description: "Remove `-c` / `--call`. Pin to a specific package version with `npx <pkg>@<version>` instead; if shell execution is required, declare the target binary explicitly rather than piggy-backing on npx.",
+              before: `"command": "${command}", "args": ${JSON.stringify(args)}`,
+              after: `"command": "npx", "args": ["<package>@<version>"]`,
+              auto: false
+            }
+          });
+        }
+      } catch {
+      }
+      return findings;
+    }
   }
 ];
 var mcpRules = rawMcpRules.map((rule) => ({

--- a/dist/action.js
+++ b/dist/action.js
@@ -5199,6 +5199,17 @@ var rawMcpRules = [
       return findings;
     }
   },
+  /**
+   * Detects MCP servers that invoke `npx -c` / `--call` (or `--call=…`).
+   *
+   * These flags pass the trailing argument to the user's shell, giving an
+   * RCE primitive equivalent to `sh -c`. This is the Flowise bypass pattern
+   * documented by Ox Security ("Mother of All AI Supply Chains", Family 2).
+   *
+   * The rule only scans flags that appear **before** the first positional
+   * (package name) in the args array — anything after the package belongs
+   * to the downstream command and must not be matched.
+   */
   {
     id: "mcp-npx-shell-exec",
     name: "MCP npx shell-exec flag",
@@ -5218,7 +5229,6 @@ var rawMcpRules = [
         "--package",
         "-w",
         "--workspace",
-        "--workspaces",
         "--registry",
         "--loglevel",
         "--userconfig",

--- a/dist/index.js
+++ b/dist/index.js
@@ -5033,6 +5033,17 @@ var init_mcp = __esm({
           return findings;
         }
       },
+      /**
+       * Detects MCP servers that invoke `npx -c` / `--call` (or `--call=…`).
+       *
+       * These flags pass the trailing argument to the user's shell, giving an
+       * RCE primitive equivalent to `sh -c`. This is the Flowise bypass pattern
+       * documented by Ox Security ("Mother of All AI Supply Chains", Family 2).
+       *
+       * The rule only scans flags that appear **before** the first positional
+       * (package name) in the args array — anything after the package belongs
+       * to the downstream command and must not be matched.
+       */
       {
         id: "mcp-npx-shell-exec",
         name: "MCP npx shell-exec flag",
@@ -5052,7 +5063,6 @@ var init_mcp = __esm({
             "--package",
             "-w",
             "--workspace",
-            "--workspaces",
             "--registry",
             "--loglevel",
             "--userconfig",

--- a/dist/index.js
+++ b/dist/index.js
@@ -5032,6 +5032,86 @@ var init_mcp = __esm({
           }
           return findings;
         }
+      },
+      {
+        id: "mcp-npx-shell-exec",
+        name: "MCP npx shell-exec flag",
+        description: "Checks for MCP servers using `npx -c` / `--call` (including `--call=\u2026`) \u2014 these pass the argument to the user's shell, giving RCE equivalent to `sh -c`.",
+        severity: "high",
+        category: "mcp",
+        check(file) {
+          if (file.type !== "mcp-json" && file.type !== "settings-json") return [];
+          const findings = [];
+          function isNpxCommand(cmd) {
+            if (!cmd) return false;
+            const basename3 = cmd.split(/[\\/]/).pop() ?? "";
+            return basename3 === "npx" || basename3 === "npx.cmd" || basename3 === "npx.exe";
+          }
+          const npxValueTakingOptions = /* @__PURE__ */ new Set([
+            "-p",
+            "--package",
+            "-w",
+            "--workspace",
+            "--workspaces",
+            "--registry",
+            "--loglevel",
+            "--userconfig",
+            "--globalconfig",
+            "--prefix"
+          ]);
+          function findShellExecFlag(args) {
+            let i = 0;
+            while (i < args.length) {
+              const raw = args[i];
+              if (typeof raw !== "string") return void 0;
+              if (raw === "-c" || raw === "--call") return raw;
+              if (raw.startsWith("--call=")) return "--call";
+              if (raw.startsWith("--") && raw.includes("=")) {
+                i++;
+                continue;
+              }
+              if (npxValueTakingOptions.has(raw)) {
+                i += 2;
+                continue;
+              }
+              if (raw.startsWith("-")) {
+                i++;
+                continue;
+              }
+              return void 0;
+            }
+            return void 0;
+          }
+          try {
+            const config = JSON.parse(file.content);
+            const servers = config.mcpServers ?? {};
+            for (const [name, server] of Object.entries(servers)) {
+              const serverConfig = server;
+              const command = serverConfig.command;
+              const args = serverConfig.args ?? [];
+              if (!isNpxCommand(command) || !Array.isArray(args)) continue;
+              const matchedFlag = findShellExecFlag(args);
+              if (!matchedFlag) continue;
+              findings.push({
+                id: `mcp-npx-shell-exec-${name}`,
+                severity: "high",
+                category: "mcp",
+                title: `MCP server "${name}" uses npx ${matchedFlag} (shell execution)`,
+                description: `The MCP server "${name}" invokes \`npx ${matchedFlag}\` which passes the next argument to the user's shell \u2014 identical RCE primitive to \`sh -c\`. This is the Flowise bypass pattern (Ox Security "Mother of All AI Supply Chains", Family 2).`,
+                file: file.path,
+                evidence: `command: ${command}, args: ${JSON.stringify(args)}`,
+                fix: {
+                  description: "Remove `-c` / `--call`. Pin to a specific package version with `npx <pkg>@<version>` instead; if shell execution is required, declare the target binary explicitly rather than piggy-backing on npx.",
+                  before: `"command": "${command}", "args": ${JSON.stringify(args)}`,
+                  after: `"command": "npx", "args": ["<package>@<version>"]`,
+                  auto: false
+                }
+              });
+            }
+          } catch {
+          }
+          return findings;
+        }
       }
     ];
     mcpRules = rawMcpRules.map((rule) => ({

--- a/examples/vulnerable/mcp.json
+++ b/examples/vulnerable/mcp.json
@@ -47,6 +47,10 @@
     "unsandboxed-browser": {
       "command": "chromium",
       "args": ["--no-sandbox", "--disable-web-security", "--remote-debugging-port=9222"]
+    },
+    "npx-shell-exec": {
+      "command": "npx",
+      "args": ["-c", "touch /tmp/pwn"]
     }
   }
 }

--- a/src/rules/mcp.ts
+++ b/src/rules/mcp.ts
@@ -1539,14 +1539,29 @@ const rawMcpRules: ReadonlyArray<Rule> = [
     id: "mcp-npx-shell-exec",
     name: "MCP npx shell-exec flag",
     description:
-      "Checks for MCP servers using `npx -c`, `--call`, `-e`, or `--eval` — these pass the argument to the user's shell, giving RCE equivalent to `sh -c`.",
+      "Checks for MCP servers using `npx -c` / `--call` (including `--call=…`) — these pass the argument to the user's shell, giving RCE equivalent to `sh -c`.",
     severity: "high",
     category: "mcp",
     check(file: ConfigFile): ReadonlyArray<Finding> {
       if (file.type !== "mcp-json" && file.type !== "settings-json") return [];
 
       const findings: Finding[] = [];
-      const shellExecFlags = new Set(["-c", "--call", "-e", "--eval"]);
+
+      function isNpxCommand(cmd: string | undefined): boolean {
+        if (!cmd) return false;
+        const basename = cmd.split(/[\\/]/).pop() ?? "";
+        return basename === "npx" || basename === "npx.cmd" || basename === "npx.exe";
+      }
+
+      function findShellExecFlag(args: ReadonlyArray<unknown>): string | undefined {
+        for (const raw of args) {
+          if (typeof raw !== "string") return undefined;
+          if (raw === "-c" || raw === "--call") return raw;
+          if (raw.startsWith("--call=")) return "--call";
+          if (!raw.startsWith("-")) return undefined;
+        }
+        return undefined;
+      }
 
       try {
         const config = JSON.parse(file.content);
@@ -1557,11 +1572,9 @@ const rawMcpRules: ReadonlyArray<Rule> = [
           const command = serverConfig.command as string | undefined;
           const args = (serverConfig.args ?? []) as unknown;
 
-          if (command !== "npx" || !Array.isArray(args)) continue;
+          if (!isNpxCommand(command) || !Array.isArray(args)) continue;
 
-          const matchedFlag = args.find(
-            (a): a is string => typeof a === "string" && shellExecFlags.has(a)
-          );
+          const matchedFlag = findShellExecFlag(args);
           if (!matchedFlag) continue;
 
           findings.push({
@@ -1571,11 +1584,11 @@ const rawMcpRules: ReadonlyArray<Rule> = [
             title: `MCP server "${name}" uses npx ${matchedFlag} (shell execution)`,
             description: `The MCP server "${name}" invokes \`npx ${matchedFlag}\` which passes the next argument to the user's shell — identical RCE primitive to \`sh -c\`. This is the Flowise bypass pattern (Ox Security "Mother of All AI Supply Chains", Family 2).`,
             file: file.path,
-            evidence: `command: npx, args: ${JSON.stringify(args)}`,
+            evidence: `command: ${command}, args: ${JSON.stringify(args)}`,
             fix: {
               description:
-                "Remove the shell-exec flag. Pin to a specific package version with `npx <pkg>@<version>` instead; if shell execution is required, declare the target binary explicitly rather than piggy-backing on npx.",
-              before: `"command": "npx", "args": ${JSON.stringify(args)}`,
+                "Remove `-c` / `--call`. Pin to a specific package version with `npx <pkg>@<version>` instead; if shell execution is required, declare the target binary explicitly rather than piggy-backing on npx.",
+              before: `"command": "${command}", "args": ${JSON.stringify(args)}`,
               after: `"command": "npx", "args": ["<package>@<version>"]`,
               auto: false,
             },

--- a/src/rules/mcp.ts
+++ b/src/rules/mcp.ts
@@ -1535,6 +1535,59 @@ const rawMcpRules: ReadonlyArray<Rule> = [
       return findings;
     },
   },
+  {
+    id: "mcp-npx-shell-exec",
+    name: "MCP npx shell-exec flag",
+    description:
+      "Checks for MCP servers using `npx -c`, `--call`, `-e`, or `--eval` — these pass the argument to the user's shell, giving RCE equivalent to `sh -c`.",
+    severity: "high",
+    category: "mcp",
+    check(file: ConfigFile): ReadonlyArray<Finding> {
+      if (file.type !== "mcp-json" && file.type !== "settings-json") return [];
+
+      const findings: Finding[] = [];
+      const shellExecFlags = new Set(["-c", "--call", "-e", "--eval"]);
+
+      try {
+        const config = JSON.parse(file.content);
+        const servers = config.mcpServers ?? {};
+
+        for (const [name, server] of Object.entries(servers)) {
+          const serverConfig = server as Record<string, unknown>;
+          const command = serverConfig.command as string | undefined;
+          const args = (serverConfig.args ?? []) as unknown;
+
+          if (command !== "npx" || !Array.isArray(args)) continue;
+
+          const matchedFlag = args.find(
+            (a): a is string => typeof a === "string" && shellExecFlags.has(a)
+          );
+          if (!matchedFlag) continue;
+
+          findings.push({
+            id: `mcp-npx-shell-exec-${name}`,
+            severity: "high",
+            category: "mcp",
+            title: `MCP server "${name}" uses npx ${matchedFlag} (shell execution)`,
+            description: `The MCP server "${name}" invokes \`npx ${matchedFlag}\` which passes the next argument to the user's shell — identical RCE primitive to \`sh -c\`. This is the Flowise bypass pattern (Ox Security "Mother of All AI Supply Chains", Family 2).`,
+            file: file.path,
+            evidence: `command: npx, args: ${JSON.stringify(args)}`,
+            fix: {
+              description:
+                "Remove the shell-exec flag. Pin to a specific package version with `npx <pkg>@<version>` instead; if shell execution is required, declare the target binary explicitly rather than piggy-backing on npx.",
+              before: `"command": "npx", "args": ${JSON.stringify(args)}`,
+              after: `"command": "npx", "args": ["<package>@<version>"]`,
+              auto: false,
+            },
+          });
+        }
+      } catch {
+        // Not valid JSON
+      }
+
+      return findings;
+    },
+  },
 ];
 
 export const mcpRules: ReadonlyArray<Rule> = rawMcpRules.map((rule) => ({

--- a/src/rules/mcp.ts
+++ b/src/rules/mcp.ts
@@ -1535,6 +1535,17 @@ const rawMcpRules: ReadonlyArray<Rule> = [
       return findings;
     },
   },
+  /**
+   * Detects MCP servers that invoke `npx -c` / `--call` (or `--call=…`).
+   *
+   * These flags pass the trailing argument to the user's shell, giving an
+   * RCE primitive equivalent to `sh -c`. This is the Flowise bypass pattern
+   * documented by Ox Security ("Mother of All AI Supply Chains", Family 2).
+   *
+   * The rule only scans flags that appear **before** the first positional
+   * (package name) in the args array — anything after the package belongs
+   * to the downstream command and must not be matched.
+   */
   {
     id: "mcp-npx-shell-exec",
     name: "MCP npx shell-exec flag",
@@ -1547,15 +1558,27 @@ const rawMcpRules: ReadonlyArray<Rule> = [
 
       const findings: Finding[] = [];
 
+      /**
+       * Returns true if `cmd` resolves to the npx binary.
+       *
+       * Matches bare `npx` as well as absolute paths (e.g. `/usr/local/bin/npx`)
+       * and Windows variants (`npx.cmd`, `npx.exe`). Splits on both `/` and `\`
+       * so the check is cross-platform.
+       */
       function isNpxCommand(cmd: string | undefined): boolean {
         if (!cmd) return false;
         const basename = cmd.split(/[\\/]/).pop() ?? "";
         return basename === "npx" || basename === "npx.cmd" || basename === "npx.exe";
       }
 
-      // npx options that consume the following argv token as their value.
-      // When we encounter one of these we must skip that value so it isn't
-      // mistaken for the package positional (which terminates flag scanning).
+      /**
+       * npx options that consume the following argv token as their value.
+       *
+       * When we encounter one of these we must skip that value so it isn't
+       * mistaken for the package positional (which terminates flag scanning).
+       * Keep this list aligned with the options documented by `npx --help`
+       * that take a separate value token.
+       */
       const npxValueTakingOptions: ReadonlySet<string> = new Set([
         "-p",
         "--package",
@@ -1568,6 +1591,23 @@ const rawMcpRules: ReadonlyArray<Rule> = [
         "--prefix",
       ]);
 
+      /**
+       * Scans npx args for a shell-execution flag before the package positional.
+       *
+       * Returns the matched flag (`-c`, `--call`, or `--call` for the `--call=…`
+       * attached form) or `undefined` if no such flag appears in the pre-package
+       * region of the args array.
+       *
+       * Handling rules:
+       * - `--call=<cmd>` — attached long-option form, matches immediately.
+       * - `--<name>=<value>` — any other attached long option is self-contained;
+       *   advance one token.
+       * - Value-taking options from `npxValueTakingOptions` consume the next
+       *   token as their value; advance two tokens.
+       * - Any other `-`-prefixed token (including combined short flags like
+       *   `-yp`) is a boolean flag; advance one token.
+       * - First non-flag token = package name; stop scanning.
+       */
       function findShellExecFlag(args: ReadonlyArray<unknown>): string | undefined {
         let i = 0;
         while (i < args.length) {

--- a/src/rules/mcp.ts
+++ b/src/rules/mcp.ts
@@ -1561,7 +1561,6 @@ const rawMcpRules: ReadonlyArray<Rule> = [
         "--package",
         "-w",
         "--workspace",
-        "--workspaces",
         "--registry",
         "--loglevel",
         "--userconfig",

--- a/src/rules/mcp.ts
+++ b/src/rules/mcp.ts
@@ -1553,12 +1553,48 @@ const rawMcpRules: ReadonlyArray<Rule> = [
         return basename === "npx" || basename === "npx.cmd" || basename === "npx.exe";
       }
 
+      // npx options that consume the following argv token as their value.
+      // When we encounter one of these we must skip that value so it isn't
+      // mistaken for the package positional (which terminates flag scanning).
+      const npxValueTakingOptions: ReadonlySet<string> = new Set([
+        "-p",
+        "--package",
+        "-w",
+        "--workspace",
+        "--workspaces",
+        "--registry",
+        "--loglevel",
+        "--userconfig",
+        "--globalconfig",
+        "--prefix",
+      ]);
+
       function findShellExecFlag(args: ReadonlyArray<unknown>): string | undefined {
-        for (const raw of args) {
+        let i = 0;
+        while (i < args.length) {
+          const raw = args[i];
           if (typeof raw !== "string") return undefined;
           if (raw === "-c" || raw === "--call") return raw;
           if (raw.startsWith("--call=")) return "--call";
-          if (!raw.startsWith("-")) return undefined;
+          // Attached long-option values (--package=foo) are self-contained.
+          if (raw.startsWith("--") && raw.includes("=")) {
+            i++;
+            continue;
+          }
+          // Known value-taking options consume the next token.
+          if (npxValueTakingOptions.has(raw)) {
+            i += 2;
+            continue;
+          }
+          // Any other flag (including combined short flags like -yp) is kept
+          // but doesn't consume the next token.
+          if (raw.startsWith("-")) {
+            i++;
+            continue;
+          }
+          // First positional = package name; anything past this belongs to
+          // the downstream command and must not be scanned.
+          return undefined;
         }
         return undefined;
       }

--- a/tests/rules/mcp.test.ts
+++ b/tests/rules/mcp.test.ts
@@ -1404,5 +1404,29 @@ describe("mcpRules", () => {
       const findings = runAllMcpRules(file);
       expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
     });
+
+    it("flags -c that follows a value-taking option like --package", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["--package", "some-pkg", "-c", "echo pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
+    it("flags --call after --package=attached=value", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["--package=some-pkg", "--call", "echo pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
+    it("does not flag -c that appears inside the downstream package arguments", () => {
+      const file = makeMcpConfig({
+        good: { command: "npx", args: ["-y", "some-mcp", "-c", "downstream-arg"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id.startsWith("mcp-npx-shell-exec"))).toBe(false);
+    });
   });
 });

--- a/tests/rules/mcp.test.ts
+++ b/tests/rules/mcp.test.ts
@@ -1342,11 +1342,35 @@ describe("mcpRules", () => {
       expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
     });
 
-    it("flags npx -e and npx --eval", () => {
+    it("flags npx --call= attached long-option form", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["--call=touch /tmp/pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
+    it("does not flag -e / --eval (these are Node flags, not npx flags)", () => {
       const file1 = makeMcpConfig({ a: { command: "npx", args: ["-e", "process.exit(0)"] } });
       const file2 = makeMcpConfig({ b: { command: "npx", args: ["--eval", "1+1"] } });
-      expect(runAllMcpRules(file1).some((f) => f.id === "mcp-npx-shell-exec-a")).toBe(true);
-      expect(runAllMcpRules(file2).some((f) => f.id === "mcp-npx-shell-exec-b")).toBe(true);
+      expect(runAllMcpRules(file1).some((f) => f.id.startsWith("mcp-npx-shell-exec"))).toBe(false);
+      expect(runAllMcpRules(file2).some((f) => f.id.startsWith("mcp-npx-shell-exec"))).toBe(false);
+    });
+
+    it("flags npx invoked by absolute path", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "/usr/local/bin/npx", args: ["-c", "touch /tmp/pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
+    it("does not flag -c that belongs to a downstream package (after positional)", () => {
+      const file = makeMcpConfig({
+        benign: { command: "npx", args: ["mytool@1.0.0", "-c", "config.yaml"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id.startsWith("mcp-npx-shell-exec"))).toBe(false);
     });
 
     it("still flags when combined with -y", () => {

--- a/tests/rules/mcp.test.ts
+++ b/tests/rules/mcp.test.ts
@@ -1322,4 +1322,63 @@ describe("mcpRules", () => {
       expect(findings.some((f) => f.id.includes("no-timeout"))).toBe(false);
     });
   });
+
+  describe("npx shell-exec (mcp-npx-shell-exec)", () => {
+    it("flags npx -c as high", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["-c", "touch /tmp/pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      const finding = findings.find((f) => f.id === "mcp-npx-shell-exec-pwn");
+      expect(finding?.severity).toBe("high");
+      expect(finding?.title).toContain("-c");
+    });
+
+    it("flags npx --call", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["--call", "node -e 'require(`x`)()'"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
+    it("flags npx -e and npx --eval", () => {
+      const file1 = makeMcpConfig({ a: { command: "npx", args: ["-e", "process.exit(0)"] } });
+      const file2 = makeMcpConfig({ b: { command: "npx", args: ["--eval", "1+1"] } });
+      expect(runAllMcpRules(file1).some((f) => f.id === "mcp-npx-shell-exec-a")).toBe(true);
+      expect(runAllMcpRules(file2).some((f) => f.id === "mcp-npx-shell-exec-b")).toBe(true);
+    });
+
+    it("still flags when combined with -y", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["-y", "-c", "touch /tmp/pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
+    it("does not flag pinned npx package invocations", () => {
+      const file = makeMcpConfig({
+        good: { command: "npx", args: ["chrome-devtools-mcp@0.21.0"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id.startsWith("mcp-npx-shell-exec"))).toBe(false);
+    });
+
+    it("does not flag non-npx commands that happen to include -c", () => {
+      const file = makeMcpConfig({
+        shelly: { command: "bash", args: ["-c", "echo hi"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id.startsWith("mcp-npx-shell-exec"))).toBe(false);
+    });
+
+    it("also applies to settings-json mcpServers", () => {
+      const file = makeSettingsConfig({
+        mcpServers: { pwn: { command: "npx", args: ["-c", "echo pwn"] } },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+  });
 });

--- a/tests/rules/mcp.test.ts
+++ b/tests/rules/mcp.test.ts
@@ -1421,6 +1421,14 @@ describe("mcpRules", () => {
       expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
     });
 
+    it("flags -c after the boolean --workspaces flag (regression: must not consume next token)", () => {
+      const file = makeMcpConfig({
+        pwn: { command: "npx", args: ["--workspaces", "-c", "touch /tmp/pwn"] },
+      });
+      const findings = runAllMcpRules(file);
+      expect(findings.some((f) => f.id === "mcp-npx-shell-exec-pwn")).toBe(true);
+    });
+
     it("does not flag -c that appears inside the downstream package arguments", () => {
       const file = makeMcpConfig({
         good: { command: "npx", args: ["-y", "some-mcp", "-c", "downstream-arg"] },


### PR DESCRIPTION
## Summary

Adds a new rule `mcp-npx-shell-exec` (high severity, category `mcp`) that flags STDIO MCP entries where `command` is `npx` and `args` contains any of `-c`, `--call`, `-e`, `--eval`. These flags pass the next argument to the user's shell, giving an RCE primitive identical to `sh -c`.

## Gap this closes

Existing rules don't cover this:
- `mcp-npx-supply-chain` fires on `npx -y` only
- `mcp-no-version-pin` fires on unversioned packages
- The shell-exec rule in `hooks.ts` / `mcp.ts` matches `command` in `{sh, bash, zsh, cmd}` — not `npx`

So a configuration like this passes today:

```json
{ "command": "npx", "args": ["-c", "touch /tmp/pwn"] }
```

An allowlist that permits `npx` at all is defeated.

## Context

This is the **Flowise bypass pattern** documented in Ox Security's _Mother of All AI Supply Chains_ whitepaper (Apr 2026), Family 2 — Hardening Bypass:
- Flowise advisory: [GHSA-c9gw-hvqq-f33r](https://github.com/advisories/GHSA-c9gw-hvqq-f33r)
- Related: CVE-2026-30625 (Upsonic)

## Changes

| File | Change |
|---|---|
| `src/rules/mcp.ts` | New rule `mcp-npx-shell-exec` appended to `rawMcpRules` |
| `tests/rules/mcp.test.ts` | 7 tests: `-c`, `--call`, `-e`, `--eval`, combined with `-y`, pinned-package negative, non-npx `bash -c` negative, settings-json positive |
| `examples/vulnerable/mcp.json` | New \`npx-shell-exec\` server entry |

## Test plan

- [x] \`npm run typecheck\` — passes
- [x] \`npm test\` — 586/586 passing (129 in mcp.test.ts, +7 new)
- [x] \`npm run scan:demo\` — rule fires on the new example entry

## Rule output example

\`\`\`
● MCP server \"npx-shell-exec\" uses npx -c (shell execution)
  The MCP server \"npx-shell-exec\" invokes \`npx -c\` which passes the next argument
  to the user's shell — identical RCE primitive to \`sh -c\`. This is the Flowise
  bypass pattern (Ox Security \"Mother of All AI Supply Chains\", Family 2).
  Fix: Remove the shell-exec flag. Pin to a specific package version with
       \`npx <pkg>@<version>\` instead; if shell execution is required, declare
       the target binary explicitly rather than piggy-backing on npx.
\`\`\`

## Notes

- Fix set to \`auto: false\` — remediation requires understanding intent (was this deliberate shell-out, or was a package reference garbled?).
- No changes to existing rules; purely additive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `mcp-npx-shell-exec`, a high-severity rule that flags MCP servers calling `npx` with shell-exec flags (`-c`, `--call`, including `--call=`). Closes the Flowise bypass gap not covered by existing rules.

- **New Features**
  - Detects `command: "npx"` with shell-exec flags in `mcp.json`/`settings.json`. Skips value-taking options before the first package; ignores `-e`/`--eval`; supports absolute paths and Windows `npx`; still fires with `-y`. Adds a vulnerable example and tests (positives for `--package <pkg> -c`, `--package=<pkg> --call`, `--call=`, absolute-path `npx`; negatives for pinned packages, downstream `-c` after a positional, and `-e`/`--eval`).
  - Adds JSDoc docstrings for the rule and helper functions.

- **Bug Fixes**
  - Treats `--workspaces` as a boolean flag so `npx --workspaces -c ...` is detected; adds a regression test.

<sup>Written for commit ddef66cdf4858d14f2ef6602e358fe18cb254065. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detection rule that flags unsafe use of npx with shell-execution flags and provides remediation guidance.

* **Documentation**
  * Added an example configuration demonstrating the unsafe npx pattern.

* **Tests**
  * Added comprehensive tests covering various npx invocation and configuration scenarios to validate the rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->