### PR TITLE
feat: add AgentShield SARIF code scanning output

### DIFF
--- a/API.md
+++ b/API.md
@@ -73,7 +73,8 @@ agentshield miniclaw start [options]
 ```
 
 High-value `scan` options:
-- `--format terminal|json|markdown|html`
+- `--format terminal|json|markdown|html|sarif`
+- `--output <path>` for writing the selected report format to a file
 - `--fix`
 - `--opus`
 - `--stream`

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Notes:
 AgentShield currently has three distinct automation surfaces:
 
 - CLI: `agentshield scan`, `agentshield init`, and `agentshield miniclaw start`
-- Scanner report JSON: `agentshield scan --format json`
+- Scanner report JSON/SARIF: `agentshield scan --format json` or `agentshield scan --format sarif --output agentshield.sarif`
 - MiniClaw package + HTTP API: `ecc-agentshield/miniclaw`
 
 Important packaging note:
@@ -466,18 +466,20 @@ Detailed request/response and schema notes live in [`API.md`](./API.md).
 | `path` | `.` | Path to scan |
 | `min-severity` | `medium` | Minimum severity: critical, high, medium, low, info |
 | `fail-on-findings` | `true` | Fail the action if findings meet severity threshold |
-| `format` | `terminal` | Output format |
+| `format` | `terminal` | Output format: terminal, json, markdown, sarif |
+| `sarif-output` | `agentshield-results.sarif` | SARIF output path when `format` is `sarif` |
 
-**Outputs:** `score` (0–100), `grade` (A–F), `total-findings`, `critical-count`
+**Outputs:** `score` (0–100), `grade` (A–F), `total-findings`, `critical-count`, `sarif-path`
 
-The action writes a markdown job summary and emits GitHub annotations inline on affected files.
+The action writes a markdown job summary and emits GitHub annotations inline on affected files. When `format: sarif` is set, it also writes a SARIF 2.1.0 report that can be uploaded to GitHub code scanning with `github/codeql-action/upload-sarif`.
 
 ## CLI Reference
 
 ```
 agentshield scan [options]         Scan configuration directory
   -p, --path <path>                Path to scan (default: ~/.claude or cwd)
-  -f, --format <format>            Output: terminal, json, markdown, html
+  -f, --format <format>            Output: terminal, json, markdown, html, sarif
+  -o, --output <path>              Write the primary report output to a file
   --fix                            Auto-apply safe fixes
   --opus                           Enable Opus 4.6 multi-agent analysis
   --stream                         Stream Opus analysis in real-time

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,13 @@ inputs:
     required: false
     default: "true"
   format:
-    description: "Output format: terminal, json, markdown"
+    description: "Output format: terminal, json, markdown, sarif"
     required: false
     default: "terminal"
+  sarif-output:
+    description: "Path to write SARIF results when format is sarif"
+    required: false
+    default: "agentshield-results.sarif"
 
 outputs:
   score:
@@ -33,6 +37,8 @@ outputs:
     description: "Total number of findings"
   critical-count:
     description: "Number of critical findings"
+  sarif-path:
+    description: "Path to the generated SARIF file when format is sarif"
 
 runs:
   using: "node20"

--- a/dist/action.js
+++ b/dist/action.js
@@ -206,8 +206,9 @@ var init_baseline = __esm({
 
 // src/action.ts
 import { resolve as resolve2 } from "path";
+import { dirname as dirname3 } from "path";
 import { existsSync as existsSync3 } from "fs";
-import { appendFileSync } from "fs";
+import { appendFileSync, mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from "fs";
 
 // src/scanner/discovery.ts
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
@@ -8553,6 +8554,146 @@ function renderMarkdownReport(report) {
   return lines.join("\n");
 }
 
+// src/reporter/sarif.ts
+var SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json";
+function renderSarifReport(report) {
+  const rules = buildRules(report.findings);
+  const ruleIndexes = new Map(rules.map((rule, index) => [rule.id, index]));
+  return JSON.stringify(
+    {
+      version: "2.1.0",
+      $schema: SARIF_SCHEMA,
+      runs: [
+        {
+          tool: {
+            driver: {
+              name: "AgentShield",
+              informationUri: "https://github.com/affaan-m/agentshield",
+              rules
+            }
+          },
+          automationDetails: {
+            id: "agentshield/security-scan"
+          },
+          invocations: [
+            {
+              executionSuccessful: true,
+              endTimeUtc: report.timestamp,
+              workingDirectory: {
+                uri: normalizeUri(report.targetPath)
+              }
+            }
+          ],
+          properties: {
+            score: report.score.numericScore,
+            grade: report.score.grade,
+            filesScanned: report.summary.filesScanned
+          },
+          results: report.findings.map(
+            (finding) => renderSarifResult(finding, ruleIndexes.get(finding.id) ?? 0)
+          )
+        }
+      ]
+    },
+    null,
+    2
+  );
+}
+function buildRules(findings) {
+  const rules = /* @__PURE__ */ new Map();
+  for (const finding of findings) {
+    if (rules.has(finding.id)) continue;
+    rules.set(finding.id, {
+      id: finding.id,
+      name: finding.title,
+      shortDescription: { text: finding.title },
+      fullDescription: { text: finding.description },
+      help: finding.fix ? { text: `${finding.description}
+
+Recommended fix: ${finding.fix.description}` } : { text: finding.description },
+      defaultConfiguration: {
+        level: severityToLevel(finding.severity)
+      },
+      properties: {
+        category: finding.category,
+        severity: finding.severity,
+        "security-severity": severityToSecurityScore(finding.severity),
+        tags: ["security", "agent-config", finding.category],
+        precision: precisionForFinding(finding)
+      }
+    });
+  }
+  return [...rules.values()];
+}
+function renderSarifResult(finding, ruleIndex) {
+  return {
+    ruleId: finding.id,
+    ruleIndex,
+    level: severityToLevel(finding.severity),
+    message: {
+      text: finding.description
+    },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri: normalizeUri(finding.file)
+          },
+          ...finding.line ? {
+            region: {
+              startLine: Math.max(1, finding.line)
+            }
+          } : {}
+        }
+      }
+    ],
+    properties: {
+      title: finding.title,
+      category: finding.category,
+      severity: finding.severity,
+      runtimeConfidence: finding.runtimeConfidence,
+      evidence: finding.evidence,
+      fix: finding.fix?.description
+    }
+  };
+}
+function severityToLevel(severity) {
+  switch (severity) {
+    case "critical":
+    case "high":
+      return "error";
+    case "medium":
+      return "warning";
+    case "low":
+    case "info":
+      return "note";
+  }
+}
+function severityToSecurityScore(severity) {
+  switch (severity) {
+    case "critical":
+      return "9.5";
+    case "high":
+      return "8.0";
+    case "medium":
+      return "5.0";
+    case "low":
+      return "2.5";
+    case "info":
+      return "1.0";
+  }
+}
+function precisionForFinding(finding) {
+  if (finding.runtimeConfidence === "active-runtime") return "very-high";
+  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example") {
+    return "medium";
+  }
+  return "high";
+}
+function normalizeUri(uri) {
+  return uri.replace(/\\/g, "/");
+}
+
 // src/action.ts
 function getInput(name, fallback) {
   const envKey = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
@@ -8609,6 +8750,7 @@ async function run() {
   const format = getInput("format", "terminal");
   const baselinePath = getInput("baseline", "");
   const saveBaselinePath = getInput("save-baseline", "");
+  const sarifOutput = getInput("sarif-output", "agentshield-results.sarif");
   const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
   const targetPath = resolve2(workspace, inputPath);
   if (!existsSync3(targetPath)) {
@@ -8632,6 +8774,13 @@ async function run() {
   setOutput("grade", report.score.grade);
   setOutput("total-findings", String(report.summary.totalFindings));
   setOutput("critical-count", String(report.summary.critical));
+  if (format === "sarif") {
+    const sarifPath = resolve2(workspace, sarifOutput);
+    mkdirSync2(dirname3(sarifPath), { recursive: true });
+    writeFileSync2(sarifPath, renderSarifReport(report));
+    setOutput("sarif-path", sarifPath);
+    console.log(`SARIF written to: ${sarifPath}`);
+  }
   const markdownSummary = renderMarkdownReport(report);
   writeJobSummary(markdownSummary);
   console.log(`Score: ${report.score.numericScore}/100 (Grade: ${report.score.grade})`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -12202,6 +12202,7 @@ var init_supply_chain = __esm({
 init_scanner();
 import { Command } from "commander";
 import { resolve as resolve8 } from "path";
+import { dirname as dirname5 } from "path";
 import { existsSync as existsSync10, writeFileSync as writeFileSync5, appendFileSync as appendFileSync2, mkdirSync as mkdirSync5 } from "fs";
 
 // src/reporter/score.ts
@@ -13144,6 +13145,146 @@ function inlineStyles() {
       }
     }
   `;
+}
+
+// src/reporter/sarif.ts
+var SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json";
+function renderSarifReport(report) {
+  const rules = buildRules(report.findings);
+  const ruleIndexes = new Map(rules.map((rule, index) => [rule.id, index]));
+  return JSON.stringify(
+    {
+      version: "2.1.0",
+      $schema: SARIF_SCHEMA,
+      runs: [
+        {
+          tool: {
+            driver: {
+              name: "AgentShield",
+              informationUri: "https://github.com/affaan-m/agentshield",
+              rules
+            }
+          },
+          automationDetails: {
+            id: "agentshield/security-scan"
+          },
+          invocations: [
+            {
+              executionSuccessful: true,
+              endTimeUtc: report.timestamp,
+              workingDirectory: {
+                uri: normalizeUri(report.targetPath)
+              }
+            }
+          ],
+          properties: {
+            score: report.score.numericScore,
+            grade: report.score.grade,
+            filesScanned: report.summary.filesScanned
+          },
+          results: report.findings.map(
+            (finding) => renderSarifResult(finding, ruleIndexes.get(finding.id) ?? 0)
+          )
+        }
+      ]
+    },
+    null,
+    2
+  );
+}
+function buildRules(findings) {
+  const rules = /* @__PURE__ */ new Map();
+  for (const finding of findings) {
+    if (rules.has(finding.id)) continue;
+    rules.set(finding.id, {
+      id: finding.id,
+      name: finding.title,
+      shortDescription: { text: finding.title },
+      fullDescription: { text: finding.description },
+      help: finding.fix ? { text: `${finding.description}
+
+Recommended fix: ${finding.fix.description}` } : { text: finding.description },
+      defaultConfiguration: {
+        level: severityToLevel(finding.severity)
+      },
+      properties: {
+        category: finding.category,
+        severity: finding.severity,
+        "security-severity": severityToSecurityScore(finding.severity),
+        tags: ["security", "agent-config", finding.category],
+        precision: precisionForFinding(finding)
+      }
+    });
+  }
+  return [...rules.values()];
+}
+function renderSarifResult(finding, ruleIndex) {
+  return {
+    ruleId: finding.id,
+    ruleIndex,
+    level: severityToLevel(finding.severity),
+    message: {
+      text: finding.description
+    },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri: normalizeUri(finding.file)
+          },
+          ...finding.line ? {
+            region: {
+              startLine: Math.max(1, finding.line)
+            }
+          } : {}
+        }
+      }
+    ],
+    properties: {
+      title: finding.title,
+      category: finding.category,
+      severity: finding.severity,
+      runtimeConfidence: finding.runtimeConfidence,
+      evidence: finding.evidence,
+      fix: finding.fix?.description
+    }
+  };
+}
+function severityToLevel(severity) {
+  switch (severity) {
+    case "critical":
+    case "high":
+      return "error";
+    case "medium":
+      return "warning";
+    case "low":
+    case "info":
+      return "note";
+  }
+}
+function severityToSecurityScore(severity) {
+  switch (severity) {
+    case "critical":
+      return "9.5";
+    case "high":
+      return "8.0";
+    case "medium":
+      return "5.0";
+    case "low":
+      return "2.5";
+    case "info":
+      return "1.0";
+  }
+}
+function precisionForFinding(finding) {
+  if (finding.runtimeConfidence === "active-runtime") return "very-high";
+  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example") {
+    return "medium";
+  }
+  return "high";
+}
+function normalizeUri(uri) {
+  return uri.replace(/\\/g, "/");
 }
 
 // src/opus/pipeline.ts
@@ -15618,7 +15759,17 @@ function createScanLogger(logPath, logFormat) {
 }
 var program = new Command();
 program.name("agentshield").description("Security auditor for AI agent configurations").version("1.4.0");
-program.command("scan").description("Scan a Claude Code configuration directory for security issues").option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)").option("-f, --format <format>", "Output format: terminal, json, markdown, html", "terminal").option("--fix", "Auto-apply safe fixes", false).option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false).option("--stream", "Stream Opus analysis in real-time", false).option("--injection", "Run active prompt injection testing against the config", false).option("--sandbox", "Execute hooks in sandbox and observe behavior", false).option("--taint", "Run taint analysis (data flow tracking)", false).option("--deep", "Run ALL analysis (injection + sandbox + taint + opus)", false).option("--log <path>", "Write structured scan log to file").option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson").option("--corpus", "Run scanner validation against built-in attack corpus", false).option("--baseline <path>", "Compare against a baseline file and report regressions").option("--save-baseline <path>", "Save current scan results as a baseline file").option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false).option("--supply-chain", "Verify MCP npm packages against known-bad list and typosquatting", false).option("--supply-chain-online", "Also query npm registry for metadata (requires network)", false).option("--policy <path>", "Validate against an organization policy file").option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info").option("-v, --verbose", "Show detailed output", false).action(async (options) => {
+function emitReportOutput(output, outputPath) {
+  if (!outputPath) {
+    console.log(output);
+    return;
+  }
+  const resolvedOutput = resolve8(outputPath);
+  mkdirSync5(dirname5(resolvedOutput), { recursive: true });
+  writeFileSync5(resolvedOutput, output);
+  console.log(`Report written to: ${resolvedOutput}`);
+}
+program.command("scan").description("Scan a Claude Code configuration directory for security issues").option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)").option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal").option("-o, --output <path>", "Write the primary report output to a file").option("--fix", "Auto-apply safe fixes", false).option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false).option("--stream", "Stream Opus analysis in real-time", false).option("--injection", "Run active prompt injection testing against the config", false).option("--sandbox", "Execute hooks in sandbox and observe behavior", false).option("--taint", "Run taint analysis (data flow tracking)", false).option("--deep", "Run ALL analysis (injection + sandbox + taint + opus)", false).option("--log <path>", "Write structured scan log to file").option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson").option("--corpus", "Run scanner validation against built-in attack corpus", false).option("--baseline <path>", "Compare against a baseline file and report regressions").option("--save-baseline <path>", "Save current scan results as a baseline file").option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false).option("--supply-chain", "Verify MCP npm packages against known-bad list and typosquatting", false).option("--supply-chain-online", "Also query npm registry for metadata (requires network)", false).option("--policy <path>", "Validate against an organization policy file").option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info").option("-v, --verbose", "Show detailed output", false).action(async (options) => {
   const targetPath = resolveTargetPath(options.path);
   if (!existsSync10(targetPath)) {
     console.error(`Error: Path does not exist: ${targetPath}`);
@@ -15647,19 +15798,24 @@ program.command("scan").description("Scan a Claude Code configuration directory 
     message: `Static analysis complete: ${report.summary.totalFindings} findings`,
     data: { grade: report.score.grade, score: report.score.numericScore }
   });
+  let renderedReport;
   switch (options.format) {
     case "json":
-      console.log(renderJsonReport(report));
+      renderedReport = renderJsonReport(report);
       break;
     case "markdown":
-      console.log(renderMarkdownReport(report));
+      renderedReport = renderMarkdownReport(report);
       break;
     case "html":
-      console.log(renderHtmlReport(report));
+      renderedReport = renderHtmlReport(report);
+      break;
+    case "sarif":
+      renderedReport = renderSarifReport(report);
       break;
     default:
-      console.log(renderTerminalReport(report));
+      renderedReport = renderTerminalReport(report);
   }
+  emitReportOutput(renderedReport, options.output);
   if (options.saveBaseline) {
     const { saveBaseline: saveBaseline2 } = await Promise.resolve().then(() => (init_baseline(), baseline_exports));
     saveBaseline2(filteredResult.findings, report.score, options.saveBaseline);

--- a/examples/agentshield-workflow.yml
+++ b/examples/agentshield-workflow.yml
@@ -33,12 +33,23 @@ on:
 jobs:
   security-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Run AgentShield
+        id: agentshield
         uses: affaan-m/agentshield@v1.4.0
         with:
           min-severity: medium
           fail-on-findings: true
-          format: terminal
+          format: sarif
+          sarif-output: agentshield-results.sarif
+
+      - name: Upload AgentShield SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.agentshield.outputs.sarif-path }}

--- a/src/action.ts
+++ b/src/action.ts
@@ -7,11 +7,13 @@
  */
 
 import { resolve } from "node:path";
+import { dirname } from "node:path";
 import { existsSync } from "node:fs";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import { scan } from "./scanner/index.js";
 import { calculateScore } from "./reporter/score.js";
 import { renderMarkdownReport } from "./reporter/json.js";
+import { renderSarifReport } from "./reporter/sarif.js";
 import type { Finding, Severity } from "./types.js";
 
 // ─── GitHub Actions Helpers ──────────────────────────────────
@@ -92,6 +94,7 @@ async function run(): Promise<void> {
   const format = getInput("format", "terminal");
   const baselinePath = getInput("baseline", "");
   const saveBaselinePath = getInput("save-baseline", "");
+  const sarifOutput = getInput("sarif-output", "agentshield-results.sarif");
 
   // Resolve and validate path
   const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
@@ -129,6 +132,14 @@ async function run(): Promise<void> {
   setOutput("grade", report.score.grade);
   setOutput("total-findings", String(report.summary.totalFindings));
   setOutput("critical-count", String(report.summary.critical));
+
+  if (format === "sarif") {
+    const sarifPath = resolve(workspace, sarifOutput);
+    mkdirSync(dirname(sarifPath), { recursive: true });
+    writeFileSync(sarifPath, renderSarifReport(report));
+    setOutput("sarif-path", sarifPath);
+    console.log(`SARIF written to: ${sarifPath}`);
+  }
 
   // Write job summary as markdown
   const markdownSummary = renderMarkdownReport(report);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,14 @@
 
 import { Command } from "commander";
 import { resolve } from "node:path";
+import { dirname } from "node:path";
 import { existsSync, writeFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { scan } from "./scanner/index.js";
 import { calculateScore } from "./reporter/score.js";
 import { renderTerminalReport } from "./reporter/terminal.js";
 import { renderJsonReport, renderMarkdownReport } from "./reporter/json.js";
 import { renderHtmlReport } from "./reporter/html.js";
+import { renderSarifReport } from "./reporter/sarif.js";
 import { runOpusPipeline, renderOpusAnalysis } from "./opus/index.js";
 import { applyFixes, renderFixSummary } from "./fixer/index.js";
 import { runInit, renderInitSummary } from "./init/index.js";
@@ -197,11 +199,24 @@ program
   .description("Security auditor for AI agent configurations")
   .version("1.4.0");
 
+function emitReportOutput(output: string, outputPath: string | undefined): void {
+  if (!outputPath) {
+    console.log(output);
+    return;
+  }
+
+  const resolvedOutput = resolve(outputPath);
+  mkdirSync(dirname(resolvedOutput), { recursive: true });
+  writeFileSync(resolvedOutput, output);
+  console.log(`Report written to: ${resolvedOutput}`);
+}
+
 program
   .command("scan")
   .description("Scan a Claude Code configuration directory for security issues")
   .option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)")
-  .option("-f, --format <format>", "Output format: terminal, json, markdown, html", "terminal")
+  .option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal")
+  .option("-o, --output <path>", "Write the primary report output to a file")
   .option("--fix", "Auto-apply safe fixes", false)
   .option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false)
   .option("--stream", "Stream Opus analysis in real-time", false)
@@ -262,19 +277,24 @@ program
     });
 
     // Output static scan
+    let renderedReport: string;
     switch (options.format) {
       case "json":
-        console.log(renderJsonReport(report));
+        renderedReport = renderJsonReport(report);
         break;
       case "markdown":
-        console.log(renderMarkdownReport(report));
+        renderedReport = renderMarkdownReport(report);
         break;
       case "html":
-        console.log(renderHtmlReport(report));
+        renderedReport = renderHtmlReport(report);
+        break;
+      case "sarif":
+        renderedReport = renderSarifReport(report);
         break;
       default:
-        console.log(renderTerminalReport(report));
+        renderedReport = renderTerminalReport(report);
     }
+    emitReportOutput(renderedReport, options.output);
 
     // ── Phase 1b: Baseline save/compare ───────────────────
     if (options.saveBaseline) {

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -2,3 +2,4 @@ export { calculateScore } from "./score.js";
 export { renderTerminalReport } from "./terminal.js";
 export { renderJsonReport, renderMarkdownReport } from "./json.js";
 export { renderHtmlReport } from "./html.js";
+export { renderSarifReport } from "./sarif.js";

--- a/src/reporter/sarif.ts
+++ b/src/reporter/sarif.ts
@@ -1,0 +1,172 @@
+import type { Finding, SecurityReport, Severity } from "../types.js";
+
+const SARIF_SCHEMA =
+  "https://json.schemastore.org/sarif-2.1.0.json";
+
+type SarifLevel = "error" | "warning" | "note";
+
+interface SarifReportingDescriptor {
+  readonly id: string;
+  readonly name: string;
+  readonly shortDescription: { readonly text: string };
+  readonly fullDescription: { readonly text: string };
+  readonly help?: { readonly text: string };
+  readonly defaultConfiguration: { readonly level: SarifLevel };
+  readonly properties: Record<string, unknown>;
+}
+
+/**
+ * Render an AgentShield report as SARIF 2.1.0 for GitHub code scanning.
+ */
+export function renderSarifReport(report: SecurityReport): string {
+  const rules = buildRules(report.findings);
+  const ruleIndexes = new Map(rules.map((rule, index) => [rule.id, index]));
+
+  return JSON.stringify(
+    {
+      version: "2.1.0",
+      $schema: SARIF_SCHEMA,
+      runs: [
+        {
+          tool: {
+            driver: {
+              name: "AgentShield",
+              informationUri: "https://github.com/affaan-m/agentshield",
+              rules,
+            },
+          },
+          automationDetails: {
+            id: "agentshield/security-scan",
+          },
+          invocations: [
+            {
+              executionSuccessful: true,
+              endTimeUtc: report.timestamp,
+              workingDirectory: {
+                uri: normalizeUri(report.targetPath),
+              },
+            },
+          ],
+          properties: {
+            score: report.score.numericScore,
+            grade: report.score.grade,
+            filesScanned: report.summary.filesScanned,
+          },
+          results: report.findings.map((finding) =>
+            renderSarifResult(finding, ruleIndexes.get(finding.id) ?? 0)
+          ),
+        },
+      ],
+    },
+    null,
+    2
+  );
+}
+
+function buildRules(findings: ReadonlyArray<Finding>): SarifReportingDescriptor[] {
+  const rules = new Map<string, SarifReportingDescriptor>();
+
+  for (const finding of findings) {
+    if (rules.has(finding.id)) continue;
+
+    rules.set(finding.id, {
+      id: finding.id,
+      name: finding.title,
+      shortDescription: { text: finding.title },
+      fullDescription: { text: finding.description },
+      help: finding.fix
+        ? { text: `${finding.description}\n\nRecommended fix: ${finding.fix.description}` }
+        : { text: finding.description },
+      defaultConfiguration: {
+        level: severityToLevel(finding.severity),
+      },
+      properties: {
+        category: finding.category,
+        severity: finding.severity,
+        "security-severity": severityToSecurityScore(finding.severity),
+        tags: ["security", "agent-config", finding.category],
+        precision: precisionForFinding(finding),
+      },
+    });
+  }
+
+  return [...rules.values()];
+}
+
+function renderSarifResult(
+  finding: Finding,
+  ruleIndex: number
+): Record<string, unknown> {
+  return {
+    ruleId: finding.id,
+    ruleIndex,
+    level: severityToLevel(finding.severity),
+    message: {
+      text: finding.description,
+    },
+    locations: [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri: normalizeUri(finding.file),
+          },
+          ...(finding.line
+            ? {
+                region: {
+                  startLine: Math.max(1, finding.line),
+                },
+              }
+            : {}),
+        },
+      },
+    ],
+    properties: {
+      title: finding.title,
+      category: finding.category,
+      severity: finding.severity,
+      runtimeConfidence: finding.runtimeConfidence,
+      evidence: finding.evidence,
+      fix: finding.fix?.description,
+    },
+  };
+}
+
+function severityToLevel(severity: Severity): SarifLevel {
+  switch (severity) {
+    case "critical":
+    case "high":
+      return "error";
+    case "medium":
+      return "warning";
+    case "low":
+    case "info":
+      return "note";
+  }
+}
+
+function severityToSecurityScore(severity: Severity): string {
+  switch (severity) {
+    case "critical":
+      return "9.5";
+    case "high":
+      return "8.0";
+    case "medium":
+      return "5.0";
+    case "low":
+      return "2.5";
+    case "info":
+      return "1.0";
+  }
+}
+
+function precisionForFinding(finding: Finding): "very-high" | "high" | "medium" {
+  if (finding.runtimeConfidence === "active-runtime") return "very-high";
+  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example") {
+    return "medium";
+  }
+  return "high";
+}
+
+function normalizeUri(uri: string): string {
+  return uri.replace(/\\/g, "/");
+}

--- a/tests/reporter/sarif.test.ts
+++ b/tests/reporter/sarif.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import { renderSarifReport } from "../../src/reporter/sarif.js";
+import type { SecurityReport } from "../../src/types.js";
+
+function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
+  return {
+    timestamp: "2026-05-11T20:00:00.000Z",
+    targetPath: "/tmp/repo",
+    findings: [],
+    score: {
+      grade: "B",
+      numericScore: 84,
+      breakdown: { secrets: 100, permissions: 80, hooks: 80, mcp: 80, agents: 80 },
+    },
+    summary: {
+      totalFindings: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+      filesScanned: 4,
+      autoFixable: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("renderSarifReport", () => {
+  it("renders a SARIF 2.1.0 document", () => {
+    const sarif = JSON.parse(renderSarifReport(makeReport()));
+
+    expect(sarif.version).toBe("2.1.0");
+    expect(sarif.$schema).toContain("sarif-2.1.0");
+    expect(sarif.runs).toHaveLength(1);
+    expect(sarif.runs[0].tool.driver.name).toBe("AgentShield");
+  });
+
+  it("maps findings to rules and results", () => {
+    const sarif = JSON.parse(renderSarifReport(makeReport({
+      findings: [
+        {
+          id: "secrets-hardcoded-1",
+          severity: "critical",
+          category: "secrets",
+          title: "Hardcoded API key",
+          description: "Found a hardcoded API key.",
+          file: "CLAUDE.md",
+          line: 7,
+          runtimeConfidence: "active-runtime",
+          evidence: "sk-***",
+          fix: {
+            description: "Move the key into an environment variable.",
+            before: "sk-xxx",
+            after: "${API_KEY}",
+            auto: false,
+          },
+        },
+      ],
+      summary: {
+        totalFindings: 1,
+        critical: 1,
+        high: 0,
+        medium: 0,
+        low: 0,
+        info: 0,
+        filesScanned: 1,
+        autoFixable: 0,
+      },
+    })));
+
+    expect(sarif.runs[0].tool.driver.rules).toHaveLength(1);
+    expect(sarif.runs[0].tool.driver.rules[0]).toMatchObject({
+      id: "secrets-hardcoded-1",
+      properties: {
+        category: "secrets",
+        severity: "critical",
+        "security-severity": "9.5",
+        precision: "very-high",
+      },
+    });
+    expect(sarif.runs[0].results[0]).toMatchObject({
+      ruleId: "secrets-hardcoded-1",
+      ruleIndex: 0,
+      level: "error",
+      message: { text: "Found a hardcoded API key." },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: { uri: "CLAUDE.md" },
+            region: { startLine: 7 },
+          },
+        },
+      ],
+    });
+  });
+
+  it("deduplicates rules while preserving multiple results", () => {
+    const sarif = JSON.parse(renderSarifReport(makeReport({
+      findings: [
+        {
+          id: "mcp-url-transport",
+          severity: "high",
+          category: "mcp",
+          title: "Remote MCP transport",
+          description: "Remote MCP server configured.",
+          file: "mcp.json",
+        },
+        {
+          id: "mcp-url-transport",
+          severity: "high",
+          category: "mcp",
+          title: "Remote MCP transport",
+          description: "Remote MCP server configured.",
+          file: ".claude/mcp.json",
+        },
+      ],
+      summary: {
+        totalFindings: 2,
+        critical: 0,
+        high: 2,
+        medium: 0,
+        low: 0,
+        info: 0,
+        filesScanned: 2,
+        autoFixable: 0,
+      },
+    })));
+
+    expect(sarif.runs[0].tool.driver.rules).toHaveLength(1);
+    expect(sarif.runs[0].results).toHaveLength(2);
+    expect(sarif.runs[0].results[1].ruleIndex).toBe(0);
+  });
+
+  it("normalizes Windows path separators in artifact URIs", () => {
+    const sarif = JSON.parse(renderSarifReport(makeReport({
+      findings: [
+        {
+          id: "hooks-shell",
+          severity: "medium",
+          category: "hooks",
+          title: "Hook finding",
+          description: "A hook finding.",
+          file: ".claude\\hooks\\scan.ps1",
+        },
+      ],
+      summary: {
+        totalFindings: 1,
+        critical: 0,
+        high: 0,
+        medium: 1,
+        low: 0,
+        info: 0,
+        filesScanned: 1,
+        autoFixable: 0,
+      },
+    })));
+
+    expect(
+      sarif.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri
+    ).toBe(".claude/hooks/scan.ps1");
+  });
+});


### PR DESCRIPTION
## Summary

Adds SARIF 2.1.0 output so AgentShield findings can flow into GitHub code scanning instead of only console annotations/job summaries.

## What changed

- new SARIF reporter with AgentShield rules/results, severity mapping, security-severity metadata, and normalized artifact URIs
- CLI support for `agentshield scan --format sarif --output agentshield.sarif`
- GitHub Action `format: sarif` support with a `sarif-path` output
- example workflow updated to grant `security-events: write` and call `github/codeql-action/upload-sarif@v3`
- README/API docs updated for SARIF/code scanning usage
- dist action/CLI rebuilt for the published action entrypoints

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/reporter/sarif.test.ts tests/action.test.ts`
- `npx tsx src/index.ts scan --path examples/vulnerable --format sarif --output /tmp/agentshield-example.sarif || true`
- `npx tsx src/index.ts scan --path examples/vulnerable --format sarif > /tmp/agentshield-example-stdout.sarif || true`
- `npm run build`
- built action smoke test with `INPUT_FORMAT=sarif`, verified `sarif-path` output and SARIF JSON parse
- built CLI smoke test with `node dist/index.js scan --path examples/vulnerable --format sarif --output /tmp/agentshield-dist.sarif || true`
- `npm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SARIF 2.1.0 reporting so AgentShield findings can be uploaded to GitHub code scanning from both the CLI and the GitHub Action. Includes a new action output for the SARIF path and docs/examples to enable code scanning.

- **New Features**
  - Added SARIF 2.1.0 reporter (rule mapping, severity-to-level, `security-severity`, normalized artifact URIs).
  - CLI: `--format sarif` and `-o/--output` to write SARIF to a file.
  - GitHub Action: supports `format: sarif`, new `sarif-output` input, and exposes `sarif-path`; example workflow adds `security-events: write` and uploads via `github/codeql-action/upload-sarif@v3` (README/API updated).

- **Migration**
  - In your workflow, set `format: sarif` (optionally `sarif-output`).
  - Grant `permissions: security-events: write`.
  - Upload using `github/codeql-action/upload-sarif@v3` with `sarif_file: ${{ steps.agentshield.outputs.sarif-path }}`.
  - CLI usage: `agentshield scan --format sarif --output agentshield.sarif`.

<sup>Written for commit a83b8773d3b60495047ca63596eb75df4250e2bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SARIF output format for the scan command with a new `--output` flag to write reports to files
  * GitHub Action now supports SARIF format with configurable output path, enabling integration with GitHub Code Scanning for security vulnerability uploads

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/50)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->