### PR TITLE
feat: add corpus regression benchmark summary

### DIFF
--- a/API.md
+++ b/API.md
@@ -92,6 +92,10 @@ High-value `scan` options:
 - `--log <path>`
 - `--log-format ndjson|json`
 
+`--corpus` runs the built-in attack corpus as a regression benchmark and
+reports category coverage plus whether the gate is ready for continuous rule
+hardening.
+
 Policy preset generation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ agentshield scan [options]         Scan configuration directory
   --deep                           Run injection + sandbox + taint + opus together
   --log <path>                     Write structured scan logs to a file
   --log-format <format>            Log format: ndjson or json
-  --corpus                         Run built-in attack corpus validation
+  --corpus                         Run built-in attack corpus benchmark
   --supply-chain                   Verify MCP package provenance and risk
   --supply-chain-online            Include npm registry metadata
   --policy <path>                  Validate against an organization policy

--- a/dist/index.js
+++ b/dist/index.js
@@ -8527,9 +8527,24 @@ function renderCorpusResults(result) {
   lines.push(`  Detected:        ${chalk.green(`${result.detected}`)}`);
   lines.push(`  Missed:          ${result.missed > 0 ? chalk.red(`${result.missed}`) : chalk.green("0")}`);
   lines.push(`  Detection rate:  ${rateColor(`${rate}%`)}`);
+  lines.push(
+    `  Regression gate: ${result.readyForRegressionGate ? chalk.green("READY") : chalk.red("FAILED")}`
+  );
   lines.push("");
   lines.push(renderBar("Detection", Math.round(result.detectionRate * 100)));
   lines.push("");
+  if (result.categoryBreakdown.length > 0) {
+    lines.push(chalk.bold("  Category Coverage"));
+    lines.push("");
+    for (const category of result.categoryBreakdown) {
+      const categoryRate = (category.detectionRate * 100).toFixed(0);
+      const categoryColor = category.missed === 0 ? chalk.green : chalk.red;
+      lines.push(
+        `    ${categoryColor(`${category.detected}/${category.totalConfigs}`)} ${category.category} (${categoryRate}%)`
+      );
+    }
+    lines.push("");
+  }
   const missed = result.results.filter((r) => !r.detected);
   if (missed.length > 0) {
     lines.push(chalk.red.bold("  Missed Attacks (scanner gaps)"));
@@ -11086,10 +11101,14 @@ function validateCorpus(ruleScanFn, rules) {
   }
   const passed = results.filter((r) => r.passed).length;
   const failed = results.filter((r) => !r.passed).length;
+  const detectionRate = vulnerableConfigs.length > 0 ? passed / vulnerableConfigs.length : 1;
   return {
     totalConfigs: vulnerableConfigs.length,
     passed,
     failed,
+    detectionRate,
+    readyForRegressionGate: failed === 0,
+    categoryBreakdown: buildCategoryBreakdown(results),
     results
   };
 }
@@ -11125,12 +11144,33 @@ function validateSingleConfig(config, ruleScanFn, rules) {
   return {
     configId: config.id,
     configName: config.name,
+    category: config.category,
     expectedFindings: expectedTotal,
     actualFindings: actualTotal,
     missingRules,
     extraRules,
     passed: missingRules.length === 0
   };
+}
+function buildCategoryBreakdown(results) {
+  const byCategory = /* @__PURE__ */ new Map();
+  for (const result of results) {
+    const current = byCategory.get(result.category) ?? { total: 0, detected: 0 };
+    byCategory.set(result.category, {
+      total: current.total + 1,
+      detected: current.detected + (result.passed ? 1 : 0)
+    });
+  }
+  return [...byCategory.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([category, counts]) => {
+    const missed = counts.total - counts.detected;
+    return {
+      category,
+      totalConfigs: counts.total,
+      detected: counts.detected,
+      missed,
+      detectionRate: counts.total > 0 ? counts.detected / counts.total : 1
+    };
+  });
 }
 function getCorpusConfigs() {
   return vulnerableConfigs;
@@ -16368,6 +16408,8 @@ async function runCorpusValidation(_targetPath) {
       detected,
       missed,
       detectionRate: totalAttacks > 0 ? detected / totalAttacks : 0,
+      readyForRegressionGate: validation.readyForRegressionGate,
+      categoryBreakdown: validation.categoryBreakdown,
       results: validation.results.map((r) => ({
         attackId: r.configId,
         attackName: r.configName,

--- a/src/corpus/index.ts
+++ b/src/corpus/index.ts
@@ -10,6 +10,7 @@ export type { VulnerableConfig } from "./vulnerable-configs.js";
 export interface CorpusValidationResult {
   readonly configId: string;
   readonly configName: string;
+  readonly category: string;
   readonly expectedFindings: number;
   readonly actualFindings: number;
   readonly missingRules: ReadonlyArray<string>;
@@ -17,10 +18,21 @@ export interface CorpusValidationResult {
   readonly passed: boolean;
 }
 
+export interface CorpusCategoryBreakdown {
+  readonly category: string;
+  readonly totalConfigs: number;
+  readonly detected: number;
+  readonly missed: number;
+  readonly detectionRate: number;
+}
+
 export interface CorpusValidation {
   readonly totalConfigs: number;
   readonly passed: number;
   readonly failed: number;
+  readonly detectionRate: number;
+  readonly readyForRegressionGate: boolean;
+  readonly categoryBreakdown: ReadonlyArray<CorpusCategoryBreakdown>;
   readonly results: ReadonlyArray<CorpusValidationResult>;
 }
 
@@ -62,11 +74,15 @@ export function validateCorpus(ruleScanFn: RuleScanFn, rules: ReadonlyArray<Rule
 
   const passed = results.filter((r) => r.passed).length;
   const failed = results.filter((r) => !r.passed).length;
+  const detectionRate = vulnerableConfigs.length > 0 ? passed / vulnerableConfigs.length : 1;
 
   return {
     totalConfigs: vulnerableConfigs.length,
     passed,
     failed,
+    detectionRate,
+    readyForRegressionGate: failed === 0,
+    categoryBreakdown: buildCategoryBreakdown(results),
     results,
   };
 }
@@ -120,12 +136,40 @@ function validateSingleConfig(
   return {
     configId: config.id,
     configName: config.name,
+    category: config.category,
     expectedFindings: expectedTotal,
     actualFindings: actualTotal,
     missingRules,
     extraRules,
     passed: missingRules.length === 0,
   };
+}
+
+function buildCategoryBreakdown(
+  results: ReadonlyArray<CorpusValidationResult>
+): ReadonlyArray<CorpusCategoryBreakdown> {
+  const byCategory = new Map<string, { total: number; detected: number }>();
+
+  for (const result of results) {
+    const current = byCategory.get(result.category) ?? { total: 0, detected: 0 };
+    byCategory.set(result.category, {
+      total: current.total + 1,
+      detected: current.detected + (result.passed ? 1 : 0),
+    });
+  }
+
+  return [...byCategory.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([category, counts]) => {
+      const missed = counts.total - counts.detected;
+      return {
+        category,
+        totalConfigs: counts.total,
+        detected: counts.detected,
+        missed,
+        detectionRate: counts.total > 0 ? counts.detected / counts.total : 1,
+      };
+    });
 }
 
 // ─── Helpers ──────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,6 +144,8 @@ async function runCorpusValidation(
       detected,
       missed,
       detectionRate: totalAttacks > 0 ? detected / totalAttacks : 0,
+      readyForRegressionGate: validation.readyForRegressionGate,
+      categoryBreakdown: validation.categoryBreakdown,
       results: validation.results.map((r: { configId: string; configName: string; passed: boolean; missingRules: ReadonlyArray<string> }) => ({
         attackId: r.configId,
         attackName: r.configName,

--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -378,11 +378,27 @@ export function renderCorpusResults(
   lines.push(`  Detected:        ${chalk.green(`${result.detected}`)}`);
   lines.push(`  Missed:          ${result.missed > 0 ? chalk.red(`${result.missed}`) : chalk.green("0")}`);
   lines.push(`  Detection rate:  ${rateColor(`${rate}%`)}`);
+  lines.push(
+    `  Regression gate: ${result.readyForRegressionGate ? chalk.green("READY") : chalk.red("FAILED")}`
+  );
   lines.push("");
 
   // Detection rate bar
   lines.push(renderBar("Detection", Math.round(result.detectionRate * 100)));
   lines.push("");
+
+  if (result.categoryBreakdown.length > 0) {
+    lines.push(chalk.bold("  Category Coverage"));
+    lines.push("");
+    for (const category of result.categoryBreakdown) {
+      const categoryRate = (category.detectionRate * 100).toFixed(0);
+      const categoryColor = category.missed === 0 ? chalk.green : chalk.red;
+      lines.push(
+        `    ${categoryColor(`${category.detected}/${category.totalConfigs}`)} ${category.category} (${categoryRate}%)`
+      );
+    }
+    lines.push("");
+  }
 
   // Show missed attacks (these need attention)
   const missed = result.results.filter((r) => !r.detected);

--- a/src/types.ts
+++ b/src/types.ts
@@ -335,12 +335,22 @@ export interface CorpusValidationResult {
   readonly detected: number;
   readonly missed: number;
   readonly detectionRate: number;
+  readonly readyForRegressionGate: boolean;
+  readonly categoryBreakdown: ReadonlyArray<CorpusCategoryBreakdown>;
   readonly results: ReadonlyArray<{
     readonly attackId: string;
     readonly attackName: string;
     readonly detected: boolean;
     readonly ruleId?: string;
   }>;
+}
+
+export interface CorpusCategoryBreakdown {
+  readonly category: string;
+  readonly totalConfigs: number;
+  readonly detected: number;
+  readonly missed: number;
+  readonly detectionRate: number;
 }
 
 // ─── Scan Log Entry ───────────────────────────────────────

--- a/tests/corpus.test.ts
+++ b/tests/corpus.test.ts
@@ -221,6 +221,18 @@ describe("validateCorpus", () => {
     expect(validation.passed).toBeGreaterThan(0);
   });
 
+  it("summarizes category-level benchmark readiness", () => {
+    const validation = validateCorpus(defaultRuleScanFn, allRules);
+    const injection = validation.categoryBreakdown.find((c) => c.category === "injection");
+
+    expect(validation.detectionRate).toBe(1);
+    expect(validation.readyForRegressionGate).toBe(true);
+    expect(injection).toBeDefined();
+    expect(injection!.totalConfigs).toBeGreaterThan(0);
+    expect(injection!.missed).toBe(0);
+    expect(injection!.detectionRate).toBe(1);
+  });
+
   it("marks configs as failed when expected findings are missing", () => {
     // Use an empty scanner that returns nothing
     const emptyFn = () => new Map<string, ReadonlyArray<Finding>>();
@@ -228,6 +240,9 @@ describe("validateCorpus", () => {
     const validation = validateCorpus(emptyFn, allRules);
 
     expect(validation.failed).toBe(vulnerableConfigs.length);
+    expect(validation.detectionRate).toBe(0);
+    expect(validation.readyForRegressionGate).toBe(false);
+    expect(validation.categoryBreakdown.every((c) => c.missed === c.totalConfigs)).toBe(true);
 
     for (const result of validation.results) {
       expect(result.passed).toBe(false);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -162,6 +162,11 @@ function makeCorpusResult(
     detected: 47,
     missed: 3,
     detectionRate: 0.94,
+    readyForRegressionGate: false,
+    categoryBreakdown: [
+      { category: "secrets", totalConfigs: 1, detected: 1, missed: 0, detectionRate: 1 },
+      { category: "injection", totalConfigs: 2, detected: 1, missed: 1, detectionRate: 0.5 },
+    ],
     results: [
       { attackId: "ATK-001", attackName: "Hardcoded API key", detected: true, ruleId: "SEC-001" },
       { attackId: "ATK-002", attackName: "Bash(*) wildcard", detected: true, ruleId: "PERM-001" },
@@ -357,6 +362,10 @@ describe("integration", () => {
       expect(output).toContain("Total attacks:   50");
       expect(output).toContain("47");
       expect(output).toContain("94.0%");
+      expect(output).toContain("Category Coverage");
+      expect(output).toContain("injection");
+      expect(output).toContain("1/2");
+      expect(output).toContain("Regression gate: FAILED");
       expect(output).toContain("Missed Attacks");
       expect(output).toContain("Indirect prompt injection");
     });
@@ -367,6 +376,10 @@ describe("integration", () => {
         detected: 10,
         missed: 0,
         detectionRate: 1.0,
+        readyForRegressionGate: true,
+        categoryBreakdown: [
+          { category: "injection", totalConfigs: 10, detected: 10, missed: 0, detectionRate: 1 },
+        ],
         results: [
           { attackId: "ATK-001", attackName: "Test", detected: true, ruleId: "R-001" },
         ],
@@ -374,6 +387,7 @@ describe("integration", () => {
       const output = renderCorpusResults(result);
 
       expect(output).toContain("100.0%");
+      expect(output).toContain("Regression gate: READY");
       expect(output).not.toContain("Missed Attacks");
     });
   });
@@ -489,6 +503,8 @@ describe("integration", () => {
       const result: CorpusValidationResult = makeCorpusResult();
       expect(result.totalAttacks).toBe(50);
       expect(result.detectionRate).toBe(0.94);
+      expect(result.categoryBreakdown[0].category).toBe("secrets");
+      expect(result.readyForRegressionGate).toBe(false);
     });
 
     it("DeepScanResult type is valid with all nulls", () => {


### PR DESCRIPTION
## Summary

Turns built-in corpus validation into a more useful regression benchmark for continuous prompt-injection and rule-hardening work.

## Details

- Adds category-level corpus coverage to validation results
- Adds an explicit `readyForRegressionGate` flag
- Renders category coverage and READY/FAILED gate status in terminal output
- Carries the benchmark fields through the CLI `--corpus` path and public result type
- Updates README/API wording for the corpus benchmark surface

## Test plan

- [x] `npx vitest run tests/corpus.test.ts tests/integration.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (1705 tests)
- [x] built CLI smoke: `scan --corpus` contains `Category Coverage`, `Regression gate: READY`, and `injection`
- [x] `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the built‑in corpus validation into a regression benchmark with category coverage and a simple READY/FAILED gate. The summary is shown in `scan --corpus` and exposed via the public API to support continuous rule hardening.

- **New Features**
  - Category-level coverage in corpus results (`categoryBreakdown` with rates and totals).
  - New `readyForRegressionGate` flag and overall `detectionRate`.
  - Terminal reporter for `scan --corpus` shows Category Coverage and “Regression gate: READY/FAILED”.
  - API types and CLI `--corpus` path include the new fields; docs updated to describe the benchmark.

<sup>Written for commit f1382509f3584fe2a8512791b6203361b1895cef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI `--corpus` option documentation to reflect it as a built-in attack corpus regression benchmark.

* **New Features**
  * Added detection rate reporting for corpus validation runs.
  * Added category coverage breakdown showing per-category detection metrics.
  * Added regression gate status indicator displaying readiness for continuous hardening.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->