### PR TITLE
feat: add executive HTML report summary

### DIFF
--- a/API.md
+++ b/API.md
@@ -61,6 +61,8 @@ function renderHtmlReport(report: SecurityReport): string;
 - reporters consume a `SecurityReport`
 - `renderJsonReport()` returns formatted JSON text
 - `renderMarkdownReport()` and `renderHtmlReport()` also expose `runtimeConfidence` when present on findings
+- `renderHtmlReport()` includes an executive summary with risk posture,
+  priority findings, and category exposure
 
 ## CLI API
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ agentshield scan --fix
 # JSON output for CI pipelines
 agentshield scan --format json
 
-# Generate an HTML security report
+# Generate an HTML executive security report
 agentshield scan --format html > report.html
 
 # Three-agent Opus 4.6 adversarial analysis (requires ANTHROPIC_API_KEY)
@@ -384,7 +384,7 @@ Requires `ANTHROPIC_API_KEY` environment variable.
 | Terminal | `--format terminal` (default) | Interactive use |
 | JSON | `--format json` | CI pipelines, programmatic access |
 | Markdown | `--format markdown` | Documentation, PRs |
-| HTML | `--format html` | Self-contained shareable report (dark theme, all CSS inlined) |
+| HTML | `--format html` | Executive report with risk posture and priorities |
 
 ### JSON Report Shape
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -12797,6 +12797,8 @@ function renderHtmlReport(report) {
       </div>
     </header>
 
+    ${renderExecutiveSummary(report)}
+
     <!-- Summary Stats -->
     <section class="section">
       <h2 class="section-title">Summary</h2>
@@ -12862,6 +12864,108 @@ function renderHtmlReport(report) {
   </div>
 </body>
 </html>`;
+}
+function renderExecutiveSummary(report) {
+  const posture = executivePosture(report);
+  const priorities = executivePriorityFindings(report.findings);
+  const priorityItems = priorities.length === 0 ? '<li class="priority-item muted">No executive action items.</li>' : priorities.map((finding) => {
+    const location = finding.line ? `${finding.file}:${finding.line}` : finding.file;
+    return `<li class="priority-item">
+            <span class="priority-severity" style="background-color: ${severityColor(finding.severity)};">${finding.severity.toUpperCase()}</span>
+            <span>
+              <strong>${escapeHtml(finding.title)}</strong>
+              <span class="priority-meta">${escapeHtml(location)} - ${escapeHtml(finding.category)}</span>
+            </span>
+          </li>`;
+  }).join("");
+  return `
+    <!-- Executive Summary -->
+    <section class="section executive-summary">
+      <h2 class="section-title">Executive Summary</h2>
+      <div class="executive-grid">
+        <div class="executive-card posture-card" style="border-color: ${posture.color};">
+          <span class="executive-label">Risk Posture</span>
+          <strong class="posture-title" style="color: ${posture.color};">${escapeHtml(posture.label)}</strong>
+          <p class="executive-copy">${escapeHtml(posture.detail)}</p>
+        </div>
+        <div class="executive-card">
+          <span class="executive-label">Executive Priorities</span>
+          <ul class="priority-list">${priorityItems}</ul>
+        </div>
+        <div class="executive-card">
+          <span class="executive-label">Category Exposure</span>
+          ${renderCategoryExposure(report.findings)}
+        </div>
+      </div>
+    </section>`;
+}
+function executivePosture(report) {
+  const { summary } = report;
+  if (summary.critical > 0) {
+    return {
+      label: "Immediate remediation required",
+      detail: formatOwnerReviewDetail(summary.critical, summary.high),
+      color: "#f85149"
+    };
+  }
+  if (summary.high > 0) {
+    return {
+      label: "High-risk changes need review",
+      detail: `${summary.high} high-severity findings require owner review before rollout.`,
+      color: "#d29922"
+    };
+  }
+  if (summary.medium > 0) {
+    return {
+      label: "Monitor before broad rollout",
+      detail: `${summary.medium} medium-severity findings should be reviewed before broad rollout.`,
+      color: "#388bfd"
+    };
+  }
+  return {
+    label: "Ready for standard rollout",
+    detail: "No critical or high-severity findings were detected.",
+    color: "#2ea043"
+  };
+}
+function formatOwnerReviewDetail(critical, high) {
+  if (critical > 0 && high > 0) {
+    return `${critical} critical and ${high} high-severity findings require owner review.`;
+  }
+  if (critical > 0) {
+    return `${critical} critical findings require owner review.`;
+  }
+  return `${high} high-severity findings require owner review before rollout.`;
+}
+function executivePriorityFindings(findings) {
+  const severityRank = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+    info: 4
+  };
+  return findings.filter((finding) => finding.severity === "critical" || finding.severity === "high").slice().sort((a, b) => severityRank[a.severity] - severityRank[b.severity]).slice(0, 5);
+}
+function renderCategoryExposure(findings) {
+  if (findings.length === 0) {
+    return '<p class="executive-copy muted">No category exposure to display.</p>';
+  }
+  const categoryCounts = /* @__PURE__ */ new Map();
+  for (const finding of findings) {
+    categoryCounts.set(finding.category, (categoryCounts.get(finding.category) ?? 0) + 1);
+  }
+  const rows = [...categoryCounts.entries()].sort(([leftCategory, leftCount], [rightCategory, rightCount]) => {
+    if (rightCount !== leftCount) return rightCount - leftCount;
+    return leftCategory.localeCompare(rightCategory);
+  }).map(([category, count]) => {
+    const noun = count === 1 ? "finding" : "findings";
+    return `<div class="exposure-row">
+        <span class="exposure-category">${escapeHtml(category)}</span>
+        <span class="exposure-count">${count} ${noun}</span>
+      </div>`;
+  }).join("");
+  return `<div class="exposure-grid">${rows}</div>`;
 }
 function gradeMetadata(grade) {
   const map = {
@@ -13148,6 +13252,116 @@ function inlineStyles() {
       margin-bottom: 16px;
       padding-bottom: 8px;
       border-bottom: 1px solid #21262d;
+    }
+
+    /* Executive Summary */
+    .executive-summary {
+      border-color: #3d444d;
+    }
+
+    .executive-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+      gap: 12px;
+    }
+
+    .executive-card {
+      background: #0d1117;
+      border: 1px solid #21262d;
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .posture-card {
+      grid-row: span 2;
+    }
+
+    .executive-label {
+      display: block;
+      font-size: 12px;
+      color: #8b949e;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 8px;
+    }
+
+    .posture-title {
+      display: block;
+      font-size: 18px;
+      margin-bottom: 8px;
+    }
+
+    .executive-copy {
+      font-size: 14px;
+      color: #8b949e;
+    }
+
+    .muted {
+      color: #8b949e;
+    }
+
+    .priority-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .priority-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      font-size: 14px;
+      color: #e6edf3;
+    }
+
+    .priority-severity {
+      color: #ffffff;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      border-radius: 10px;
+      padding: 2px 7px;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    .priority-meta {
+      display: block;
+      color: #8b949e;
+      font-size: 12px;
+      margin-top: 2px;
+      overflow-wrap: anywhere;
+    }
+
+    .exposure-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .exposure-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      border-bottom: 1px solid #21262d;
+      padding-bottom: 8px;
+      font-size: 14px;
+    }
+
+    .exposure-row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .exposure-category {
+      color: #e6edf3;
+      font-weight: 600;
+    }
+
+    .exposure-count {
+      color: #8b949e;
+      white-space: nowrap;
     }
 
     /* Stats Grid */
@@ -13469,6 +13683,14 @@ function inlineStyles() {
 
       .fix-diff {
         grid-template-columns: 1fr;
+      }
+
+      .executive-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .posture-card {
+        grid-row: auto;
       }
 
       .stats-grid {

--- a/src/reporter/html.ts
+++ b/src/reporter/html.ts
@@ -43,6 +43,8 @@ export function renderHtmlReport(report: SecurityReport): string {
       </div>
     </header>
 
+    ${renderExecutiveSummary(report)}
+
     <!-- Summary Stats -->
     <section class="section">
       <h2 class="section-title">Summary</h2>
@@ -114,6 +116,144 @@ export function renderHtmlReport(report: SecurityReport): string {
   </div>
 </body>
 </html>`;
+}
+
+// ─── Executive Summary ───────────────────────────────────────
+
+interface ExecutivePosture {
+  readonly label: string;
+  readonly detail: string;
+  readonly color: string;
+}
+
+function renderExecutiveSummary(report: SecurityReport): string {
+  const posture = executivePosture(report);
+  const priorities = executivePriorityFindings(report.findings);
+  const priorityItems =
+    priorities.length === 0
+      ? '<li class="priority-item muted">No executive action items.</li>'
+      : priorities
+        .map((finding) => {
+          const location = finding.line ? `${finding.file}:${finding.line}` : finding.file;
+          return `<li class="priority-item">
+            <span class="priority-severity" style="background-color: ${severityColor(finding.severity)};">${finding.severity.toUpperCase()}</span>
+            <span>
+              <strong>${escapeHtml(finding.title)}</strong>
+              <span class="priority-meta">${escapeHtml(location)} - ${escapeHtml(finding.category)}</span>
+            </span>
+          </li>`;
+        })
+        .join("");
+
+  return `
+    <!-- Executive Summary -->
+    <section class="section executive-summary">
+      <h2 class="section-title">Executive Summary</h2>
+      <div class="executive-grid">
+        <div class="executive-card posture-card" style="border-color: ${posture.color};">
+          <span class="executive-label">Risk Posture</span>
+          <strong class="posture-title" style="color: ${posture.color};">${escapeHtml(posture.label)}</strong>
+          <p class="executive-copy">${escapeHtml(posture.detail)}</p>
+        </div>
+        <div class="executive-card">
+          <span class="executive-label">Executive Priorities</span>
+          <ul class="priority-list">${priorityItems}</ul>
+        </div>
+        <div class="executive-card">
+          <span class="executive-label">Category Exposure</span>
+          ${renderCategoryExposure(report.findings)}
+        </div>
+      </div>
+    </section>`;
+}
+
+function executivePosture(report: SecurityReport): ExecutivePosture {
+  const { summary } = report;
+
+  if (summary.critical > 0) {
+    return {
+      label: "Immediate remediation required",
+      detail: formatOwnerReviewDetail(summary.critical, summary.high),
+      color: "#f85149",
+    };
+  }
+
+  if (summary.high > 0) {
+    return {
+      label: "High-risk changes need review",
+      detail: `${summary.high} high-severity findings require owner review before rollout.`,
+      color: "#d29922",
+    };
+  }
+
+  if (summary.medium > 0) {
+    return {
+      label: "Monitor before broad rollout",
+      detail: `${summary.medium} medium-severity findings should be reviewed before broad rollout.`,
+      color: "#388bfd",
+    };
+  }
+
+  return {
+    label: "Ready for standard rollout",
+    detail: "No critical or high-severity findings were detected.",
+    color: "#2ea043",
+  };
+}
+
+function formatOwnerReviewDetail(critical: number, high: number): string {
+  if (critical > 0 && high > 0) {
+    return `${critical} critical and ${high} high-severity findings require owner review.`;
+  }
+
+  if (critical > 0) {
+    return `${critical} critical findings require owner review.`;
+  }
+
+  return `${high} high-severity findings require owner review before rollout.`;
+}
+
+function executivePriorityFindings(findings: ReadonlyArray<Finding>): ReadonlyArray<Finding> {
+  const severityRank: Record<Severity, number> = {
+    critical: 0,
+    high: 1,
+    medium: 2,
+    low: 3,
+    info: 4,
+  };
+
+  return findings
+    .filter((finding) => finding.severity === "critical" || finding.severity === "high")
+    .slice()
+    .sort((a, b) => severityRank[a.severity] - severityRank[b.severity])
+    .slice(0, 5);
+}
+
+function renderCategoryExposure(findings: ReadonlyArray<Finding>): string {
+  if (findings.length === 0) {
+    return '<p class="executive-copy muted">No category exposure to display.</p>';
+  }
+
+  const categoryCounts = new Map<string, number>();
+  for (const finding of findings) {
+    categoryCounts.set(finding.category, (categoryCounts.get(finding.category) ?? 0) + 1);
+  }
+
+  const rows = [...categoryCounts.entries()]
+    .sort(([leftCategory, leftCount], [rightCategory, rightCount]) => {
+      if (rightCount !== leftCount) return rightCount - leftCount;
+      return leftCategory.localeCompare(rightCategory);
+    })
+    .map(([category, count]) => {
+      const noun = count === 1 ? "finding" : "findings";
+      return `<div class="exposure-row">
+        <span class="exposure-category">${escapeHtml(category)}</span>
+        <span class="exposure-count">${count} ${noun}</span>
+      </div>`;
+    })
+    .join("");
+
+  return `<div class="exposure-grid">${rows}</div>`;
 }
 
 // ─── Grade Metadata ──────────────────────────────────────────
@@ -492,6 +632,116 @@ function inlineStyles(): string {
       border-bottom: 1px solid #21262d;
     }
 
+    /* Executive Summary */
+    .executive-summary {
+      border-color: #3d444d;
+    }
+
+    .executive-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+      gap: 12px;
+    }
+
+    .executive-card {
+      background: #0d1117;
+      border: 1px solid #21262d;
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .posture-card {
+      grid-row: span 2;
+    }
+
+    .executive-label {
+      display: block;
+      font-size: 12px;
+      color: #8b949e;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      margin-bottom: 8px;
+    }
+
+    .posture-title {
+      display: block;
+      font-size: 18px;
+      margin-bottom: 8px;
+    }
+
+    .executive-copy {
+      font-size: 14px;
+      color: #8b949e;
+    }
+
+    .muted {
+      color: #8b949e;
+    }
+
+    .priority-list {
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .priority-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      font-size: 14px;
+      color: #e6edf3;
+    }
+
+    .priority-severity {
+      color: #ffffff;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.5px;
+      border-radius: 10px;
+      padding: 2px 7px;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    .priority-meta {
+      display: block;
+      color: #8b949e;
+      font-size: 12px;
+      margin-top: 2px;
+      overflow-wrap: anywhere;
+    }
+
+    .exposure-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .exposure-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      border-bottom: 1px solid #21262d;
+      padding-bottom: 8px;
+      font-size: 14px;
+    }
+
+    .exposure-row:last-child {
+      border-bottom: 0;
+      padding-bottom: 0;
+    }
+
+    .exposure-category {
+      color: #e6edf3;
+      font-weight: 600;
+    }
+
+    .exposure-count {
+      color: #8b949e;
+      white-space: nowrap;
+    }
+
     /* Stats Grid */
     .stats-grid {
       display: grid;
@@ -811,6 +1061,14 @@ function inlineStyles(): string {
 
       .fix-diff {
         grid-template-columns: 1fr;
+      }
+
+      .executive-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .posture-card {
+        grid-row: auto;
       }
 
       .stats-grid {

--- a/tests/reporter/html.test.ts
+++ b/tests/reporter/html.test.ts
@@ -64,6 +64,65 @@ describe("renderHtmlReport", () => {
     expect(html).toContain("Agents");
   });
 
+  it("renders an executive summary for clean reports", () => {
+    const html = renderHtmlReport(makeReport());
+    expect(html).toContain("Executive Summary");
+    expect(html).toContain("Risk Posture");
+    expect(html).toContain("Ready for standard rollout");
+    expect(html).toContain("No critical or high-severity findings were detected.");
+  });
+
+  it("renders executive priorities and category exposure for risky reports", () => {
+    const html = renderHtmlReport(makeReport({
+      findings: [
+        {
+          id: "SEC-001",
+          severity: "critical",
+          category: "secrets",
+          title: "Leaked API key",
+          description: "Found exposed key",
+          file: "CLAUDE.md",
+        },
+        {
+          id: "HOOK-001",
+          severity: "high",
+          category: "hooks",
+          title: "Networked hook",
+          description: "Hook reaches the network",
+          file: "settings.json",
+        },
+        {
+          id: "HOOK-002",
+          severity: "medium",
+          category: "hooks",
+          title: "Broad hook",
+          description: "Hook has broad trigger scope",
+          file: "settings.json",
+        },
+      ],
+      summary: {
+        totalFindings: 3,
+        critical: 1,
+        high: 1,
+        medium: 1,
+        low: 0,
+        info: 0,
+        filesScanned: 3,
+        autoFixable: 0,
+      },
+    }));
+
+    expect(html).toContain("Immediate remediation required");
+    expect(html).toContain("Executive Priorities");
+    expect(html).toContain("1 critical and 1 high-severity findings require owner review.");
+    expect(html).toContain("Leaked API key");
+    expect(html).toContain("Networked hook");
+    expect(html).toContain("Category Exposure");
+    expect(html).toContain("hooks");
+    expect(html).toContain("2 findings");
+    expect(html).toContain("secrets");
+  });
+
   it("shows no-findings message when empty", () => {
     const html = renderHtmlReport(makeReport());
     expect(html).toContain("No security issues found");


### PR DESCRIPTION
## Summary

Adds an executive summary section to the self-contained HTML security report.

## Details

- Shows a clear risk posture immediately below the report header
- Lists critical/high findings as executive priorities
- Groups finding counts by category exposure
- Preserves escaping for dynamic report fields
- Updates README/API wording for HTML report behavior

## Test plan

- [x] `npx vitest run tests/reporter/html.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (1704 tests)
- [x] built CLI HTML smoke for `Executive Summary` and `Risk Posture`
- [x] `git diff --check`

## Notes

`npx --yes markdownlint-cli README.md API.md` still fails on broad pre-existing README/API markdownlint debt; the touched doc lines were kept short and scoped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Executive Summary to the HTML security report to surface risk posture, executive priorities, and category exposure at a glance. Updates docs to reflect the executive-focused HTML output.

- **New Features**
  - Adds an Executive Summary at the top with risk posture, priority findings (top 5 critical/high), and category exposure counts.
  - Escapes all dynamic fields; includes responsive styles for mobile.
  - Updates README wording and notes in `API.md`; `renderHtmlReport()` now includes the executive summary.
  - Adds tests for clean and risky reports.

<sup>Written for commit 55d8b300eb36928d2f75ec01a793c83e3fd0c50f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTML reports now include an Executive Summary section displaying risk posture assessment, priority findings, and category exposure metrics.

* **Documentation**
  * Updated API reference documentation to describe executive summary content.
  * Updated README to label HTML report format as "Executive report with risk posture and priorities."

* **Tests**
  * Added test coverage for executive summary functionality in HTML report generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/59)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->