### PR TITLE
feat: report supply-chain provenance

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,6 +83,8 @@ High-value `scan` options:
 - `--taint`
 - `--deep`
 - `--corpus`
+- `--supply-chain`
+- `--supply-chain-online`
 - `--policy <path>`
 - `--min-severity critical|high|medium|low|info`
 - `--log <path>`

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ JSON reports now expose `findings[].runtimeConfidence` when AgentShield can dist
 | Auto-approve | `autoApprove` settings that skip user confirmation for tool calls |
 | Missing timeouts | High-risk servers without timeout — resource exhaustion risk |
 
+Supply-chain verification (`agentshield scan --supply-chain`) extracts MCP
+package references and reports provenance counts for npm vs git, pinned vs
+unpinned, known-good packages, and npm-registry-backed metadata. Add
+`--supply-chain-online` to query npm for downloads, maintainers, postinstall
+scripts, deprecation, and package age.
+
 #### MCP Confidence Notes
 
 AgentShield scans both active MCP config and repository-shipped MCP templates.
@@ -493,6 +499,8 @@ agentshield scan [options]         Scan configuration directory
   --log <path>                     Write structured scan logs to a file
   --log-format <format>            Log format: ndjson or json
   --corpus                         Run built-in attack corpus validation
+  --supply-chain                   Verify MCP package provenance and risk
+  --supply-chain-online            Include npm registry metadata
   --policy <path>                  Validate against an organization policy
   --min-severity <severity>        Filter: critical, high, medium, low, info
   -v, --verbose                    Show detailed output

--- a/dist/index.js
+++ b/dist/index.js
@@ -12203,6 +12203,7 @@ async function verifyPackages(packages, options = {}) {
     ).severity : "info";
     verifications.push({
       package: pkg,
+      provenance: buildPackageProvenance(pkg, registry),
       registry,
       risks,
       overallSeverity
@@ -12214,7 +12215,8 @@ async function verifyPackages(packages, options = {}) {
     totalPackages: verifications.length,
     riskyPackages: riskyPackages.length,
     criticalCount: riskyPackages.filter((v) => v.overallSeverity === "critical").length,
-    highCount: riskyPackages.filter((v) => v.overallSeverity === "high").length
+    highCount: riskyPackages.filter((v) => v.overallSeverity === "high").length,
+    provenance: summarizePackageProvenance(verifications)
   };
 }
 function checkTyposquatting(packageName) {
@@ -12236,6 +12238,47 @@ function checkTyposquatting(packageName) {
 }
 function hasPinnedGitCommit(gitRef) {
   return !!gitRef && GIT_COMMIT_HASH.test(gitRef);
+}
+function buildPackageProvenance(pkg, registry) {
+  if (pkg.source === "git") {
+    return {
+      ecosystem: "git",
+      locator: pkg.gitUrl ?? pkg.name,
+      pinned: hasPinnedGitCommit(pkg.gitRef),
+      knownGood: false,
+      metadataSource: "git-url"
+    };
+  }
+  return {
+    ecosystem: "npm",
+    locator: `${pkg.name}@${pkg.version ?? "latest"}`,
+    pinned: isPinnedNpmVersion(pkg.version),
+    knownGood: KNOWN_GOOD_PACKAGES.includes(pkg.name),
+    metadataSource: registry ? "npm-registry" : "offline"
+  };
+}
+function summarizePackageProvenance(verifications) {
+  return verifications.reduce(
+    (summary, verification) => ({
+      npmPackages: summary.npmPackages + (verification.provenance.ecosystem === "npm" ? 1 : 0),
+      gitPackages: summary.gitPackages + (verification.provenance.ecosystem === "git" ? 1 : 0),
+      pinnedPackages: summary.pinnedPackages + (verification.provenance.pinned ? 1 : 0),
+      unpinnedPackages: summary.unpinnedPackages + (verification.provenance.pinned ? 0 : 1),
+      knownGoodPackages: summary.knownGoodPackages + (verification.provenance.knownGood ? 1 : 0),
+      registryMetadataPackages: summary.registryMetadataPackages + (verification.provenance.metadataSource === "npm-registry" ? 1 : 0)
+    }),
+    {
+      npmPackages: 0,
+      gitPackages: 0,
+      pinnedPackages: 0,
+      unpinnedPackages: 0,
+      knownGoodPackages: 0,
+      registryMetadataPackages: 0
+    }
+  );
+}
+function isPinnedNpmVersion(version) {
+  return !!version && EXACT_NPM_VERSION.test(version);
 }
 function levenshteinDistance(a, b) {
   const m = a.length;
@@ -12347,7 +12390,7 @@ function assessRegistryRisks(meta) {
   }
   return risks;
 }
-var SEVERITY_ORDER3, GIT_COMMIT_HASH;
+var SEVERITY_ORDER3, GIT_COMMIT_HASH, EXACT_NPM_VERSION;
 var init_verify = __esm({
   "src/supply-chain/verify.ts"() {
     "use strict";
@@ -12361,6 +12404,7 @@ var init_verify = __esm({
       info: 4
     };
     GIT_COMMIT_HASH = /^[0-9a-f]{7,40}$/i;
+    EXACT_NPM_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
   }
 });
 
@@ -12375,6 +12419,9 @@ function renderSupplyChainReport(report) {
   lines.push("");
   lines.push(`  Packages analyzed: ${report.totalPackages}`);
   lines.push(`  Risky packages:    ${report.riskyPackages}`);
+  lines.push(
+    `  Provenance:        npm: ${report.provenance.npmPackages}, git: ${report.provenance.gitPackages}, pinned: ${report.provenance.pinnedPackages}, unpinned: ${report.provenance.unpinnedPackages}, known-good: ${report.provenance.knownGoodPackages}, registry-backed: ${report.provenance.registryMetadataPackages}`
+  );
   if (report.criticalCount > 0) {
     lines.push(`  Critical:          ${report.criticalCount}`);
   }

--- a/src/supply-chain/index.ts
+++ b/src/supply-chain/index.ts
@@ -4,9 +4,11 @@ export { renderSupplyChainReport, renderSupplyChainJson } from "./render.js";
 export type {
   ExtractedPackage,
   NpmRegistryMeta,
+  PackageProvenance,
   PackageVerification,
   PackageRisk,
   RiskType,
   SupplyChainReport,
+  SupplyChainProvenanceSummary,
 } from "./types.js";
 export { KNOWN_GOOD_PACKAGES } from "./types.js";

--- a/src/supply-chain/render.ts
+++ b/src/supply-chain/render.ts
@@ -17,6 +17,11 @@ export function renderSupplyChainReport(report: SupplyChainReport): string {
   lines.push("");
   lines.push(`  Packages analyzed: ${report.totalPackages}`);
   lines.push(`  Risky packages:    ${report.riskyPackages}`);
+  lines.push(
+    `  Provenance:        npm: ${report.provenance.npmPackages}, git: ${report.provenance.gitPackages}, ` +
+      `pinned: ${report.provenance.pinnedPackages}, unpinned: ${report.provenance.unpinnedPackages}, ` +
+      `known-good: ${report.provenance.knownGoodPackages}, registry-backed: ${report.provenance.registryMetadataPackages}`
+  );
 
   if (report.criticalCount > 0) {
     lines.push(`  Critical:          ${report.criticalCount}`);

--- a/src/supply-chain/types.ts
+++ b/src/supply-chain/types.ts
@@ -28,9 +28,18 @@ export interface NpmRegistryMeta {
 
 export interface PackageVerification {
   readonly package: ExtractedPackage;
+  readonly provenance: PackageProvenance;
   readonly registry?: NpmRegistryMeta;
   readonly risks: ReadonlyArray<PackageRisk>;
   readonly overallSeverity: Severity;
+}
+
+export interface PackageProvenance {
+  readonly ecosystem: "npm" | "git";
+  readonly locator: string;
+  readonly pinned: boolean;
+  readonly knownGood: boolean;
+  readonly metadataSource: "offline" | "npm-registry" | "git-url";
 }
 
 export interface PackageRisk {
@@ -59,6 +68,16 @@ export interface SupplyChainReport {
   readonly riskyPackages: number;
   readonly criticalCount: number;
   readonly highCount: number;
+  readonly provenance: SupplyChainProvenanceSummary;
+}
+
+export interface SupplyChainProvenanceSummary {
+  readonly npmPackages: number;
+  readonly gitPackages: number;
+  readonly pinnedPackages: number;
+  readonly unpinnedPackages: number;
+  readonly knownGoodPackages: number;
+  readonly registryMetadataPackages: number;
 }
 
 // ─── Known Good Packages ────────────────────────────────────

--- a/src/supply-chain/verify.ts
+++ b/src/supply-chain/verify.ts
@@ -1,4 +1,12 @@
-import type { ExtractedPackage, PackageVerification, PackageRisk, NpmRegistryMeta, SupplyChainReport } from "./types.js";
+import type {
+  ExtractedPackage,
+  PackageProvenance,
+  PackageVerification,
+  PackageRisk,
+  NpmRegistryMeta,
+  SupplyChainReport,
+  SupplyChainProvenanceSummary,
+} from "./types.js";
 import { KNOWN_GOOD_PACKAGES } from "./types.js";
 import { checkPackageName, checkServerPackage } from "../threat-intel/cve-database.js";
 import type { Severity } from "../types.js";
@@ -7,6 +15,8 @@ const SEVERITY_ORDER: Record<Severity, number> = {
   critical: 0, high: 1, medium: 2, low: 3, info: 4,
 };
 const GIT_COMMIT_HASH = /^[0-9a-f]{7,40}$/i;
+const EXACT_NPM_VERSION =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 /**
  * Verify a list of extracted packages against known-bad lists and optionally the npm registry.
@@ -79,6 +89,7 @@ export async function verifyPackages(
 
     verifications.push({
       package: pkg,
+      provenance: buildPackageProvenance(pkg, registry),
       registry,
       risks,
       overallSeverity,
@@ -92,6 +103,7 @@ export async function verifyPackages(
     riskyPackages: riskyPackages.length,
     criticalCount: riskyPackages.filter((v) => v.overallSeverity === "critical").length,
     highCount: riskyPackages.filter((v) => v.overallSeverity === "high").length,
+    provenance: summarizePackageProvenance(verifications),
   };
 }
 
@@ -123,6 +135,56 @@ export function checkTyposquatting(packageName: string): PackageRisk | null {
 
 function hasPinnedGitCommit(gitRef: string | undefined): boolean {
   return !!gitRef && GIT_COMMIT_HASH.test(gitRef);
+}
+
+function buildPackageProvenance(
+  pkg: ExtractedPackage,
+  registry: NpmRegistryMeta | undefined
+): PackageProvenance {
+  if (pkg.source === "git") {
+    return {
+      ecosystem: "git",
+      locator: pkg.gitUrl ?? pkg.name,
+      pinned: hasPinnedGitCommit(pkg.gitRef),
+      knownGood: false,
+      metadataSource: "git-url",
+    };
+  }
+
+  return {
+    ecosystem: "npm",
+    locator: `${pkg.name}@${pkg.version ?? "latest"}`,
+    pinned: isPinnedNpmVersion(pkg.version),
+    knownGood: KNOWN_GOOD_PACKAGES.includes(pkg.name),
+    metadataSource: registry ? "npm-registry" : "offline",
+  };
+}
+
+function summarizePackageProvenance(
+  verifications: ReadonlyArray<PackageVerification>
+): SupplyChainProvenanceSummary {
+  return verifications.reduce<SupplyChainProvenanceSummary>(
+    (summary, verification) => ({
+      npmPackages: summary.npmPackages + (verification.provenance.ecosystem === "npm" ? 1 : 0),
+      gitPackages: summary.gitPackages + (verification.provenance.ecosystem === "git" ? 1 : 0),
+      pinnedPackages: summary.pinnedPackages + (verification.provenance.pinned ? 1 : 0),
+      unpinnedPackages: summary.unpinnedPackages + (verification.provenance.pinned ? 0 : 1),
+      knownGoodPackages: summary.knownGoodPackages + (verification.provenance.knownGood ? 1 : 0),
+      registryMetadataPackages: summary.registryMetadataPackages + (verification.provenance.metadataSource === "npm-registry" ? 1 : 0),
+    }),
+    {
+      npmPackages: 0,
+      gitPackages: 0,
+      pinnedPackages: 0,
+      unpinnedPackages: 0,
+      knownGoodPackages: 0,
+      registryMetadataPackages: 0,
+    }
+  );
+}
+
+function isPinnedNpmVersion(version: string | undefined): boolean {
+  return !!version && EXACT_NPM_VERSION.test(version);
 }
 
 /**

--- a/tests/supply-chain/render.test.ts
+++ b/tests/supply-chain/render.test.ts
@@ -12,6 +12,14 @@ function makeReport(overrides: Partial<SupplyChainReport> = {}): SupplyChainRepo
     riskyPackages: 0,
     criticalCount: 0,
     highCount: 0,
+    provenance: {
+      npmPackages: 0,
+      gitPackages: 0,
+      pinnedPackages: 0,
+      unpinnedPackages: 0,
+      knownGoodPackages: 0,
+      registryMetadataPackages: 0,
+    },
     ...overrides,
   };
 }
@@ -27,9 +35,24 @@ describe("renderSupplyChainReport", () => {
     const output = renderSupplyChainReport(
       makeReport({
         totalPackages: 1,
+        provenance: {
+          npmPackages: 1,
+          gitPackages: 0,
+          pinnedPackages: 0,
+          unpinnedPackages: 1,
+          knownGoodPackages: 1,
+          registryMetadataPackages: 0,
+        },
         packages: [
           {
             package: { name: "my-server", source: "npx", serverName: "test" },
+            provenance: {
+              ecosystem: "npm",
+              locator: "my-server@latest",
+              pinned: false,
+              knownGood: false,
+              metadataSource: "offline",
+            },
             risks: [],
             overallSeverity: "info",
           },
@@ -38,6 +61,9 @@ describe("renderSupplyChainReport", () => {
     );
     expect(output).toContain("CLEAN PACKAGES");
     expect(output).toContain("[OK] my-server");
+    expect(output).toContain("Provenance:");
+    expect(output).toContain("npm: 1");
+    expect(output).toContain("unpinned: 1");
   });
 
   it("renders risky packages", () => {
@@ -52,6 +78,13 @@ describe("renderSupplyChainReport", () => {
               name: "@evil/mcp-sdk",
               source: "npx",
               serverName: "evil",
+            },
+            provenance: {
+              ecosystem: "npm",
+              locator: "@evil/mcp-sdk@latest",
+              pinned: false,
+              knownGood: false,
+              metadataSource: "offline",
             },
             risks: [
               {
@@ -83,6 +116,13 @@ describe("renderSupplyChainReport", () => {
               name: "suspicious-mcp",
               source: "npx",
               serverName: "sus",
+            },
+            provenance: {
+              ecosystem: "npm",
+              locator: "suspicious-mcp@latest",
+              pinned: false,
+              knownGood: false,
+              metadataSource: "npm-registry",
             },
             registry: {
               name: "suspicious-mcp",
@@ -120,6 +160,13 @@ describe("renderSupplyChainReport", () => {
               source: "npx",
               serverName: "prod\u000a",
             },
+            provenance: {
+              ecosystem: "npm",
+              locator: "evil\u001b[31m-server@1.0.0\u0007",
+              pinned: true,
+              knownGood: false,
+              metadataSource: "offline",
+            },
             risks: [
               {
                 type: "known-malicious",
@@ -155,9 +202,24 @@ describe("renderSupplyChainJson", () => {
       riskyPackages: 1,
       criticalCount: 1,
       highCount: 0,
+      provenance: {
+        npmPackages: 1,
+        gitPackages: 0,
+        pinnedPackages: 0,
+        unpinnedPackages: 1,
+        knownGoodPackages: 0,
+        registryMetadataPackages: 0,
+      },
       packages: [
         {
           package: { name: "test", source: "npx", serverName: "s" },
+          provenance: {
+            ecosystem: "npm",
+            locator: "test@latest",
+            pinned: false,
+            knownGood: false,
+            metadataSource: "offline",
+          },
           risks: [{ type: "known-malicious", severity: "critical", description: "Bad" }],
           overallSeverity: "critical",
         },
@@ -165,5 +227,7 @@ describe("renderSupplyChainJson", () => {
     });
     const parsed = JSON.parse(renderSupplyChainJson(report));
     expect(parsed.packages[0].risks[0].type).toBe("known-malicious");
+    expect(parsed.provenance.unpinnedPackages).toBe(1);
+    expect(parsed.packages[0].provenance.locator).toBe("test@latest");
   });
 });

--- a/tests/supply-chain/verify.test.ts
+++ b/tests/supply-chain/verify.test.ts
@@ -94,6 +94,21 @@ describe("verifyPackages", () => {
 
     expect(report.totalPackages).toBe(1);
     expect(report.riskyPackages).toBe(0);
+    expect(report.provenance).toMatchObject({
+      npmPackages: 1,
+      gitPackages: 0,
+      pinnedPackages: 0,
+      unpinnedPackages: 1,
+      knownGoodPackages: 1,
+      registryMetadataPackages: 0,
+    });
+    expect(report.packages[0].provenance).toEqual({
+      ecosystem: "npm",
+      locator: "@modelcontextprotocol/server-github@latest",
+      pinned: false,
+      knownGood: true,
+      metadataSource: "offline",
+    });
   });
 
   it("detects known malicious packages", async () => {
@@ -157,6 +172,13 @@ describe("verifyPackages", () => {
 
     const pkg = report.packages[0];
     expect(pkg.risks.some((r) => r.type === "unpinned-git")).toBe(false);
+    expect(pkg.provenance).toEqual({
+      ecosystem: "git",
+      locator: "https://github.com/org/custom-server#0123456789abcdef0123456789abcdef01234567",
+      pinned: true,
+      knownGood: false,
+      metadataSource: "git-url",
+    });
   });
 
   it("flags branch refs as unpinned git URLs", async () => {
@@ -241,6 +263,12 @@ describe("verifyPackages", () => {
       latestVersion: "1.2.3",
       deprecated: true,
     });
+    expect(verifiedPackage.provenance).toMatchObject({
+      ecosystem: "npm",
+      locator: "very-rare-package@latest",
+      metadataSource: "npm-registry",
+    });
+    expect(report.provenance.registryMetadataPackages).toBe(1);
     expect(verifiedPackage.risks.map((risk) => risk.type)).toEqual(
       expect.arrayContaining([
         "deprecated",
@@ -303,5 +331,58 @@ describe("verifyPackages", () => {
     expect(report.packages[0].registry).toBeUndefined();
     expect(report.packages[0].risks).toEqual([]);
     expect(report.packages[0].overallSeverity).toBe("info");
+  });
+
+  it("treats only exact npm versions as pinned provenance", async () => {
+    const report = await verifyPackages([
+      makePackage({ name: "exact-server", version: "1.2.3", serverName: "exact" }),
+      makePackage({ name: "range-server", version: "^1.2.3", serverName: "range" }),
+      makePackage({ name: "major-server", version: "1.x", serverName: "major" }),
+      makePackage({ name: "latest-server", version: "latest", serverName: "latest" }),
+    ]);
+
+    expect(report.provenance).toMatchObject({
+      npmPackages: 4,
+      pinnedPackages: 1,
+      unpinnedPackages: 3,
+    });
+    expect(report.packages.map((pkg) => pkg.provenance.pinned)).toEqual([
+      true,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("summarizes mixed npm and git provenance", async () => {
+    const report = await verifyPackages([
+      makePackage({
+        name: "@modelcontextprotocol/server-github",
+        version: "1.2.3",
+        serverName: "github",
+      }),
+      makePackage({
+        name: "org/custom-server",
+        source: "git",
+        serverName: "custom",
+        gitUrl: "https://github.com/org/custom-server",
+      }),
+      makePackage({
+        name: "org/pinned-server",
+        source: "git",
+        serverName: "pinned",
+        gitUrl: "https://github.com/org/pinned-server#0123456789abcdef0123456789abcdef01234567",
+        gitRef: "0123456789abcdef0123456789abcdef01234567",
+      }),
+    ]);
+
+    expect(report.provenance).toEqual({
+      npmPackages: 1,
+      gitPackages: 2,
+      pinnedPackages: 2,
+      unpinnedPackages: 1,
+      knownGoodPackages: 1,
+      registryMetadataPackages: 0,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds explicit supply-chain provenance metadata to MCP package verification reports.

- records per-package provenance for npm/git, locator, pinned status, known-good status, and metadata source
- adds report-level provenance counts for npm vs git, pinned vs unpinned, known-good, and npm-registry-backed packages
- renders provenance counts in terminal supply-chain reports and preserves fields in JSON output
- documents `--supply-chain` and `--supply-chain-online` in README/API docs
- rebuilds `dist/index.js`

## Test plan

- [x] `npx vitest run tests/supply-chain/verify.test.ts tests/supply-chain/render.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test`
- [x] `git diff --check`
- [x] CLI smoke: `node dist/index.js scan --path <temp-mcp-config> --supply-chain`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add supply‑chain provenance to MCP package verification. Per‑package provenance is recorded and a short provenance summary is shown in terminal and JSON reports; docs cover `--supply-chain` and `--supply-chain-online`.

- **New Features**
  - Record per‑package provenance: ecosystem (`npm`/`git`), locator, pinned status, known‑good, metadata source.
  - Add report‑level counts: npm vs git, pinned vs unpinned, known‑good, registry‑backed metadata.
  - Show a provenance line in terminal reports and include provenance in JSON output.
  - Document `--supply-chain` and `--supply-chain-online` (online mode fetches npm metadata).

<sup>Written for commit bd8200bc75ef964a2d5dd395f78122af739193f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--supply-chain` option to analyze package provenance, including ecosystem breakdown (npm vs. git), pinning status, and known-good package identification.
  * Added `--supply-chain-online` option for enhanced registry metadata analysis (downloads, maintainers, postinstall scripts, package age).

* **Documentation**
  * Updated API reference and README with new supply-chain verification capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->