### PR TITLE
feat: add policy pack presets

### DIFF
--- a/API.md
+++ b/API.md
@@ -88,6 +88,16 @@ High-value `scan` options:
 - `--log <path>`
 - `--log-format ndjson|json`
 
+Policy preset generation:
+
+```bash
+agentshield policy init --pack enterprise --owner security@example.com
+agentshield policy init --pack regulated --name "Regulated Agent Policy"
+```
+
+Supported packs: `oss`, `team`, `enterprise`, `regulated`,
+`high-risk-hooks-mcp`, and `ci-enforcement`.
+
 The GitHub Action exposes the same organization policy gate through the
 `policy` input. It reports `policy-status` and `policy-violations` outputs,
 adds policy results to the job summary, emits policy violations into SARIF as

--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ agentshield scan [options]         Scan configuration directory
   -v, --verbose                    Show detailed output
 
 agentshield init                   Generate secure baseline config
+agentshield policy init            Generate an organization policy preset
 ```
 
 Runtime monitor lifecycle:
@@ -514,6 +515,18 @@ agentshield runtime repair
 ```
 
 Organization policy files support enterprise metadata and temporary exceptions:
+
+```bash
+agentshield policy init --pack enterprise --owner security-platform@acme.example
+agentshield policy init --pack regulated --name "Acme Regulated Policy"
+```
+
+Policy pack presets are starter baselines, not hidden SaaS policy. `oss` keeps
+public repos permissive while requiring destructive-command deny entries;
+`team` adds the runtime hook; `enterprise` raises score gates and blocks broad
+tool allowlists; `regulated` disallows critical/high findings and bans broader
+MCP/tool surfaces; `high-risk-hooks-mcp` focuses on hook/MCP-heavy repos; and
+`ci-enforcement` is tuned for branch-protection evidence.
 
 ```json
 {

--- a/dist/action.js
+++ b/dist/action.js
@@ -62,6 +62,148 @@ var init_types = __esm({
   }
 });
 
+// src/policy/presets.ts
+function listPolicyPacks() {
+  return PACK_SUMMARIES;
+}
+function generatePolicyPack(pack, options = {}) {
+  const policy = buildPolicyPack(pack);
+  return {
+    ...policy,
+    name: options.name ?? policy.name,
+    owners: [...options.owners ?? policy.owners ?? []]
+  };
+}
+function buildPolicyPack(pack) {
+  switch (pack) {
+    case "oss":
+      return {
+        ...basePolicy(pack, "AgentShield OSS Policy"),
+        description: "Public-repository baseline for obvious destructive tools and risky shell MCPs.",
+        min_score: 70,
+        max_severity: "high"
+      };
+    case "team":
+      return {
+        ...basePolicy(pack, "AgentShield Team Policy"),
+        description: "Shared team baseline with runtime monitoring and risky MCP restrictions.",
+        min_score: 75,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK]
+      };
+    case "enterprise":
+      return {
+        ...basePolicy(pack, "AgentShield Enterprise Policy"),
+        description: "Managed organization baseline with runtime hooks and strict score gates.",
+        min_score: 85,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+        banned_tools: ["Bash(*)"]
+      };
+    case "regulated":
+      return {
+        ...basePolicy(pack, "AgentShield Regulated Policy"),
+        description: "Compliance baseline for sensitive repositories and regulated environments.",
+        min_score: 90,
+        max_severity: "medium",
+        required_hooks: [RUNTIME_HOOK, POST_TOOL_HOOK],
+        banned_mcp_servers: [...RISKY_MCP_SERVERS, "filesystem*", "browser*"],
+        banned_tools: ["Bash(*)", "WebFetch(*)"]
+      };
+    case "high-risk-hooks-mcp":
+      return {
+        ...basePolicy(pack, "AgentShield High-risk Hooks/MCP Policy"),
+        description: "Focused gate for repositories shipping hook code, MCP configs, or plugin manifests.",
+        min_score: 80,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK, POST_TOOL_HOOK],
+        banned_mcp_servers: [...RISKY_MCP_SERVERS, "filesystem*"],
+        banned_tools: ["Bash(*)"]
+      };
+    case "ci-enforcement":
+      return {
+        ...basePolicy(pack, "AgentShield CI Enforcement Policy"),
+        description: "Branch-protection baseline for collecting policy status in CI.",
+        min_score: 80,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+        banned_tools: ["Bash(*)"]
+      };
+  }
+}
+function basePolicy(policyPack, name) {
+  return {
+    version: 1,
+    name,
+    policy_pack: policyPack,
+    owners: [],
+    exceptions: [],
+    required_deny_list: [...REQUIRED_DESTRUCTIVE_DENY_LIST],
+    banned_mcp_servers: [...RISKY_MCP_SERVERS],
+    min_score: 75,
+    max_severity: "high",
+    required_hooks: [],
+    banned_tools: []
+  };
+}
+var REQUIRED_DESTRUCTIVE_DENY_LIST, RISKY_MCP_SERVERS, RUNTIME_HOOK, POST_TOOL_HOOK, PACK_SUMMARIES;
+var init_presets = __esm({
+  "src/policy/presets.ts"() {
+    "use strict";
+    REQUIRED_DESTRUCTIVE_DENY_LIST = [
+      "Bash(rm",
+      "Bash(curl",
+      "Bash(wget"
+    ];
+    RISKY_MCP_SERVERS = [
+      "shell*",
+      "terminal*"
+    ];
+    RUNTIME_HOOK = {
+      event: "PreToolUse",
+      pattern: "agentshield",
+      description: "AgentShield runtime monitor must be installed"
+    };
+    POST_TOOL_HOOK = {
+      event: "PostToolUse",
+      pattern: "agentshield",
+      description: "AgentShield post-tool evidence hook must be installed"
+    };
+    PACK_SUMMARIES = [
+      {
+        id: "oss",
+        label: "OSS",
+        description: "Baseline policy for public repositories with permissive contribution paths."
+      },
+      {
+        id: "team",
+        label: "Team",
+        description: "Default team policy for shared private repositories and active development."
+      },
+      {
+        id: "enterprise",
+        label: "Enterprise",
+        description: "Stricter organization policy for managed production engineering groups."
+      },
+      {
+        id: "regulated",
+        label: "Regulated",
+        description: "High-assurance policy for compliance, audit, and sensitive-data environments."
+      },
+      {
+        id: "high-risk-hooks-mcp",
+        label: "High-risk hooks/MCP",
+        description: "Focused policy for repositories with privileged hooks or MCP integrations."
+      },
+      {
+        id: "ci-enforcement",
+        label: "CI enforcement",
+        description: "Branch-protection policy tuned for GitHub Actions enforcement gates."
+      }
+    ];
+  }
+});
+
 // src/policy/evaluate.ts
 import { readFileSync as readFileSync2, existsSync as existsSync2 } from "fs";
 function loadPolicy(policyPath) {
@@ -357,13 +499,13 @@ function renderPolicyEvaluation(evaluation) {
   lines.push("");
   return lines.join("\n");
 }
-function generateExamplePolicy() {
+function generateExamplePolicy(pack = "enterprise", options = {}) {
+  const policy = generatePolicyPack(pack, {
+    name: options.name ?? "Acme Corp Security Policy",
+    owners: options.owners ?? ["security-platform@acme.example"]
+  });
   const example = {
-    version: 1,
-    name: "Acme Corp Security Policy",
-    description: "Organization-wide Claude Code security requirements",
-    policy_pack: "enterprise",
-    owners: ["security-platform@acme.example"],
+    ...policy,
     exceptions: [
       {
         id: "AS-EX-001",
@@ -374,19 +516,7 @@ function generateExamplePolicy() {
         scope: "agentshield",
         ticket: "SEC-1234"
       }
-    ],
-    required_deny_list: ["Bash(rm -rf", "Bash(curl.*|.*sh"],
-    banned_mcp_servers: ["shell", "terminal"],
-    min_score: 75,
-    max_severity: "high",
-    required_hooks: [
-      {
-        event: "PreToolUse",
-        pattern: "agentshield",
-        description: "AgentShield runtime monitor must be installed"
-      }
-    ],
-    banned_tools: ["Bash(*)"]
+    ]
   };
   return JSON.stringify(example, null, 2);
 }
@@ -395,6 +525,7 @@ var init_evaluate = __esm({
   "src/policy/evaluate.ts"() {
     "use strict";
     init_types();
+    init_presets();
     SEVERITY_ORDER = {
       critical: 0,
       high: 1,
@@ -413,6 +544,8 @@ __export(policy_exports, {
   PolicyPackSchema: () => PolicyPackSchema,
   evaluatePolicy: () => evaluatePolicy,
   generateExamplePolicy: () => generateExamplePolicy,
+  generatePolicyPack: () => generatePolicyPack,
+  listPolicyPacks: () => listPolicyPacks,
   loadPolicy: () => loadPolicy,
   renderPolicyEvaluation: () => renderPolicyEvaluation
 });
@@ -420,6 +553,7 @@ var init_policy = __esm({
   "src/policy/index.ts"() {
     "use strict";
     init_evaluate();
+    init_presets();
     init_types();
   }
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -11213,6 +11213,148 @@ var init_types = __esm({
   }
 });
 
+// src/policy/presets.ts
+function listPolicyPacks() {
+  return PACK_SUMMARIES;
+}
+function generatePolicyPack(pack, options = {}) {
+  const policy = buildPolicyPack(pack);
+  return {
+    ...policy,
+    name: options.name ?? policy.name,
+    owners: [...options.owners ?? policy.owners ?? []]
+  };
+}
+function buildPolicyPack(pack) {
+  switch (pack) {
+    case "oss":
+      return {
+        ...basePolicy(pack, "AgentShield OSS Policy"),
+        description: "Public-repository baseline for obvious destructive tools and risky shell MCPs.",
+        min_score: 70,
+        max_severity: "high"
+      };
+    case "team":
+      return {
+        ...basePolicy(pack, "AgentShield Team Policy"),
+        description: "Shared team baseline with runtime monitoring and risky MCP restrictions.",
+        min_score: 75,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK]
+      };
+    case "enterprise":
+      return {
+        ...basePolicy(pack, "AgentShield Enterprise Policy"),
+        description: "Managed organization baseline with runtime hooks and strict score gates.",
+        min_score: 85,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+        banned_tools: ["Bash(*)"]
+      };
+    case "regulated":
+      return {
+        ...basePolicy(pack, "AgentShield Regulated Policy"),
+        description: "Compliance baseline for sensitive repositories and regulated environments.",
+        min_score: 90,
+        max_severity: "medium",
+        required_hooks: [RUNTIME_HOOK, POST_TOOL_HOOK],
+        banned_mcp_servers: [...RISKY_MCP_SERVERS, "filesystem*", "browser*"],
+        banned_tools: ["Bash(*)", "WebFetch(*)"]
+      };
+    case "high-risk-hooks-mcp":
+      return {
+        ...basePolicy(pack, "AgentShield High-risk Hooks/MCP Policy"),
+        description: "Focused gate for repositories shipping hook code, MCP configs, or plugin manifests.",
+        min_score: 80,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK, POST_TOOL_HOOK],
+        banned_mcp_servers: [...RISKY_MCP_SERVERS, "filesystem*"],
+        banned_tools: ["Bash(*)"]
+      };
+    case "ci-enforcement":
+      return {
+        ...basePolicy(pack, "AgentShield CI Enforcement Policy"),
+        description: "Branch-protection baseline for collecting policy status in CI.",
+        min_score: 80,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+        banned_tools: ["Bash(*)"]
+      };
+  }
+}
+function basePolicy(policyPack, name) {
+  return {
+    version: 1,
+    name,
+    policy_pack: policyPack,
+    owners: [],
+    exceptions: [],
+    required_deny_list: [...REQUIRED_DESTRUCTIVE_DENY_LIST],
+    banned_mcp_servers: [...RISKY_MCP_SERVERS],
+    min_score: 75,
+    max_severity: "high",
+    required_hooks: [],
+    banned_tools: []
+  };
+}
+var REQUIRED_DESTRUCTIVE_DENY_LIST, RISKY_MCP_SERVERS, RUNTIME_HOOK, POST_TOOL_HOOK, PACK_SUMMARIES;
+var init_presets = __esm({
+  "src/policy/presets.ts"() {
+    "use strict";
+    REQUIRED_DESTRUCTIVE_DENY_LIST = [
+      "Bash(rm",
+      "Bash(curl",
+      "Bash(wget"
+    ];
+    RISKY_MCP_SERVERS = [
+      "shell*",
+      "terminal*"
+    ];
+    RUNTIME_HOOK = {
+      event: "PreToolUse",
+      pattern: "agentshield",
+      description: "AgentShield runtime monitor must be installed"
+    };
+    POST_TOOL_HOOK = {
+      event: "PostToolUse",
+      pattern: "agentshield",
+      description: "AgentShield post-tool evidence hook must be installed"
+    };
+    PACK_SUMMARIES = [
+      {
+        id: "oss",
+        label: "OSS",
+        description: "Baseline policy for public repositories with permissive contribution paths."
+      },
+      {
+        id: "team",
+        label: "Team",
+        description: "Default team policy for shared private repositories and active development."
+      },
+      {
+        id: "enterprise",
+        label: "Enterprise",
+        description: "Stricter organization policy for managed production engineering groups."
+      },
+      {
+        id: "regulated",
+        label: "Regulated",
+        description: "High-assurance policy for compliance, audit, and sensitive-data environments."
+      },
+      {
+        id: "high-risk-hooks-mcp",
+        label: "High-risk hooks/MCP",
+        description: "Focused policy for repositories with privileged hooks or MCP integrations."
+      },
+      {
+        id: "ci-enforcement",
+        label: "CI enforcement",
+        description: "Branch-protection policy tuned for GitHub Actions enforcement gates."
+      }
+    ];
+  }
+});
+
 // src/policy/evaluate.ts
 import { readFileSync as readFileSync6, existsSync as existsSync8 } from "fs";
 function loadPolicy2(policyPath) {
@@ -11508,13 +11650,13 @@ function renderPolicyEvaluation(evaluation) {
   lines.push("");
   return lines.join("\n");
 }
-function generateExamplePolicy() {
+function generateExamplePolicy(pack = "enterprise", options = {}) {
+  const policy = generatePolicyPack(pack, {
+    name: options.name ?? "Acme Corp Security Policy",
+    owners: options.owners ?? ["security-platform@acme.example"]
+  });
   const example = {
-    version: 1,
-    name: "Acme Corp Security Policy",
-    description: "Organization-wide Claude Code security requirements",
-    policy_pack: "enterprise",
-    owners: ["security-platform@acme.example"],
+    ...policy,
     exceptions: [
       {
         id: "AS-EX-001",
@@ -11525,19 +11667,7 @@ function generateExamplePolicy() {
         scope: "agentshield",
         ticket: "SEC-1234"
       }
-    ],
-    required_deny_list: ["Bash(rm -rf", "Bash(curl.*|.*sh"],
-    banned_mcp_servers: ["shell", "terminal"],
-    min_score: 75,
-    max_severity: "high",
-    required_hooks: [
-      {
-        event: "PreToolUse",
-        pattern: "agentshield",
-        description: "AgentShield runtime monitor must be installed"
-      }
-    ],
-    banned_tools: ["Bash(*)"]
+    ]
   };
   return JSON.stringify(example, null, 2);
 }
@@ -11546,6 +11676,7 @@ var init_evaluate = __esm({
   "src/policy/evaluate.ts"() {
     "use strict";
     init_types();
+    init_presets();
     SEVERITY_ORDER2 = {
       critical: 0,
       high: 1,
@@ -11564,6 +11695,8 @@ __export(policy_exports, {
   PolicyPackSchema: () => PolicyPackSchema,
   evaluatePolicy: () => evaluatePolicy,
   generateExamplePolicy: () => generateExamplePolicy,
+  generatePolicyPack: () => generatePolicyPack,
+  listPolicyPacks: () => listPolicyPacks,
   loadPolicy: () => loadPolicy2,
   renderPolicyEvaluation: () => renderPolicyEvaluation
 });
@@ -11571,6 +11704,7 @@ var init_policy = __esm({
   "src/policy/index.ts"() {
     "use strict";
     init_evaluate();
+    init_presets();
     init_types();
   }
 });
@@ -16012,6 +16146,9 @@ function emitReportOutput(output, outputPath) {
   writeFileSync5(resolvedOutput, output);
   console.log(`Report written to: ${resolvedOutput}`);
 }
+function collectOption(value, previous) {
+  return [...previous, value];
+}
 program.command("scan").description("Scan a Claude Code configuration directory for security issues").option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)").option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal").option("-o, --output <path>", "Write the primary report output to a file").option("--fix", "Auto-apply safe fixes", false).option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false).option("--stream", "Stream Opus analysis in real-time", false).option("--injection", "Run active prompt injection testing against the config", false).option("--sandbox", "Execute hooks in sandbox and observe behavior", false).option("--taint", "Run taint analysis (data flow tracking)", false).option("--deep", "Run ALL analysis (injection + sandbox + taint + opus)", false).option("--log <path>", "Write structured scan log to file").option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson").option("--corpus", "Run scanner validation against built-in attack corpus", false).option("--baseline <path>", "Compare against a baseline file and report regressions").option("--save-baseline <path>", "Save current scan results as a baseline file").option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false).option("--supply-chain", "Verify MCP npm packages against known-bad list and typosquatting", false).option("--supply-chain-online", "Also query npm registry for metadata (requires network)", false).option("--policy <path>", "Validate against an organization policy file").option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info").option("-v, --verbose", "Show detailed output", false).action(async (options) => {
   const targetPath = resolveTargetPath(options.path);
   if (!existsSync10(targetPath)) {
@@ -16443,12 +16580,20 @@ runtime.command("repair").description("Back up invalid runtime files and restore
   }
 });
 var policyCmd = program.command("policy").description("Organization-wide security policy management");
-policyCmd.command("init").description("Generate an example organization policy file").option("-o, --output <path>", "Output path", ".agentshield/policy.json").action(async (options) => {
-  const { generateExamplePolicy: generateExamplePolicy2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
+policyCmd.command("init").description("Generate an example organization policy file").option("-o, --output <path>", "Output path", ".agentshield/policy.json").option("--pack <pack>", "Policy pack preset: oss, team, enterprise, regulated, high-risk-hooks-mcp, ci-enforcement", "enterprise").option("--owner <owner>", "Policy owner identifier; repeat for multiple owners", collectOption, []).option("--name <name>", "Policy display name").action(async (options) => {
+  const { generateExamplePolicy: generateExamplePolicy2, listPolicyPacks: listPolicyPacks2, PolicyPackSchema: PolicyPackSchema2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
   const outputPath = resolve8(options.output);
+  const packResult = PolicyPackSchema2.safeParse(options.pack);
   if (existsSync10(outputPath)) {
     console.error(`
   Error: Policy file already exists at ${outputPath}
+`);
+    process.exit(1);
+  }
+  if (!packResult.success) {
+    const packs = listPolicyPacks2().map((pack) => pack.id).join(", ");
+    console.error(`
+  Error: Unknown policy pack "${options.pack}". Valid packs: ${packs}
 `);
     process.exit(1);
   }
@@ -16456,9 +16601,13 @@ policyCmd.command("init").description("Generate an example organization policy f
   if (!existsSync10(dir)) {
     mkdirSync5(dir, { recursive: true });
   }
-  writeFileSync5(outputPath, generateExamplePolicy2());
+  writeFileSync5(outputPath, generateExamplePolicy2(packResult.data, {
+    name: options.name,
+    owners: options.owner
+  }));
   console.log(`
   Example policy written to: ${outputPath}`);
+  console.log(`  Policy pack: ${packResult.data}`);
   console.log(`  Edit the file to match your organization's requirements.`);
   console.log(`  Then run: agentshield scan --policy ${options.output}
 `);

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,10 @@ function emitReportOutput(output: string, outputPath: string | undefined): void 
   console.log(`Report written to: ${resolvedOutput}`);
 }
 
+function collectOption(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
 program
   .command("scan")
   .description("Scan a Claude Code configuration directory for security issues")
@@ -765,12 +769,24 @@ policyCmd
   .command("init")
   .description("Generate an example organization policy file")
   .option("-o, --output <path>", "Output path", ".agentshield/policy.json")
+  .option("--pack <pack>", "Policy pack preset: oss, team, enterprise, regulated, high-risk-hooks-mcp, ci-enforcement", "enterprise")
+  .option("--owner <owner>", "Policy owner identifier; repeat for multiple owners", collectOption, [])
+  .option("--name <name>", "Policy display name")
   .action(async (options) => {
-    const { generateExamplePolicy } = await import("./policy/index.js");
+    const { generateExamplePolicy, listPolicyPacks, PolicyPackSchema } = await import("./policy/index.js");
     const outputPath = resolve(options.output);
+    const packResult = PolicyPackSchema.safeParse(options.pack);
 
     if (existsSync(outputPath)) {
       console.error(`\n  Error: Policy file already exists at ${outputPath}\n`);
+      process.exit(1);
+    }
+
+    if (!packResult.success) {
+      const packs = listPolicyPacks()
+        .map((pack) => pack.id)
+        .join(", ");
+      console.error(`\n  Error: Unknown policy pack "${options.pack}". Valid packs: ${packs}\n`);
       process.exit(1);
     }
 
@@ -779,8 +795,12 @@ policyCmd
       mkdirSync(dir, { recursive: true });
     }
 
-    writeFileSync(outputPath, generateExamplePolicy());
+    writeFileSync(outputPath, generateExamplePolicy(packResult.data, {
+      name: options.name,
+      owners: options.owner,
+    }));
     console.log(`\n  Example policy written to: ${outputPath}`);
+    console.log(`  Policy pack: ${packResult.data}`);
     console.log(`  Edit the file to match your organization's requirements.`);
     console.log(`  Then run: agentshield scan --policy ${options.output}\n`);
   });

--- a/src/policy/evaluate.ts
+++ b/src/policy/evaluate.ts
@@ -1,9 +1,11 @@
 import { readFileSync, existsSync } from "node:fs";
 import { OrgPolicySchema } from "./types.js";
+import { generatePolicyPack } from "./presets.js";
 import type {
   AppliedPolicyException,
   OrgPolicy,
   PolicyException,
+  PolicyPack,
   PolicyViolation,
   PolicyEvaluation,
 } from "./types.js";
@@ -436,13 +438,19 @@ export function renderPolicyEvaluation(evaluation: PolicyEvaluation): string {
 /**
  * Generate an example policy file.
  */
-export function generateExamplePolicy(): string {
+export function generateExamplePolicy(
+  pack: PolicyPack = "enterprise",
+  options: {
+    readonly name?: string;
+    readonly owners?: ReadonlyArray<string>;
+  } = {}
+): string {
+  const policy = generatePolicyPack(pack, {
+    name: options.name ?? "Acme Corp Security Policy",
+    owners: options.owners ?? ["security-platform@acme.example"],
+  });
   const example: OrgPolicy = {
-    version: 1,
-    name: "Acme Corp Security Policy",
-    description: "Organization-wide Claude Code security requirements",
-    policy_pack: "enterprise",
-    owners: ["security-platform@acme.example"],
+    ...policy,
     exceptions: [
       {
         id: "AS-EX-001",
@@ -454,18 +462,6 @@ export function generateExamplePolicy(): string {
         ticket: "SEC-1234",
       },
     ],
-    required_deny_list: ["Bash(rm -rf", "Bash(curl.*|.*sh"],
-    banned_mcp_servers: ["shell", "terminal"],
-    min_score: 75,
-    max_severity: "high",
-    required_hooks: [
-      {
-        event: "PreToolUse",
-        pattern: "agentshield",
-        description: "AgentShield runtime monitor must be installed",
-      },
-    ],
-    banned_tools: ["Bash(*)"],
   };
 
   return JSON.stringify(example, null, 2);

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -4,7 +4,15 @@ export {
   renderPolicyEvaluation,
   generateExamplePolicy,
 } from "./evaluate.js";
+export {
+  generatePolicyPack,
+  listPolicyPacks,
+} from "./presets.js";
 export type { EvaluatePolicyOptions, LoadPolicyResult } from "./evaluate.js";
+export type {
+  GeneratePolicyPackOptions,
+  PolicyPackSummary,
+} from "./presets.js";
 export {
   OrgPolicySchema,
   PolicyExceptionSchema,

--- a/src/policy/presets.ts
+++ b/src/policy/presets.ts
@@ -1,0 +1,159 @@
+import type { OrgPolicy, PolicyPack } from "./types.js";
+
+export interface PolicyPackSummary {
+  readonly id: PolicyPack;
+  readonly label: string;
+  readonly description: string;
+}
+
+export interface GeneratePolicyPackOptions {
+  readonly name?: string;
+  readonly owners?: ReadonlyArray<string>;
+}
+
+const REQUIRED_DESTRUCTIVE_DENY_LIST = [
+  "Bash(rm",
+  "Bash(curl",
+  "Bash(wget",
+];
+
+const RISKY_MCP_SERVERS = [
+  "shell*",
+  "terminal*",
+];
+
+const RUNTIME_HOOK = {
+  event: "PreToolUse" as const,
+  pattern: "agentshield",
+  description: "AgentShield runtime monitor must be installed",
+};
+
+const POST_TOOL_HOOK = {
+  event: "PostToolUse" as const,
+  pattern: "agentshield",
+  description: "AgentShield post-tool evidence hook must be installed",
+};
+
+const PACK_SUMMARIES: ReadonlyArray<PolicyPackSummary> = [
+  {
+    id: "oss",
+    label: "OSS",
+    description: "Baseline policy for public repositories with permissive contribution paths.",
+  },
+  {
+    id: "team",
+    label: "Team",
+    description: "Default team policy for shared private repositories and active development.",
+  },
+  {
+    id: "enterprise",
+    label: "Enterprise",
+    description: "Stricter organization policy for managed production engineering groups.",
+  },
+  {
+    id: "regulated",
+    label: "Regulated",
+    description: "High-assurance policy for compliance, audit, and sensitive-data environments.",
+  },
+  {
+    id: "high-risk-hooks-mcp",
+    label: "High-risk hooks/MCP",
+    description: "Focused policy for repositories with privileged hooks or MCP integrations.",
+  },
+  {
+    id: "ci-enforcement",
+    label: "CI enforcement",
+    description: "Branch-protection policy tuned for GitHub Actions enforcement gates.",
+  },
+];
+
+export function listPolicyPacks(): ReadonlyArray<PolicyPackSummary> {
+  return PACK_SUMMARIES;
+}
+
+export function generatePolicyPack(
+  pack: PolicyPack,
+  options: GeneratePolicyPackOptions = {}
+): OrgPolicy {
+  const policy = buildPolicyPack(pack);
+
+  return {
+    ...policy,
+    name: options.name ?? policy.name,
+    owners: [...(options.owners ?? policy.owners ?? [])],
+  };
+}
+
+function buildPolicyPack(pack: PolicyPack): OrgPolicy {
+  switch (pack) {
+    case "oss":
+      return {
+        ...basePolicy(pack, "AgentShield OSS Policy"),
+        description: "Public-repository baseline for obvious destructive tools and risky shell MCPs.",
+        min_score: 70,
+        max_severity: "high",
+      };
+    case "team":
+      return {
+        ...basePolicy(pack, "AgentShield Team Policy"),
+        description: "Shared team baseline with runtime monitoring and risky MCP restrictions.",
+        min_score: 75,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+      };
+    case "enterprise":
+      return {
+        ...basePolicy(pack, "AgentShield Enterprise Policy"),
+        description: "Managed organization baseline with runtime hooks and strict score gates.",
+        min_score: 85,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+        banned_tools: ["Bash(*)"],
+      };
+    case "regulated":
+      return {
+        ...basePolicy(pack, "AgentShield Regulated Policy"),
+        description: "Compliance baseline for sensitive repositories and regulated environments.",
+        min_score: 90,
+        max_severity: "medium",
+        required_hooks: [RUNTIME_HOOK, POST_TOOL_HOOK],
+        banned_mcp_servers: [...RISKY_MCP_SERVERS, "filesystem*", "browser*"],
+        banned_tools: ["Bash(*)", "WebFetch(*)"],
+      };
+    case "high-risk-hooks-mcp":
+      return {
+        ...basePolicy(pack, "AgentShield High-risk Hooks/MCP Policy"),
+        description: "Focused gate for repositories shipping hook code, MCP configs, or plugin manifests.",
+        min_score: 80,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK, POST_TOOL_HOOK],
+        banned_mcp_servers: [...RISKY_MCP_SERVERS, "filesystem*"],
+        banned_tools: ["Bash(*)"],
+      };
+    case "ci-enforcement":
+      return {
+        ...basePolicy(pack, "AgentShield CI Enforcement Policy"),
+        description: "Branch-protection baseline for collecting policy status in CI.",
+        min_score: 80,
+        max_severity: "high",
+        required_hooks: [RUNTIME_HOOK],
+        banned_tools: ["Bash(*)"],
+      };
+  }
+}
+
+function basePolicy(policyPack: PolicyPack, name: string): OrgPolicy {
+  return {
+    version: 1,
+    name,
+    policy_pack: policyPack,
+    owners: [],
+    exceptions: [],
+    required_deny_list: [...REQUIRED_DESTRUCTIVE_DENY_LIST],
+    banned_mcp_servers: [...RISKY_MCP_SERVERS],
+    min_score: 75,
+    max_severity: "high",
+    required_hooks: [],
+    banned_tools: [],
+  };
+}

--- a/tests/policy/presets.test.ts
+++ b/tests/policy/presets.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  generatePolicyPack,
+  listPolicyPacks,
+} from "../../src/policy/presets.js";
+import {
+  evaluatePolicy,
+  generateExamplePolicy,
+} from "../../src/policy/evaluate.js";
+import { OrgPolicySchema } from "../../src/policy/types.js";
+import type { ConfigFile, SecurityScore } from "../../src/types.js";
+
+function makeScore(numericScore: number): SecurityScore {
+  return {
+    grade: numericScore >= 90 ? "A" : numericScore >= 75 ? "B" : "C",
+    numericScore,
+    breakdown: { secrets: 100, permissions: 100, hooks: 100, mcp: 100, agents: 100 },
+  };
+}
+
+function makeSettings(config: Record<string, unknown>): ConfigFile {
+  return {
+    path: "settings.json",
+    type: "settings-json",
+    content: JSON.stringify(config),
+  };
+}
+
+function makeMcpConfig(servers: Record<string, unknown>): ConfigFile {
+  return {
+    path: "mcp.json",
+    type: "mcp-json",
+    content: JSON.stringify({ mcpServers: servers }),
+  };
+}
+
+describe("policy pack presets", () => {
+  it("defines every public policy pack with labels and descriptions", () => {
+    expect(listPolicyPacks()).toEqual([
+      expect.objectContaining({ id: "oss", label: "OSS" }),
+      expect.objectContaining({ id: "team", label: "Team" }),
+      expect.objectContaining({ id: "enterprise", label: "Enterprise" }),
+      expect.objectContaining({ id: "regulated", label: "Regulated" }),
+      expect.objectContaining({ id: "high-risk-hooks-mcp", label: "High-risk hooks/MCP" }),
+      expect.objectContaining({ id: "ci-enforcement", label: "CI enforcement" }),
+    ]);
+
+    for (const pack of listPolicyPacks()) {
+      expect(pack.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it("generates schema-valid policies for every pack", () => {
+    for (const pack of listPolicyPacks()) {
+      const policy = generatePolicyPack(pack.id, {
+        owners: ["security@example.com"],
+      });
+      const parsed = OrgPolicySchema.parse(policy);
+
+      expect(parsed.version).toBe(1);
+      expect(parsed.policy_pack).toBe(pack.id);
+      expect(parsed.owners).toEqual(["security@example.com"]);
+      expect(parsed.required_deny_list.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("makes regulated stricter than enterprise and team", () => {
+    const team = generatePolicyPack("team");
+    const enterprise = generatePolicyPack("enterprise");
+    const regulated = generatePolicyPack("regulated");
+
+    expect(regulated.min_score).toBeGreaterThan(enterprise.min_score);
+    expect(enterprise.min_score).toBeGreaterThan(team.min_score);
+    expect(regulated.max_severity).toBe("medium");
+    expect(regulated.banned_mcp_servers).toContain("shell*");
+    expect(regulated.banned_mcp_servers).toContain("terminal*");
+  });
+
+  it("high-risk hooks/MCP pack enforces runtime hooks and risky MCP bans", () => {
+    const policy = generatePolicyPack("high-risk-hooks-mcp");
+    const files = [
+      makeSettings({
+        hooks: {},
+        permissions: { deny: ["Bash(rm", "Bash(curl"] },
+      }),
+      makeMcpConfig({ "shell-server": { command: "sh" } }),
+    ];
+    const result = evaluatePolicy(policy, [], makeScore(90), files);
+
+    expect(result.passed).toBe(false);
+    expect(result.violations.some((v) => v.rule === "required_hooks")).toBe(true);
+    expect(result.violations.some((v) => v.rule === "banned_mcp_servers")).toBe(true);
+  });
+
+  it("generates example policy from a named pack", () => {
+    const parsed = JSON.parse(generateExamplePolicy("ci-enforcement", {
+      owners: ["platform@example.com"],
+      name: "Platform CI Policy",
+    }));
+
+    expect(parsed.name).toBe("Platform CI Policy");
+    expect(parsed.policy_pack).toBe("ci-enforcement");
+    expect(parsed.owners).toEqual(["platform@example.com"]);
+    expect(parsed.required_hooks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ event: "PreToolUse" }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add named AgentShield organization-policy presets for `oss`, `team`, `enterprise`, `regulated`, `high-risk-hooks-mcp`, and `ci-enforcement`
- expose `listPolicyPacks` and `generatePolicyPack` for preset-aware tooling
- extend `agentshield policy init` with `--pack`, repeated `--owner`, and `--name`
- document policy-pack generation in README/API notes
- rebuild packaged dist outputs

## Test plan

- `npx vitest run tests/policy/presets.test.ts tests/policy/evaluate.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- CLI smoke: `agentshield policy init --pack regulated --owner security@example.com --name 'Regulated Smoke Policy' --output /tmp/agentshield-policy-pack-smoke/policy.json`
- `npm test` -> 1700 tests passed
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add named organization‑policy presets and preset-aware tooling to speed up setup and enforce consistent baselines. Extends the `agentshield` CLI to generate policies from packs and updates docs.

- **New Features**
  - Added policy packs: `oss`, `team`, `enterprise`, `regulated`, `high-risk-hooks-mcp`, `ci-enforcement` (each tuned for different trust and enforcement levels).
  - Exposed `listPolicyPacks` and `generatePolicyPack` for preset-aware tooling; `generateExamplePolicy` now builds from a selected pack with optional `name` and `owners`.
  - Extended `agentshield policy init` with `--pack` (default `enterprise`), repeatable `--owner`, and `--name`; validates pack IDs and avoids overwriting existing files.
  - Updated `README.md` and `API.md` with examples; added tests for pack generation and evaluation; rebuilt dist outputs.

<sup>Written for commit 616603be6620c8155b78af5321d677d623721cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `policy init` command with support for multiple policy pack presets (`oss`, `team`, `enterprise`, `regulated`, `high-risk-hooks-mcp`, `ci-enforcement`).
  * Enable customization of policies with organization name and owner configuration options.

* **Documentation**
  * Updated CLI reference documenting the new policy initialization command and available presets.

* **Tests**
  * Added comprehensive test coverage for policy pack generation and preset validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/57)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->