### PR TITLE
feat: emit policy violations in SARIF

### DIFF
--- a/API.md
+++ b/API.md
@@ -90,9 +90,10 @@ High-value `scan` options:
 
 The GitHub Action exposes the same organization policy gate through the
 `policy` input. It reports `policy-status` and `policy-violations` outputs,
-adds policy results to the job summary, and fails on non-compliance by default.
-Set `fail-on-policy: "false"` to collect policy evidence without failing the
-workflow.
+adds policy results to the job summary, emits policy violations into SARIF as
+`agentshield-policy/*` code-scanning results when SARIF output is enabled, and
+fails on non-compliance by default. Set `fail-on-policy: "false"` to collect
+policy evidence without failing the workflow.
 
 Policy files use schema version `1`. Enterprise policy metadata is optional but
 recommended for CI gates:

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ Detailed request/response and schema notes live in [`API.md`](./API.md).
 
 **Outputs:** `score` (0–100), `grade` (A–F), `total-findings`, `critical-count`, `sarif-path`, `policy-status`, `policy-violations`
 
-The action writes a markdown job summary and emits GitHub annotations inline on affected files. When `format: sarif` is set, it also writes a SARIF 2.1.0 report that can be uploaded to GitHub code scanning with `github/codeql-action/upload-sarif`. When `policy` is set, the action appends the organization policy result to the job summary, emits policy violation annotations, and fails by default unless `fail-on-policy: "false"` is set.
+The action writes a markdown job summary and emits GitHub annotations inline on affected files. When `format: sarif` is set, it also writes a SARIF 2.1.0 report that can be uploaded to GitHub code scanning with `github/codeql-action/upload-sarif`. When `policy` is set, the SARIF report includes organization-policy violations as `agentshield-policy/*` code-scanning results, appends the organization policy result to the job summary, emits policy violation annotations, and fails by default unless `fail-on-policy: "false"` is set.
 
 ## CLI Reference
 

--- a/dist/action.js
+++ b/dist/action.js
@@ -8,206 +8,10 @@ var __export = (target, all) => {
     __defProp(target, name, { get: all[name], enumerable: true });
 };
 
-// src/baseline/types.ts
-var DEFAULT_GATE_CONFIG;
-var init_types = __esm({
-  "src/baseline/types.ts"() {
-    "use strict";
-    DEFAULT_GATE_CONFIG = {
-      maxNewFindings: 0,
-      maxScoreDrop: 5,
-      failOnNewCritical: true,
-      failOnNewHigh: true
-    };
-  }
-});
-
-// src/baseline/compare.ts
-import { readFileSync as readFileSync2, writeFileSync, existsSync as existsSync2 } from "fs";
-import { dirname as dirname2 } from "path";
-import { mkdirSync } from "fs";
-function fingerprintFinding(finding) {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
-function saveBaseline(findings, score, outputPath) {
-  const serialized = {
-    version: 1,
-    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-    score,
-    findings: findings.map((f) => ({
-      id: f.id,
-      severity: f.severity,
-      category: f.category,
-      title: f.title,
-      file: f.file,
-      evidence: f.evidence,
-      fingerprint: fingerprintFinding(f)
-    }))
-  };
-  const dir = dirname2(outputPath);
-  if (!existsSync2(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  writeFileSync(outputPath, JSON.stringify(serialized, null, 2));
-}
-function loadBaseline(baselinePath) {
-  if (!existsSync2(baselinePath)) return null;
-  try {
-    const raw = readFileSync2(baselinePath, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
-      return null;
-    }
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-function compareBaseline(baseline, currentFindings, currentScore) {
-  const baselineFingerprints = new Set(
-    baseline.findings.map((f) => f.fingerprint)
-  );
-  const currentFingerprints = new Set(
-    currentFindings.map(fingerprintFinding)
-  );
-  const newFindings = currentFindings.filter(
-    (f) => !baselineFingerprints.has(fingerprintFinding(f))
-  );
-  const resolvedFindings = baseline.findings.filter(
-    (f) => !currentFingerprints.has(f.fingerprint)
-  );
-  const unchangedCount = currentFindings.length - newFindings.length;
-  const scoreDelta = currentScore.numericScore - baseline.score.numericScore;
-  const newCriticalCount = newFindings.filter(
-    (f) => f.severity === "critical"
-  ).length;
-  const newHighCount = newFindings.filter(
-    (f) => f.severity === "high"
-  ).length;
-  const isRegression = newFindings.length > 0 || scoreDelta < 0;
-  return {
-    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-    baselineTimestamp: baseline.timestamp,
-    newFindings,
-    resolvedFindings,
-    unchangedCount,
-    scoreDelta,
-    baselineScore: baseline.score.numericScore,
-    currentScore: currentScore.numericScore,
-    isRegression,
-    newCriticalCount,
-    newHighCount
-  };
-}
-function evaluateGate(comparison, config = DEFAULT_GATE_CONFIG) {
-  const reasons = [];
-  if (config.failOnNewCritical && comparison.newCriticalCount > 0) {
-    reasons.push(
-      `${comparison.newCriticalCount} new critical finding(s) introduced`
-    );
-  }
-  if (config.failOnNewHigh && comparison.newHighCount > 0) {
-    reasons.push(
-      `${comparison.newHighCount} new high finding(s) introduced`
-    );
-  }
-  if (comparison.newFindings.length > config.maxNewFindings) {
-    reasons.push(
-      `${comparison.newFindings.length} new finding(s) exceed threshold of ${config.maxNewFindings}`
-    );
-  }
-  if (comparison.scoreDelta < -config.maxScoreDrop) {
-    reasons.push(
-      `Score dropped by ${Math.abs(comparison.scoreDelta)} points (max allowed: ${config.maxScoreDrop})`
-    );
-  }
-  return {
-    passed: reasons.length === 0,
-    reasons,
-    comparison
-  };
-}
-function renderComparison(comparison) {
-  const lines = [];
-  const divider = "\u2500".repeat(60);
-  lines.push("");
-  lines.push(`  ${divider}`);
-  lines.push("  Baseline Comparison Report");
-  lines.push(`  ${divider}`);
-  lines.push("");
-  const direction = comparison.scoreDelta > 0 ? "+" : "";
-  const label = comparison.scoreDelta > 0 ? "IMPROVED" : comparison.scoreDelta < 0 ? "REGRESSED" : "UNCHANGED";
-  lines.push(
-    `  Score: ${comparison.baselineScore} \u2192 ${comparison.currentScore} (${direction}${comparison.scoreDelta}) [${label}]`
-  );
-  lines.push(
-    `  Baseline from: ${comparison.baselineTimestamp}`
-  );
-  lines.push("");
-  if (comparison.newFindings.length > 0) {
-    lines.push(`  NEW FINDINGS (${comparison.newFindings.length}):`);
-    for (const f of comparison.newFindings) {
-      lines.push(`    [${f.severity.toUpperCase().padEnd(8)}] ${f.title}`);
-      lines.push(`               ${f.file}`);
-    }
-    lines.push("");
-  }
-  if (comparison.resolvedFindings.length > 0) {
-    lines.push(`  RESOLVED FINDINGS (${comparison.resolvedFindings.length}):`);
-    for (const f of comparison.resolvedFindings) {
-      lines.push(`    [RESOLVED] ${f.title}`);
-    }
-    lines.push("");
-  }
-  lines.push(`  Unchanged: ${comparison.unchangedCount} finding(s)`);
-  lines.push(`  ${divider}`);
-  lines.push("");
-  return lines.join("\n");
-}
-function renderGateResult(result) {
-  const lines = [];
-  if (result.passed) {
-    lines.push("  Gate: PASSED \u2014 No regressions detected.");
-  } else {
-    lines.push("  Gate: FAILED \u2014 Security regressions detected:");
-    for (const reason of result.reasons) {
-      lines.push(`    - ${reason}`);
-    }
-  }
-  lines.push("");
-  return lines.join("\n");
-}
-var init_compare = __esm({
-  "src/baseline/compare.ts"() {
-    "use strict";
-    init_types();
-  }
-});
-
-// src/baseline/index.ts
-var baseline_exports = {};
-__export(baseline_exports, {
-  DEFAULT_GATE_CONFIG: () => DEFAULT_GATE_CONFIG,
-  compareBaseline: () => compareBaseline,
-  evaluateGate: () => evaluateGate,
-  fingerprintFinding: () => fingerprintFinding,
-  loadBaseline: () => loadBaseline,
-  renderComparison: () => renderComparison,
-  renderGateResult: () => renderGateResult,
-  saveBaseline: () => saveBaseline
-});
-var init_baseline = __esm({
-  "src/baseline/index.ts"() {
-    "use strict";
-    init_compare();
-    init_types();
-  }
-});
-
 // src/policy/types.ts
 import { z } from "zod";
 var SeveritySchema, PolicyPackSchema, PolicyExceptionSchema, OrgPolicySchema;
-var init_types2 = __esm({
+var init_types = __esm({
   "src/policy/types.ts"() {
     "use strict";
     SeveritySchema = z.enum(["critical", "high", "medium", "low", "info"]);
@@ -259,13 +63,13 @@ var init_types2 = __esm({
 });
 
 // src/policy/evaluate.ts
-import { readFileSync as readFileSync3, existsSync as existsSync3 } from "fs";
+import { readFileSync as readFileSync2, existsSync as existsSync2 } from "fs";
 function loadPolicy(policyPath) {
-  if (!existsSync3(policyPath)) {
+  if (!existsSync2(policyPath)) {
     return { success: false, error: `Policy file not found: ${policyPath}` };
   }
   try {
-    const raw = readFileSync3(policyPath, "utf-8");
+    const raw = readFileSync2(policyPath, "utf-8");
     const parsed = JSON.parse(raw);
     return { success: true, policy: OrgPolicySchema.parse(parsed) };
   } catch (error) {
@@ -590,7 +394,7 @@ var SEVERITY_ORDER;
 var init_evaluate = __esm({
   "src/policy/evaluate.ts"() {
     "use strict";
-    init_types2();
+    init_types();
     SEVERITY_ORDER = {
       critical: 0,
       high: 1,
@@ -616,6 +420,202 @@ var init_policy = __esm({
   "src/policy/index.ts"() {
     "use strict";
     init_evaluate();
+    init_types();
+  }
+});
+
+// src/baseline/types.ts
+var DEFAULT_GATE_CONFIG;
+var init_types2 = __esm({
+  "src/baseline/types.ts"() {
+    "use strict";
+    DEFAULT_GATE_CONFIG = {
+      maxNewFindings: 0,
+      maxScoreDrop: 5,
+      failOnNewCritical: true,
+      failOnNewHigh: true
+    };
+  }
+});
+
+// src/baseline/compare.ts
+import { readFileSync as readFileSync3, writeFileSync, existsSync as existsSync3 } from "fs";
+import { dirname as dirname2 } from "path";
+import { mkdirSync } from "fs";
+function fingerprintFinding(finding) {
+  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
+}
+function saveBaseline(findings, score, outputPath) {
+  const serialized = {
+    version: 1,
+    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+    score,
+    findings: findings.map((f) => ({
+      id: f.id,
+      severity: f.severity,
+      category: f.category,
+      title: f.title,
+      file: f.file,
+      evidence: f.evidence,
+      fingerprint: fingerprintFinding(f)
+    }))
+  };
+  const dir = dirname2(outputPath);
+  if (!existsSync3(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(outputPath, JSON.stringify(serialized, null, 2));
+}
+function loadBaseline(baselinePath) {
+  if (!existsSync3(baselinePath)) return null;
+  try {
+    const raw = readFileSync3(baselinePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+function compareBaseline(baseline, currentFindings, currentScore) {
+  const baselineFingerprints = new Set(
+    baseline.findings.map((f) => f.fingerprint)
+  );
+  const currentFingerprints = new Set(
+    currentFindings.map(fingerprintFinding)
+  );
+  const newFindings = currentFindings.filter(
+    (f) => !baselineFingerprints.has(fingerprintFinding(f))
+  );
+  const resolvedFindings = baseline.findings.filter(
+    (f) => !currentFingerprints.has(f.fingerprint)
+  );
+  const unchangedCount = currentFindings.length - newFindings.length;
+  const scoreDelta = currentScore.numericScore - baseline.score.numericScore;
+  const newCriticalCount = newFindings.filter(
+    (f) => f.severity === "critical"
+  ).length;
+  const newHighCount = newFindings.filter(
+    (f) => f.severity === "high"
+  ).length;
+  const isRegression = newFindings.length > 0 || scoreDelta < 0;
+  return {
+    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+    baselineTimestamp: baseline.timestamp,
+    newFindings,
+    resolvedFindings,
+    unchangedCount,
+    scoreDelta,
+    baselineScore: baseline.score.numericScore,
+    currentScore: currentScore.numericScore,
+    isRegression,
+    newCriticalCount,
+    newHighCount
+  };
+}
+function evaluateGate(comparison, config = DEFAULT_GATE_CONFIG) {
+  const reasons = [];
+  if (config.failOnNewCritical && comparison.newCriticalCount > 0) {
+    reasons.push(
+      `${comparison.newCriticalCount} new critical finding(s) introduced`
+    );
+  }
+  if (config.failOnNewHigh && comparison.newHighCount > 0) {
+    reasons.push(
+      `${comparison.newHighCount} new high finding(s) introduced`
+    );
+  }
+  if (comparison.newFindings.length > config.maxNewFindings) {
+    reasons.push(
+      `${comparison.newFindings.length} new finding(s) exceed threshold of ${config.maxNewFindings}`
+    );
+  }
+  if (comparison.scoreDelta < -config.maxScoreDrop) {
+    reasons.push(
+      `Score dropped by ${Math.abs(comparison.scoreDelta)} points (max allowed: ${config.maxScoreDrop})`
+    );
+  }
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    comparison
+  };
+}
+function renderComparison(comparison) {
+  const lines = [];
+  const divider = "\u2500".repeat(60);
+  lines.push("");
+  lines.push(`  ${divider}`);
+  lines.push("  Baseline Comparison Report");
+  lines.push(`  ${divider}`);
+  lines.push("");
+  const direction = comparison.scoreDelta > 0 ? "+" : "";
+  const label = comparison.scoreDelta > 0 ? "IMPROVED" : comparison.scoreDelta < 0 ? "REGRESSED" : "UNCHANGED";
+  lines.push(
+    `  Score: ${comparison.baselineScore} \u2192 ${comparison.currentScore} (${direction}${comparison.scoreDelta}) [${label}]`
+  );
+  lines.push(
+    `  Baseline from: ${comparison.baselineTimestamp}`
+  );
+  lines.push("");
+  if (comparison.newFindings.length > 0) {
+    lines.push(`  NEW FINDINGS (${comparison.newFindings.length}):`);
+    for (const f of comparison.newFindings) {
+      lines.push(`    [${f.severity.toUpperCase().padEnd(8)}] ${f.title}`);
+      lines.push(`               ${f.file}`);
+    }
+    lines.push("");
+  }
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push(`  RESOLVED FINDINGS (${comparison.resolvedFindings.length}):`);
+    for (const f of comparison.resolvedFindings) {
+      lines.push(`    [RESOLVED] ${f.title}`);
+    }
+    lines.push("");
+  }
+  lines.push(`  Unchanged: ${comparison.unchangedCount} finding(s)`);
+  lines.push(`  ${divider}`);
+  lines.push("");
+  return lines.join("\n");
+}
+function renderGateResult(result) {
+  const lines = [];
+  if (result.passed) {
+    lines.push("  Gate: PASSED \u2014 No regressions detected.");
+  } else {
+    lines.push("  Gate: FAILED \u2014 Security regressions detected:");
+    for (const reason of result.reasons) {
+      lines.push(`    - ${reason}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+var init_compare = __esm({
+  "src/baseline/compare.ts"() {
+    "use strict";
+    init_types2();
+  }
+});
+
+// src/baseline/index.ts
+var baseline_exports = {};
+__export(baseline_exports, {
+  DEFAULT_GATE_CONFIG: () => DEFAULT_GATE_CONFIG,
+  compareBaseline: () => compareBaseline,
+  evaluateGate: () => evaluateGate,
+  fingerprintFinding: () => fingerprintFinding,
+  loadBaseline: () => loadBaseline,
+  renderComparison: () => renderComparison,
+  renderGateResult: () => renderGateResult,
+  saveBaseline: () => saveBaseline
+});
+var init_baseline = __esm({
+  "src/baseline/index.ts"() {
+    "use strict";
+    init_compare();
     init_types2();
   }
 });
@@ -8999,9 +8999,13 @@ function renderMarkdownReport(report) {
 
 // src/reporter/sarif.ts
 var SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json";
-function renderSarifReport(report) {
-  const rules = buildRules(report.findings);
+function renderSarifReport(report, options = {}) {
+  const rules = [
+    ...buildFindingRules(report.findings),
+    ...buildPolicyRules(options.policyEvaluation)
+  ];
   const ruleIndexes = new Map(rules.map((rule, index) => [rule.id, index]));
+  const policyUri = options.policyUri ?? ".agentshield/policy.json";
   return JSON.stringify(
     {
       version: "2.1.0",
@@ -9030,11 +9034,24 @@ function renderSarifReport(report) {
           properties: {
             score: report.score.numericScore,
             grade: report.score.grade,
-            filesScanned: report.summary.filesScanned
+            filesScanned: report.summary.filesScanned,
+            ...options.policyEvaluation ? {
+              policyStatus: options.policyEvaluation.passed ? "compliant" : "non-compliant",
+              policyViolations: options.policyEvaluation.violations.length,
+              policyName: options.policyEvaluation.policyName,
+              policyPack: options.policyEvaluation.policyPack
+            } : {}
           },
-          results: report.findings.map(
-            (finding) => renderSarifResult(finding, ruleIndexes.get(finding.id) ?? 0)
-          )
+          results: [
+            ...report.findings.map(
+              (finding) => renderFindingResult(finding, ruleIndexes.get(finding.id) ?? 0)
+            ),
+            ...renderPolicyResults(
+              options.policyEvaluation,
+              ruleIndexes,
+              policyUri
+            )
+          ]
         }
       ]
     },
@@ -9042,7 +9059,7 @@ function renderSarifReport(report) {
     2
   );
 }
-function buildRules(findings) {
+function buildFindingRules(findings) {
   const rules = /* @__PURE__ */ new Map();
   for (const finding of findings) {
     if (rules.has(finding.id)) continue;
@@ -9068,7 +9085,47 @@ Recommended fix: ${finding.fix.description}` } : { text: finding.description },
   }
   return [...rules.values()];
 }
-function renderSarifResult(finding, ruleIndex) {
+function buildPolicyRules(evaluation) {
+  if (!evaluation) return [];
+  const rules = /* @__PURE__ */ new Map();
+  for (const violation of evaluation.violations) {
+    const ruleId = policyRuleId(violation);
+    if (rules.has(ruleId)) continue;
+    rules.set(ruleId, {
+      id: ruleId,
+      name: `Organization policy: ${violation.rule}`,
+      shortDescription: {
+        text: `Organization policy: ${violation.rule}`
+      },
+      fullDescription: {
+        text: violation.description
+      },
+      help: {
+        text: [
+          violation.description,
+          "",
+          `Expected: ${violation.expected}`,
+          `Actual: ${violation.actual}`
+        ].join("\n")
+      },
+      defaultConfiguration: {
+        level: severityToLevel(violation.severity)
+      },
+      properties: {
+        category: "organization-policy",
+        severity: violation.severity,
+        "security-severity": severityToSecurityScore(violation.severity),
+        tags: ["security", "agent-config", "organization-policy"],
+        precision: "high",
+        policyName: evaluation.policyName,
+        policyPack: evaluation.policyPack,
+        owners: evaluation.owners ?? []
+      }
+    });
+  }
+  return [...rules.values()];
+}
+function renderFindingResult(finding, ruleIndex) {
   return {
     ruleId: finding.id,
     ruleIndex,
@@ -9099,6 +9156,42 @@ function renderSarifResult(finding, ruleIndex) {
       fix: finding.fix?.description
     }
   };
+}
+function renderPolicyResults(evaluation, ruleIndexes, policyUri) {
+  if (!evaluation) return [];
+  return evaluation.violations.map((violation) => {
+    const ruleId = policyRuleId(violation);
+    return {
+      ruleId,
+      ruleIndex: ruleIndexes.get(ruleId) ?? 0,
+      level: severityToLevel(violation.severity),
+      message: {
+        text: violation.description
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: normalizeUri(policyUri)
+            }
+          }
+        }
+      ],
+      properties: {
+        source: "organization-policy",
+        policyName: evaluation.policyName,
+        policyPack: evaluation.policyPack,
+        owners: evaluation.owners ?? [],
+        rule: violation.rule,
+        severity: violation.severity,
+        expected: violation.expected,
+        actual: violation.actual
+      }
+    };
+  });
+}
+function policyRuleId(violation) {
+  return `agentshield-policy/${violation.rule}`;
 }
 function severityToLevel(severity) {
   switch (severity) {
@@ -9270,10 +9363,64 @@ async function run() {
   setOutput("critical-count", String(report.summary.critical));
   setOutput("policy-status", "not-run");
   setOutput("policy-violations", "0");
+  let policyEvaluation = null;
+  let shouldFailOnPolicy = false;
+  if (policyPath) {
+    const { loadPolicy: loadPolicy2, evaluatePolicy: evaluatePolicy2, renderPolicyEvaluation: renderPolicyEvaluation2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
+    const resolvedPolicyPath = resolve2(workspace, policyPath);
+    const policyResult = loadPolicy2(resolvedPolicyPath);
+    if (!policyResult.success) {
+      setOutput("policy-status", "error");
+      console.log(
+        `::error::AgentShield policy load failed: ${escapeAnnotation(policyResult.error)}`
+      );
+      writeJobSummary([
+        "",
+        "",
+        "## AgentShield Organization Policy",
+        "",
+        "- Status: error",
+        `- Error: ${policyResult.error}`,
+        ""
+      ].join("\n"));
+      if (failOnPolicy) {
+        shouldFailOnPolicy = true;
+      }
+    } else {
+      policyEvaluation = evaluatePolicy2(
+        policyResult.policy,
+        filteredResult.findings,
+        report.score,
+        result.target.files
+      );
+      const policyStatus = statusForPolicyEvaluation(policyEvaluation);
+      setOutput("policy-status", policyStatus);
+      setOutput("policy-violations", String(policyEvaluation.violations.length));
+      writeJobSummary(renderPolicyJobSummary(policyEvaluation));
+      console.log(renderPolicyEvaluation2(policyEvaluation));
+      if (!policyEvaluation.passed) {
+        for (const violation of policyEvaluation.violations) {
+          const message = escapeAnnotation(violation.description);
+          console.log(
+            `::error::AgentShield policy violation ${violation.rule}: ${message}`
+          );
+        }
+        if (failOnPolicy) {
+          shouldFailOnPolicy = true;
+        }
+      }
+    }
+  }
   if (format === "sarif") {
     const sarifPath = resolve2(workspace, sarifOutput);
     mkdirSync2(dirname3(sarifPath), { recursive: true });
-    writeFileSync2(sarifPath, renderSarifReport(report));
+    writeFileSync2(
+      sarifPath,
+      renderSarifReport(report, {
+        policyEvaluation: policyEvaluation ?? void 0,
+        policyUri: policyPath || void 0
+      })
+    );
     setOutput("sarif-path", sarifPath);
     console.log(`SARIF written to: ${sarifPath}`);
   }
@@ -9319,53 +9466,9 @@ async function run() {
       console.log(`::warning::Could not load baseline from ${baselinePath}. Skipping comparison.`);
     }
   }
-  if (policyPath) {
-    const { loadPolicy: loadPolicy2, evaluatePolicy: evaluatePolicy2, renderPolicyEvaluation: renderPolicyEvaluation2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
-    const resolvedPolicyPath = resolve2(workspace, policyPath);
-    const policyResult = loadPolicy2(resolvedPolicyPath);
-    if (!policyResult.success) {
-      setOutput("policy-status", "error");
-      console.log(
-        `::error::AgentShield policy load failed: ${escapeAnnotation(policyResult.error)}`
-      );
-      writeJobSummary([
-        "",
-        "",
-        "## AgentShield Organization Policy",
-        "",
-        "- Status: error",
-        `- Error: ${policyResult.error}`,
-        ""
-      ].join("\n"));
-      if (failOnPolicy) {
-        process.exitCode = 1;
-        return;
-      }
-    } else {
-      const evaluation = evaluatePolicy2(
-        policyResult.policy,
-        filteredResult.findings,
-        report.score,
-        result.target.files
-      );
-      const policyStatus = statusForPolicyEvaluation(evaluation);
-      setOutput("policy-status", policyStatus);
-      setOutput("policy-violations", String(evaluation.violations.length));
-      writeJobSummary(renderPolicyJobSummary(evaluation));
-      console.log(renderPolicyEvaluation2(evaluation));
-      if (!evaluation.passed) {
-        for (const violation of evaluation.violations) {
-          const message = escapeAnnotation(violation.description);
-          console.log(
-            `::error::AgentShield policy violation ${violation.rule}: ${message}`
-          );
-        }
-        if (failOnPolicy) {
-          process.exitCode = 1;
-          return;
-        }
-      }
-    }
+  if (shouldFailOnPolicy) {
+    process.exitCode = 1;
+    return;
   }
   if (failOnFindings && filteredResult.findings.length > 0) {
     console.log("");

--- a/dist/index.js
+++ b/dist/index.js
@@ -11159,206 +11159,10 @@ var init_corpus = __esm({
   }
 });
 
-// src/baseline/types.ts
-var DEFAULT_GATE_CONFIG;
-var init_types = __esm({
-  "src/baseline/types.ts"() {
-    "use strict";
-    DEFAULT_GATE_CONFIG = {
-      maxNewFindings: 0,
-      maxScoreDrop: 5,
-      failOnNewCritical: true,
-      failOnNewHigh: true
-    };
-  }
-});
-
-// src/baseline/compare.ts
-import { readFileSync as readFileSync6, writeFileSync as writeFileSync4, existsSync as existsSync8 } from "fs";
-import { dirname as dirname4 } from "path";
-import { mkdirSync as mkdirSync4 } from "fs";
-function fingerprintFinding2(finding) {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
-function saveBaseline(findings, score, outputPath) {
-  const serialized = {
-    version: 1,
-    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-    score,
-    findings: findings.map((f) => ({
-      id: f.id,
-      severity: f.severity,
-      category: f.category,
-      title: f.title,
-      file: f.file,
-      evidence: f.evidence,
-      fingerprint: fingerprintFinding2(f)
-    }))
-  };
-  const dir = dirname4(outputPath);
-  if (!existsSync8(dir)) {
-    mkdirSync4(dir, { recursive: true });
-  }
-  writeFileSync4(outputPath, JSON.stringify(serialized, null, 2));
-}
-function loadBaseline(baselinePath) {
-  if (!existsSync8(baselinePath)) return null;
-  try {
-    const raw = readFileSync6(baselinePath, "utf-8");
-    const parsed = JSON.parse(raw);
-    if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
-      return null;
-    }
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-function compareBaseline(baseline, currentFindings, currentScore) {
-  const baselineFingerprints = new Set(
-    baseline.findings.map((f) => f.fingerprint)
-  );
-  const currentFingerprints = new Set(
-    currentFindings.map(fingerprintFinding2)
-  );
-  const newFindings = currentFindings.filter(
-    (f) => !baselineFingerprints.has(fingerprintFinding2(f))
-  );
-  const resolvedFindings = baseline.findings.filter(
-    (f) => !currentFingerprints.has(f.fingerprint)
-  );
-  const unchangedCount = currentFindings.length - newFindings.length;
-  const scoreDelta = currentScore.numericScore - baseline.score.numericScore;
-  const newCriticalCount = newFindings.filter(
-    (f) => f.severity === "critical"
-  ).length;
-  const newHighCount = newFindings.filter(
-    (f) => f.severity === "high"
-  ).length;
-  const isRegression = newFindings.length > 0 || scoreDelta < 0;
-  return {
-    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
-    baselineTimestamp: baseline.timestamp,
-    newFindings,
-    resolvedFindings,
-    unchangedCount,
-    scoreDelta,
-    baselineScore: baseline.score.numericScore,
-    currentScore: currentScore.numericScore,
-    isRegression,
-    newCriticalCount,
-    newHighCount
-  };
-}
-function evaluateGate(comparison, config = DEFAULT_GATE_CONFIG) {
-  const reasons = [];
-  if (config.failOnNewCritical && comparison.newCriticalCount > 0) {
-    reasons.push(
-      `${comparison.newCriticalCount} new critical finding(s) introduced`
-    );
-  }
-  if (config.failOnNewHigh && comparison.newHighCount > 0) {
-    reasons.push(
-      `${comparison.newHighCount} new high finding(s) introduced`
-    );
-  }
-  if (comparison.newFindings.length > config.maxNewFindings) {
-    reasons.push(
-      `${comparison.newFindings.length} new finding(s) exceed threshold of ${config.maxNewFindings}`
-    );
-  }
-  if (comparison.scoreDelta < -config.maxScoreDrop) {
-    reasons.push(
-      `Score dropped by ${Math.abs(comparison.scoreDelta)} points (max allowed: ${config.maxScoreDrop})`
-    );
-  }
-  return {
-    passed: reasons.length === 0,
-    reasons,
-    comparison
-  };
-}
-function renderComparison(comparison) {
-  const lines = [];
-  const divider = "\u2500".repeat(60);
-  lines.push("");
-  lines.push(`  ${divider}`);
-  lines.push("  Baseline Comparison Report");
-  lines.push(`  ${divider}`);
-  lines.push("");
-  const direction = comparison.scoreDelta > 0 ? "+" : "";
-  const label = comparison.scoreDelta > 0 ? "IMPROVED" : comparison.scoreDelta < 0 ? "REGRESSED" : "UNCHANGED";
-  lines.push(
-    `  Score: ${comparison.baselineScore} \u2192 ${comparison.currentScore} (${direction}${comparison.scoreDelta}) [${label}]`
-  );
-  lines.push(
-    `  Baseline from: ${comparison.baselineTimestamp}`
-  );
-  lines.push("");
-  if (comparison.newFindings.length > 0) {
-    lines.push(`  NEW FINDINGS (${comparison.newFindings.length}):`);
-    for (const f of comparison.newFindings) {
-      lines.push(`    [${f.severity.toUpperCase().padEnd(8)}] ${f.title}`);
-      lines.push(`               ${f.file}`);
-    }
-    lines.push("");
-  }
-  if (comparison.resolvedFindings.length > 0) {
-    lines.push(`  RESOLVED FINDINGS (${comparison.resolvedFindings.length}):`);
-    for (const f of comparison.resolvedFindings) {
-      lines.push(`    [RESOLVED] ${f.title}`);
-    }
-    lines.push("");
-  }
-  lines.push(`  Unchanged: ${comparison.unchangedCount} finding(s)`);
-  lines.push(`  ${divider}`);
-  lines.push("");
-  return lines.join("\n");
-}
-function renderGateResult(result) {
-  const lines = [];
-  if (result.passed) {
-    lines.push("  Gate: PASSED \u2014 No regressions detected.");
-  } else {
-    lines.push("  Gate: FAILED \u2014 Security regressions detected:");
-    for (const reason of result.reasons) {
-      lines.push(`    - ${reason}`);
-    }
-  }
-  lines.push("");
-  return lines.join("\n");
-}
-var init_compare = __esm({
-  "src/baseline/compare.ts"() {
-    "use strict";
-    init_types();
-  }
-});
-
-// src/baseline/index.ts
-var baseline_exports = {};
-__export(baseline_exports, {
-  DEFAULT_GATE_CONFIG: () => DEFAULT_GATE_CONFIG,
-  compareBaseline: () => compareBaseline,
-  evaluateGate: () => evaluateGate,
-  fingerprintFinding: () => fingerprintFinding2,
-  loadBaseline: () => loadBaseline,
-  renderComparison: () => renderComparison,
-  renderGateResult: () => renderGateResult,
-  saveBaseline: () => saveBaseline
-});
-var init_baseline = __esm({
-  "src/baseline/index.ts"() {
-    "use strict";
-    init_compare();
-    init_types();
-  }
-});
-
 // src/policy/types.ts
 import { z as z2 } from "zod";
 var SeveritySchema, PolicyPackSchema, PolicyExceptionSchema, OrgPolicySchema;
-var init_types2 = __esm({
+var init_types = __esm({
   "src/policy/types.ts"() {
     "use strict";
     SeveritySchema = z2.enum(["critical", "high", "medium", "low", "info"]);
@@ -11410,13 +11214,13 @@ var init_types2 = __esm({
 });
 
 // src/policy/evaluate.ts
-import { readFileSync as readFileSync7, existsSync as existsSync9 } from "fs";
+import { readFileSync as readFileSync6, existsSync as existsSync8 } from "fs";
 function loadPolicy2(policyPath) {
-  if (!existsSync9(policyPath)) {
+  if (!existsSync8(policyPath)) {
     return { success: false, error: `Policy file not found: ${policyPath}` };
   }
   try {
-    const raw = readFileSync7(policyPath, "utf-8");
+    const raw = readFileSync6(policyPath, "utf-8");
     const parsed = JSON.parse(raw);
     return { success: true, policy: OrgPolicySchema.parse(parsed) };
   } catch (error) {
@@ -11741,7 +11545,7 @@ var SEVERITY_ORDER2;
 var init_evaluate = __esm({
   "src/policy/evaluate.ts"() {
     "use strict";
-    init_types2();
+    init_types();
     SEVERITY_ORDER2 = {
       critical: 0,
       high: 1,
@@ -11767,6 +11571,202 @@ var init_policy = __esm({
   "src/policy/index.ts"() {
     "use strict";
     init_evaluate();
+    init_types();
+  }
+});
+
+// src/baseline/types.ts
+var DEFAULT_GATE_CONFIG;
+var init_types2 = __esm({
+  "src/baseline/types.ts"() {
+    "use strict";
+    DEFAULT_GATE_CONFIG = {
+      maxNewFindings: 0,
+      maxScoreDrop: 5,
+      failOnNewCritical: true,
+      failOnNewHigh: true
+    };
+  }
+});
+
+// src/baseline/compare.ts
+import { readFileSync as readFileSync7, writeFileSync as writeFileSync4, existsSync as existsSync9 } from "fs";
+import { dirname as dirname4 } from "path";
+import { mkdirSync as mkdirSync4 } from "fs";
+function fingerprintFinding2(finding) {
+  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
+}
+function saveBaseline(findings, score, outputPath) {
+  const serialized = {
+    version: 1,
+    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+    score,
+    findings: findings.map((f) => ({
+      id: f.id,
+      severity: f.severity,
+      category: f.category,
+      title: f.title,
+      file: f.file,
+      evidence: f.evidence,
+      fingerprint: fingerprintFinding2(f)
+    }))
+  };
+  const dir = dirname4(outputPath);
+  if (!existsSync9(dir)) {
+    mkdirSync4(dir, { recursive: true });
+  }
+  writeFileSync4(outputPath, JSON.stringify(serialized, null, 2));
+}
+function loadBaseline(baselinePath) {
+  if (!existsSync9(baselinePath)) return null;
+  try {
+    const raw = readFileSync7(baselinePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+function compareBaseline(baseline, currentFindings, currentScore) {
+  const baselineFingerprints = new Set(
+    baseline.findings.map((f) => f.fingerprint)
+  );
+  const currentFingerprints = new Set(
+    currentFindings.map(fingerprintFinding2)
+  );
+  const newFindings = currentFindings.filter(
+    (f) => !baselineFingerprints.has(fingerprintFinding2(f))
+  );
+  const resolvedFindings = baseline.findings.filter(
+    (f) => !currentFingerprints.has(f.fingerprint)
+  );
+  const unchangedCount = currentFindings.length - newFindings.length;
+  const scoreDelta = currentScore.numericScore - baseline.score.numericScore;
+  const newCriticalCount = newFindings.filter(
+    (f) => f.severity === "critical"
+  ).length;
+  const newHighCount = newFindings.filter(
+    (f) => f.severity === "high"
+  ).length;
+  const isRegression = newFindings.length > 0 || scoreDelta < 0;
+  return {
+    timestamp: (/* @__PURE__ */ new Date()).toISOString(),
+    baselineTimestamp: baseline.timestamp,
+    newFindings,
+    resolvedFindings,
+    unchangedCount,
+    scoreDelta,
+    baselineScore: baseline.score.numericScore,
+    currentScore: currentScore.numericScore,
+    isRegression,
+    newCriticalCount,
+    newHighCount
+  };
+}
+function evaluateGate(comparison, config = DEFAULT_GATE_CONFIG) {
+  const reasons = [];
+  if (config.failOnNewCritical && comparison.newCriticalCount > 0) {
+    reasons.push(
+      `${comparison.newCriticalCount} new critical finding(s) introduced`
+    );
+  }
+  if (config.failOnNewHigh && comparison.newHighCount > 0) {
+    reasons.push(
+      `${comparison.newHighCount} new high finding(s) introduced`
+    );
+  }
+  if (comparison.newFindings.length > config.maxNewFindings) {
+    reasons.push(
+      `${comparison.newFindings.length} new finding(s) exceed threshold of ${config.maxNewFindings}`
+    );
+  }
+  if (comparison.scoreDelta < -config.maxScoreDrop) {
+    reasons.push(
+      `Score dropped by ${Math.abs(comparison.scoreDelta)} points (max allowed: ${config.maxScoreDrop})`
+    );
+  }
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    comparison
+  };
+}
+function renderComparison(comparison) {
+  const lines = [];
+  const divider = "\u2500".repeat(60);
+  lines.push("");
+  lines.push(`  ${divider}`);
+  lines.push("  Baseline Comparison Report");
+  lines.push(`  ${divider}`);
+  lines.push("");
+  const direction = comparison.scoreDelta > 0 ? "+" : "";
+  const label = comparison.scoreDelta > 0 ? "IMPROVED" : comparison.scoreDelta < 0 ? "REGRESSED" : "UNCHANGED";
+  lines.push(
+    `  Score: ${comparison.baselineScore} \u2192 ${comparison.currentScore} (${direction}${comparison.scoreDelta}) [${label}]`
+  );
+  lines.push(
+    `  Baseline from: ${comparison.baselineTimestamp}`
+  );
+  lines.push("");
+  if (comparison.newFindings.length > 0) {
+    lines.push(`  NEW FINDINGS (${comparison.newFindings.length}):`);
+    for (const f of comparison.newFindings) {
+      lines.push(`    [${f.severity.toUpperCase().padEnd(8)}] ${f.title}`);
+      lines.push(`               ${f.file}`);
+    }
+    lines.push("");
+  }
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push(`  RESOLVED FINDINGS (${comparison.resolvedFindings.length}):`);
+    for (const f of comparison.resolvedFindings) {
+      lines.push(`    [RESOLVED] ${f.title}`);
+    }
+    lines.push("");
+  }
+  lines.push(`  Unchanged: ${comparison.unchangedCount} finding(s)`);
+  lines.push(`  ${divider}`);
+  lines.push("");
+  return lines.join("\n");
+}
+function renderGateResult(result) {
+  const lines = [];
+  if (result.passed) {
+    lines.push("  Gate: PASSED \u2014 No regressions detected.");
+  } else {
+    lines.push("  Gate: FAILED \u2014 Security regressions detected:");
+    for (const reason of result.reasons) {
+      lines.push(`    - ${reason}`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+var init_compare = __esm({
+  "src/baseline/compare.ts"() {
+    "use strict";
+    init_types2();
+  }
+});
+
+// src/baseline/index.ts
+var baseline_exports = {};
+__export(baseline_exports, {
+  DEFAULT_GATE_CONFIG: () => DEFAULT_GATE_CONFIG,
+  compareBaseline: () => compareBaseline,
+  evaluateGate: () => evaluateGate,
+  fingerprintFinding: () => fingerprintFinding2,
+  loadBaseline: () => loadBaseline,
+  renderComparison: () => renderComparison,
+  renderGateResult: () => renderGateResult,
+  saveBaseline: () => saveBaseline
+});
+var init_baseline = __esm({
+  "src/baseline/index.ts"() {
+    "use strict";
+    init_compare();
     init_types2();
   }
 });
@@ -13299,9 +13299,13 @@ function inlineStyles() {
 
 // src/reporter/sarif.ts
 var SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json";
-function renderSarifReport(report) {
-  const rules = buildRules(report.findings);
+function renderSarifReport(report, options = {}) {
+  const rules = [
+    ...buildFindingRules(report.findings),
+    ...buildPolicyRules(options.policyEvaluation)
+  ];
   const ruleIndexes = new Map(rules.map((rule, index) => [rule.id, index]));
+  const policyUri = options.policyUri ?? ".agentshield/policy.json";
   return JSON.stringify(
     {
       version: "2.1.0",
@@ -13330,11 +13334,24 @@ function renderSarifReport(report) {
           properties: {
             score: report.score.numericScore,
             grade: report.score.grade,
-            filesScanned: report.summary.filesScanned
+            filesScanned: report.summary.filesScanned,
+            ...options.policyEvaluation ? {
+              policyStatus: options.policyEvaluation.passed ? "compliant" : "non-compliant",
+              policyViolations: options.policyEvaluation.violations.length,
+              policyName: options.policyEvaluation.policyName,
+              policyPack: options.policyEvaluation.policyPack
+            } : {}
           },
-          results: report.findings.map(
-            (finding) => renderSarifResult(finding, ruleIndexes.get(finding.id) ?? 0)
-          )
+          results: [
+            ...report.findings.map(
+              (finding) => renderFindingResult(finding, ruleIndexes.get(finding.id) ?? 0)
+            ),
+            ...renderPolicyResults(
+              options.policyEvaluation,
+              ruleIndexes,
+              policyUri
+            )
+          ]
         }
       ]
     },
@@ -13342,7 +13359,7 @@ function renderSarifReport(report) {
     2
   );
 }
-function buildRules(findings) {
+function buildFindingRules(findings) {
   const rules = /* @__PURE__ */ new Map();
   for (const finding of findings) {
     if (rules.has(finding.id)) continue;
@@ -13368,7 +13385,47 @@ Recommended fix: ${finding.fix.description}` } : { text: finding.description },
   }
   return [...rules.values()];
 }
-function renderSarifResult(finding, ruleIndex) {
+function buildPolicyRules(evaluation) {
+  if (!evaluation) return [];
+  const rules = /* @__PURE__ */ new Map();
+  for (const violation of evaluation.violations) {
+    const ruleId = policyRuleId(violation);
+    if (rules.has(ruleId)) continue;
+    rules.set(ruleId, {
+      id: ruleId,
+      name: `Organization policy: ${violation.rule}`,
+      shortDescription: {
+        text: `Organization policy: ${violation.rule}`
+      },
+      fullDescription: {
+        text: violation.description
+      },
+      help: {
+        text: [
+          violation.description,
+          "",
+          `Expected: ${violation.expected}`,
+          `Actual: ${violation.actual}`
+        ].join("\n")
+      },
+      defaultConfiguration: {
+        level: severityToLevel(violation.severity)
+      },
+      properties: {
+        category: "organization-policy",
+        severity: violation.severity,
+        "security-severity": severityToSecurityScore(violation.severity),
+        tags: ["security", "agent-config", "organization-policy"],
+        precision: "high",
+        policyName: evaluation.policyName,
+        policyPack: evaluation.policyPack,
+        owners: evaluation.owners ?? []
+      }
+    });
+  }
+  return [...rules.values()];
+}
+function renderFindingResult(finding, ruleIndex) {
   return {
     ruleId: finding.id,
     ruleIndex,
@@ -13399,6 +13456,42 @@ function renderSarifResult(finding, ruleIndex) {
       fix: finding.fix?.description
     }
   };
+}
+function renderPolicyResults(evaluation, ruleIndexes, policyUri) {
+  if (!evaluation) return [];
+  return evaluation.violations.map((violation) => {
+    const ruleId = policyRuleId(violation);
+    return {
+      ruleId,
+      ruleIndex: ruleIndexes.get(ruleId) ?? 0,
+      level: severityToLevel(violation.severity),
+      message: {
+        text: violation.description
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: normalizeUri(policyUri)
+            }
+          }
+        }
+      ],
+      properties: {
+        source: "organization-policy",
+        policyName: evaluation.policyName,
+        policyPack: evaluation.policyPack,
+        owners: evaluation.owners ?? [],
+        rule: violation.rule,
+        severity: violation.severity,
+        expected: violation.expected,
+        actual: violation.actual
+      }
+    };
+  });
+}
+function policyRuleId(violation) {
+  return `agentshield-policy/${violation.rule}`;
 }
 function severityToLevel(severity) {
   switch (severity) {
@@ -15948,6 +16041,54 @@ program.command("scan").description("Scan a Claude Code configuration directory 
     message: `Static analysis complete: ${report.summary.totalFindings} findings`,
     data: { grade: report.score.grade, score: report.score.numericScore }
   });
+  let policyEvaluation = null;
+  let policyExitCode = 0;
+  const machineReportToStdout = !options.output && (options.format === "json" || options.format === "sarif");
+  const writePolicyOutput = (message) => {
+    if (machineReportToStdout) {
+      console.error(message);
+    } else {
+      console.log(message);
+    }
+  };
+  if (options.policy) {
+    logger.log({ level: "info", phase: "policy", message: "Validating against organization policy" });
+    try {
+      const { loadPolicy: loadOrgPolicy, evaluatePolicy: evaluatePolicy2, renderPolicyEvaluation: renderPolicyEvaluation2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
+      const policyResult = loadOrgPolicy(resolve8(options.policy));
+      if (!policyResult.success) {
+        console.error(`
+  Error: ${policyResult.error}
+`);
+        logger.log({
+          level: "error",
+          phase: "policy",
+          message: `Failed to load policy: ${policyResult.error}`
+        });
+        process.exit(4);
+      }
+      policyEvaluation = evaluatePolicy2(
+        policyResult.policy,
+        filteredResult.findings,
+        report.score,
+        result.target.files
+      );
+      writePolicyOutput(renderPolicyEvaluation2(policyEvaluation));
+      logger.log({
+        level: policyEvaluation.passed ? "info" : "warn",
+        phase: "policy",
+        message: `Policy "${policyEvaluation.policyName}": ${policyEvaluation.passed ? "COMPLIANT" : `NON-COMPLIANT (${policyEvaluation.violations.length} violations)`}`
+      });
+      if (!policyEvaluation.passed) {
+        policyExitCode = 4;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`  Policy evaluation failed: ${message}`);
+      logger.log({ level: "error", phase: "policy", message: `Failed: ${message}` });
+      process.exit(4);
+    }
+  }
   let renderedReport;
   switch (options.format) {
     case "json":
@@ -15960,7 +16101,10 @@ program.command("scan").description("Scan a Claude Code configuration directory 
       renderedReport = renderHtmlReport(report);
       break;
     case "sarif":
-      renderedReport = renderSarifReport(report);
+      renderedReport = renderSarifReport(report, {
+        policyEvaluation: policyEvaluation ?? void 0,
+        policyUri: options.policy
+      });
       break;
     default:
       renderedReport = renderTerminalReport(report);
@@ -15999,43 +16143,8 @@ program.command("scan").description("Scan a Claude Code configuration directory 
       }
     }
   }
-  if (options.policy) {
-    logger.log({ level: "info", phase: "policy", message: "Validating against organization policy" });
-    try {
-      const { loadPolicy: loadOrgPolicy, evaluatePolicy: evaluatePolicy2, renderPolicyEvaluation: renderPolicyEvaluation2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
-      const policyResult = loadOrgPolicy(resolve8(options.policy));
-      if (!policyResult.success) {
-        console.error(`
-  Error: ${policyResult.error}
-`);
-        logger.log({
-          level: "error",
-          phase: "policy",
-          message: `Failed to load policy: ${policyResult.error}`
-        });
-        process.exit(4);
-      }
-      const evaluation = evaluatePolicy2(
-        policyResult.policy,
-        filteredResult.findings,
-        report.score,
-        result.target.files
-      );
-      console.log(renderPolicyEvaluation2(evaluation));
-      logger.log({
-        level: evaluation.passed ? "info" : "warn",
-        phase: "policy",
-        message: `Policy "${evaluation.policyName}": ${evaluation.passed ? "COMPLIANT" : `NON-COMPLIANT (${evaluation.violations.length} violations)`}`
-      });
-      if (!evaluation.passed) {
-        process.exit(4);
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`  Policy evaluation failed: ${message}`);
-      logger.log({ level: "error", phase: "policy", message: `Failed: ${message}` });
-      process.exit(4);
-    }
+  if (policyExitCode > 0) {
+    process.exit(policyExitCode);
   }
   if (options.fix) {
     logger.log({ level: "info", phase: "fix", message: "Applying auto-fixes" });

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,6 +18,7 @@ import {
   renderPolicyJobSummary,
   statusForPolicyEvaluation,
 } from "./action-policy.js";
+import type { PolicyEvaluation } from "./policy/index.js";
 import type { Finding, Severity } from "./types.js";
 
 // ─── GitHub Actions Helpers ──────────────────────────────────
@@ -145,10 +146,70 @@ async function run(): Promise<void> {
   setOutput("policy-status", "not-run");
   setOutput("policy-violations", "0");
 
+  let policyEvaluation: PolicyEvaluation | null = null;
+  let shouldFailOnPolicy = false;
+
+  if (policyPath) {
+    const { loadPolicy, evaluatePolicy, renderPolicyEvaluation } = await import(
+      "./policy/index.js"
+    );
+    const resolvedPolicyPath = resolve(workspace, policyPath);
+    const policyResult = loadPolicy(resolvedPolicyPath);
+
+    if (!policyResult.success) {
+      setOutput("policy-status", "error");
+      console.log(
+        `::error::AgentShield policy load failed: ${escapeAnnotation(policyResult.error)}`
+      );
+      writeJobSummary([
+        "",
+        "",
+        "## AgentShield Organization Policy",
+        "",
+        "- Status: error",
+        `- Error: ${policyResult.error}`,
+        "",
+      ].join("\n"));
+      if (failOnPolicy) {
+        shouldFailOnPolicy = true;
+      }
+    } else {
+      policyEvaluation = evaluatePolicy(
+        policyResult.policy,
+        filteredResult.findings,
+        report.score,
+        result.target.files
+      );
+      const policyStatus = statusForPolicyEvaluation(policyEvaluation);
+      setOutput("policy-status", policyStatus);
+      setOutput("policy-violations", String(policyEvaluation.violations.length));
+      writeJobSummary(renderPolicyJobSummary(policyEvaluation));
+      console.log(renderPolicyEvaluation(policyEvaluation));
+
+      if (!policyEvaluation.passed) {
+        for (const violation of policyEvaluation.violations) {
+          const message = escapeAnnotation(violation.description);
+          console.log(
+            `::error::AgentShield policy violation ${violation.rule}: ${message}`
+          );
+        }
+        if (failOnPolicy) {
+          shouldFailOnPolicy = true;
+        }
+      }
+    }
+  }
+
   if (format === "sarif") {
     const sarifPath = resolve(workspace, sarifOutput);
     mkdirSync(dirname(sarifPath), { recursive: true });
-    writeFileSync(sarifPath, renderSarifReport(report));
+    writeFileSync(
+      sarifPath,
+      renderSarifReport(report, {
+        policyEvaluation: policyEvaluation ?? undefined,
+        policyUri: policyPath || undefined,
+      })
+    );
     setOutput("sarif-path", sarifPath);
     console.log(`SARIF written to: ${sarifPath}`);
   }
@@ -208,57 +269,9 @@ async function run(): Promise<void> {
     }
   }
 
-  if (policyPath) {
-    const { loadPolicy, evaluatePolicy, renderPolicyEvaluation } = await import(
-      "./policy/index.js"
-    );
-    const resolvedPolicyPath = resolve(workspace, policyPath);
-    const policyResult = loadPolicy(resolvedPolicyPath);
-
-    if (!policyResult.success) {
-      setOutput("policy-status", "error");
-      console.log(
-        `::error::AgentShield policy load failed: ${escapeAnnotation(policyResult.error)}`
-      );
-      writeJobSummary([
-        "",
-        "",
-        "## AgentShield Organization Policy",
-        "",
-        "- Status: error",
-        `- Error: ${policyResult.error}`,
-        "",
-      ].join("\n"));
-      if (failOnPolicy) {
-        process.exitCode = 1;
-        return;
-      }
-    } else {
-      const evaluation = evaluatePolicy(
-        policyResult.policy,
-        filteredResult.findings,
-        report.score,
-        result.target.files
-      );
-      const policyStatus = statusForPolicyEvaluation(evaluation);
-      setOutput("policy-status", policyStatus);
-      setOutput("policy-violations", String(evaluation.violations.length));
-      writeJobSummary(renderPolicyJobSummary(evaluation));
-      console.log(renderPolicyEvaluation(evaluation));
-
-      if (!evaluation.passed) {
-        for (const violation of evaluation.violations) {
-          const message = escapeAnnotation(violation.description);
-          console.log(
-            `::error::AgentShield policy violation ${violation.rule}: ${message}`
-          );
-        }
-        if (failOnPolicy) {
-          process.exitCode = 1;
-          return;
-        }
-      }
-    }
+  if (shouldFailOnPolicy) {
+    process.exitCode = 1;
+    return;
   }
 
   // Fail if requested and findings exist

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import type {
   ScanLogEntry,
   DeepScanResult,
 } from "./types.js";
+import type { PolicyEvaluation } from "./policy/index.js";
 
 // ─── Dynamic Module Loaders ───────────────────────────────────
 // These modules are being built in parallel by other agents.
@@ -276,6 +277,58 @@ program
       data: { grade: report.score.grade, score: report.score.numericScore },
     });
 
+    let policyEvaluation: PolicyEvaluation | null = null;
+    let policyExitCode = 0;
+    const machineReportToStdout =
+      !options.output && (options.format === "json" || options.format === "sarif");
+    const writePolicyOutput = (message: string): void => {
+      if (machineReportToStdout) {
+        console.error(message);
+      } else {
+        console.log(message);
+      }
+    };
+
+    // ── Phase 1c: Organization policy validation ──────────
+    if (options.policy) {
+      logger.log({ level: "info", phase: "policy", message: "Validating against organization policy" });
+      try {
+        const { loadPolicy: loadOrgPolicy, evaluatePolicy, renderPolicyEvaluation } =
+          await import("./policy/index.js");
+        const policyResult = loadOrgPolicy(resolve(options.policy));
+        if (!policyResult.success) {
+          console.error(`\n  Error: ${policyResult.error}\n`);
+          logger.log({
+            level: "error",
+            phase: "policy",
+            message: `Failed to load policy: ${policyResult.error}`,
+          });
+          process.exit(4);
+        }
+
+        policyEvaluation = evaluatePolicy(
+          policyResult.policy,
+          filteredResult.findings,
+          report.score,
+          result.target.files
+        );
+        writePolicyOutput(renderPolicyEvaluation(policyEvaluation));
+        logger.log({
+          level: policyEvaluation.passed ? "info" : "warn",
+          phase: "policy",
+          message: `Policy "${policyEvaluation.policyName}": ${policyEvaluation.passed ? "COMPLIANT" : `NON-COMPLIANT (${policyEvaluation.violations.length} violations)`}`,
+        });
+        if (!policyEvaluation.passed) {
+          policyExitCode = 4;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`  Policy evaluation failed: ${message}`);
+        logger.log({ level: "error", phase: "policy", message: `Failed: ${message}` });
+        process.exit(4);
+      }
+    }
+
     // Output static scan
     let renderedReport: string;
     switch (options.format) {
@@ -289,7 +342,10 @@ program
         renderedReport = renderHtmlReport(report);
         break;
       case "sarif":
-        renderedReport = renderSarifReport(report);
+        renderedReport = renderSarifReport(report, {
+          policyEvaluation: policyEvaluation ?? undefined,
+          policyUri: options.policy,
+        });
         break;
       default:
         renderedReport = renderTerminalReport(report);
@@ -330,44 +386,8 @@ program
       }
     }
 
-    // ── Phase 1c: Organization policy validation ──────────
-    if (options.policy) {
-      logger.log({ level: "info", phase: "policy", message: "Validating against organization policy" });
-      try {
-        const { loadPolicy: loadOrgPolicy, evaluatePolicy, renderPolicyEvaluation } =
-          await import("./policy/index.js");
-        const policyResult = loadOrgPolicy(resolve(options.policy));
-        if (!policyResult.success) {
-          console.error(`\n  Error: ${policyResult.error}\n`);
-          logger.log({
-            level: "error",
-            phase: "policy",
-            message: `Failed to load policy: ${policyResult.error}`,
-          });
-          process.exit(4);
-        }
-
-        const evaluation = evaluatePolicy(
-          policyResult.policy,
-          filteredResult.findings,
-          report.score,
-          result.target.files
-        );
-        console.log(renderPolicyEvaluation(evaluation));
-        logger.log({
-          level: evaluation.passed ? "info" : "warn",
-          phase: "policy",
-          message: `Policy "${evaluation.policyName}": ${evaluation.passed ? "COMPLIANT" : `NON-COMPLIANT (${evaluation.violations.length} violations)`}`,
-        });
-        if (!evaluation.passed) {
-          process.exit(4);
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`  Policy evaluation failed: ${message}`);
-        logger.log({ level: "error", phase: "policy", message: `Failed: ${message}` });
-        process.exit(4);
-      }
+    if (policyExitCode > 0) {
+      process.exit(policyExitCode);
     }
 
     // ── Phase 2: Auto-fix (if enabled) ──────────────────────

--- a/src/reporter/sarif.ts
+++ b/src/reporter/sarif.ts
@@ -1,4 +1,5 @@
 import type { Finding, SecurityReport, Severity } from "../types.js";
+import type { PolicyEvaluation, PolicyViolation } from "../policy/index.js";
 
 const SARIF_SCHEMA =
   "https://json.schemastore.org/sarif-2.1.0.json";
@@ -15,12 +16,24 @@ interface SarifReportingDescriptor {
   readonly properties: Record<string, unknown>;
 }
 
+export interface SarifRenderOptions {
+  readonly policyEvaluation?: PolicyEvaluation;
+  readonly policyUri?: string;
+}
+
 /**
  * Render an AgentShield report as SARIF 2.1.0 for GitHub code scanning.
  */
-export function renderSarifReport(report: SecurityReport): string {
-  const rules = buildRules(report.findings);
+export function renderSarifReport(
+  report: SecurityReport,
+  options: SarifRenderOptions = {}
+): string {
+  const rules = [
+    ...buildFindingRules(report.findings),
+    ...buildPolicyRules(options.policyEvaluation),
+  ];
   const ruleIndexes = new Map(rules.map((rule, index) => [rule.id, index]));
+  const policyUri = options.policyUri ?? ".agentshield/policy.json";
 
   return JSON.stringify(
     {
@@ -51,10 +64,27 @@ export function renderSarifReport(report: SecurityReport): string {
             score: report.score.numericScore,
             grade: report.score.grade,
             filesScanned: report.summary.filesScanned,
+            ...(options.policyEvaluation
+              ? {
+                  policyStatus: options.policyEvaluation.passed
+                    ? "compliant"
+                    : "non-compliant",
+                  policyViolations: options.policyEvaluation.violations.length,
+                  policyName: options.policyEvaluation.policyName,
+                  policyPack: options.policyEvaluation.policyPack,
+                }
+              : {}),
           },
-          results: report.findings.map((finding) =>
-            renderSarifResult(finding, ruleIndexes.get(finding.id) ?? 0)
-          ),
+          results: [
+            ...report.findings.map((finding) =>
+              renderFindingResult(finding, ruleIndexes.get(finding.id) ?? 0)
+            ),
+            ...renderPolicyResults(
+              options.policyEvaluation,
+              ruleIndexes,
+              policyUri
+            ),
+          ],
         },
       ],
     },
@@ -63,7 +93,7 @@ export function renderSarifReport(report: SecurityReport): string {
   );
 }
 
-function buildRules(findings: ReadonlyArray<Finding>): SarifReportingDescriptor[] {
+function buildFindingRules(findings: ReadonlyArray<Finding>): SarifReportingDescriptor[] {
   const rules = new Map<string, SarifReportingDescriptor>();
 
   for (const finding of findings) {
@@ -93,7 +123,54 @@ function buildRules(findings: ReadonlyArray<Finding>): SarifReportingDescriptor[
   return [...rules.values()];
 }
 
-function renderSarifResult(
+function buildPolicyRules(
+  evaluation: PolicyEvaluation | undefined
+): SarifReportingDescriptor[] {
+  if (!evaluation) return [];
+
+  const rules = new Map<string, SarifReportingDescriptor>();
+
+  for (const violation of evaluation.violations) {
+    const ruleId = policyRuleId(violation);
+    if (rules.has(ruleId)) continue;
+
+    rules.set(ruleId, {
+      id: ruleId,
+      name: `Organization policy: ${violation.rule}`,
+      shortDescription: {
+        text: `Organization policy: ${violation.rule}`,
+      },
+      fullDescription: {
+        text: violation.description,
+      },
+      help: {
+        text: [
+          violation.description,
+          "",
+          `Expected: ${violation.expected}`,
+          `Actual: ${violation.actual}`,
+        ].join("\n"),
+      },
+      defaultConfiguration: {
+        level: severityToLevel(violation.severity),
+      },
+      properties: {
+        category: "organization-policy",
+        severity: violation.severity,
+        "security-severity": severityToSecurityScore(violation.severity),
+        tags: ["security", "agent-config", "organization-policy"],
+        precision: "high",
+        policyName: evaluation.policyName,
+        policyPack: evaluation.policyPack,
+        owners: evaluation.owners ?? [],
+      },
+    });
+  }
+
+  return [...rules.values()];
+}
+
+function renderFindingResult(
   finding: Finding,
   ruleIndex: number
 ): Record<string, unknown> {
@@ -129,6 +206,50 @@ function renderSarifResult(
       fix: finding.fix?.description,
     },
   };
+}
+
+function renderPolicyResults(
+  evaluation: PolicyEvaluation | undefined,
+  ruleIndexes: ReadonlyMap<string, number>,
+  policyUri: string
+): ReadonlyArray<Record<string, unknown>> {
+  if (!evaluation) return [];
+
+  return evaluation.violations.map((violation) => {
+    const ruleId = policyRuleId(violation);
+
+    return {
+      ruleId,
+      ruleIndex: ruleIndexes.get(ruleId) ?? 0,
+      level: severityToLevel(violation.severity),
+      message: {
+        text: violation.description,
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: normalizeUri(policyUri),
+            },
+          },
+        },
+      ],
+      properties: {
+        source: "organization-policy",
+        policyName: evaluation.policyName,
+        policyPack: evaluation.policyPack,
+        owners: evaluation.owners ?? [],
+        rule: violation.rule,
+        severity: violation.severity,
+        expected: violation.expected,
+        actual: violation.actual,
+      },
+    };
+  });
+}
+
+function policyRuleId(violation: PolicyViolation): string {
+  return `agentshield-policy/${violation.rule}`;
 }
 
 function severityToLevel(severity: Severity): SarifLevel {

--- a/tests/reporter/sarif.test.ts
+++ b/tests/reporter/sarif.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { renderSarifReport } from "../../src/reporter/sarif.js";
+import type { PolicyEvaluation } from "../../src/policy/index.js";
 import type { SecurityReport } from "../../src/types.js";
 
 function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
@@ -22,6 +23,22 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
       filesScanned: 4,
       autoFixable: 0,
     },
+    ...overrides,
+  };
+}
+
+function makePolicyEvaluation(
+  overrides: Partial<PolicyEvaluation> = {}
+): PolicyEvaluation {
+  return {
+    policyName: "Enterprise Policy",
+    policyPack: "enterprise",
+    owners: ["security@example.com"],
+    passed: true,
+    violations: [],
+    exceptionsApplied: [],
+    score: 84,
+    minScore: 75,
     ...overrides,
   };
 }
@@ -159,5 +176,73 @@ describe("renderSarifReport", () => {
     expect(
       sarif.runs[0].results[0].locations[0].physicalLocation.artifactLocation.uri
     ).toBe(".claude/hooks/scan.ps1");
+  });
+
+  it("adds organization policy violations as code-scanning results", () => {
+    const sarif = JSON.parse(renderSarifReport(makeReport(), {
+      policyEvaluation: makePolicyEvaluation({
+        passed: false,
+        violations: [
+          {
+            rule: "min_score",
+            severity: "high",
+            description: "Security score is below the required minimum.",
+            expected: "Score >= 90",
+            actual: "Score = 84",
+          },
+        ],
+      }),
+      policyUri: ".agentshield\\policy.json",
+    }));
+
+    expect(sarif.runs[0].tool.driver.rules).toContainEqual(
+      expect.objectContaining({
+        id: "agentshield-policy/min_score",
+        name: "Organization policy: min_score",
+        properties: expect.objectContaining({
+          category: "organization-policy",
+          severity: "high",
+          policyName: "Enterprise Policy",
+          policyPack: "enterprise",
+          owners: ["security@example.com"],
+          tags: ["security", "agent-config", "organization-policy"],
+        }),
+      })
+    );
+    expect(sarif.runs[0].results).toContainEqual(
+      expect.objectContaining({
+        ruleId: "agentshield-policy/min_score",
+        level: "error",
+        message: { text: "Security score is below the required minimum." },
+        locations: [
+          {
+            physicalLocation: {
+              artifactLocation: { uri: ".agentshield/policy.json" },
+            },
+          },
+        ],
+        properties: expect.objectContaining({
+          source: "organization-policy",
+          policyName: "Enterprise Policy",
+          expected: "Score >= 90",
+          actual: "Score = 84",
+        }),
+      })
+    );
+  });
+
+  it("records compliant policy metadata without synthetic results", () => {
+    const sarif = JSON.parse(renderSarifReport(makeReport(), {
+      policyEvaluation: makePolicyEvaluation(),
+      policyUri: ".agentshield/policy.json",
+    }));
+
+    expect(sarif.runs[0].properties).toMatchObject({
+      policyStatus: "compliant",
+      policyViolations: 0,
+      policyName: "Enterprise Policy",
+      policyPack: "enterprise",
+    });
+    expect(sarif.runs[0].results).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- add organization-policy violations to AgentShield SARIF as `agentshield-policy/*` code-scanning results
- include policy status, violation count, name, and pack in SARIF run properties
- wire CLI and GitHub Action SARIF output to include policy evaluations before failing non-compliant policy gates
- document policy SARIF behavior in README and API notes

## Test plan

- `npx vitest run tests/reporter/sarif.test.ts tests/action-policy.test.ts tests/action.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test`
- `git diff --check`
- CLI smoke: `agentshield scan --format sarif --policy /tmp/.../policy.json --output /tmp/.../agentshield.sarif` exits 4 on non-compliance and writes `agentshield-policy/*` results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit organization policy violations in SARIF so GitHub code scanning surfaces non-compliance next to findings. Also add policy metadata to the SARIF run and ensure the CLI/Action writes SARIF before failing policy gates.

- **New Features**
  - Emit `agentshield-policy/*` SARIF rules/results for violations with severity-mapped levels and location pointing to the policy file.
  - Add run properties: `policyStatus`, `policyViolations`, `policyName`, `policyPack`.
  - CLI and Action include policy evaluation in SARIF when `--policy`/`policy` is set; SARIF is written before any gate fails. Action sets `policy-status` and `policy-violations`, respects `fail-on-policy`.

- **Migration**
  - To publish policy violations to code scanning, enable SARIF and provide a policy: CLI `agentshield scan --format sarif --policy <path>`; Action `format: sarif` and `policy: <path>` (set `fail-on-policy: "false"` to avoid failing the job).

<sup>Written for commit 0e17a147e9b1f57dfa1a6e6e1b1bcd2ae1df01de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Policy violations now emitted as code-scanning results in SARIF output
  * Job summary displays policy evaluation results
  * Inline GitHub annotations added for policy violations
  * Workflow fails by default on policy non-compliance (configurable via `fail-on-policy: "false"`)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->