### PR TITLE
feat: audit policy exception lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ MCP/tool surfaces; `high-risk-hooks-mcp` focuses on hook/MCP-heavy repos; and
 }
 ```
 
+Policy evaluation now includes an exception lifecycle audit in terminal output
+and GitHub Action summaries: total exceptions, active exceptions, exceptions
+expiring within seven days, expired exceptions, owners, tickets, scopes, and
+days until expiry. This keeps temporary waivers visible in branch-protection
+evidence instead of letting them become silent permanent bypasses.
+
 Exit codes:
 - `0`: scan completed without critical findings
 - `1`: CLI usage or runtime error

--- a/dist/action.js
+++ b/dist/action.js
@@ -317,6 +317,7 @@ function evaluatePolicy(policy, findings, score, files, options = {}) {
     passed: finalViolations.length === 0,
     violations: finalViolations,
     exceptionsApplied: exceptionResult.applied,
+    exceptionSummary: buildExceptionSummary(policy.exceptions ?? [], now),
     score: score.numericScore,
     minScore: policy.min_score
   };
@@ -440,6 +441,51 @@ function isExceptionActive(exception, now) {
   if (Number.isNaN(expiresAt.getTime())) return false;
   return expiresAt.getTime() >= now.getTime();
 }
+function buildExceptionSummary(exceptions, now) {
+  const entries = exceptions.map((exception) => buildExceptionAuditEntry(exception, now)).sort(compareExceptionAuditEntries);
+  return {
+    total: entries.length,
+    active: entries.filter(
+      (entry) => entry.status === "active" || entry.status === "expiring_soon"
+    ).length,
+    expiringSoon: entries.filter((entry) => entry.status === "expiring_soon").length,
+    expired: entries.filter((entry) => entry.status === "expired").length,
+    entries
+  };
+}
+function buildExceptionAuditEntry(exception, now) {
+  const expiresAt = new Date(exception.expires_at);
+  const daysUntilExpiry = Number.isNaN(expiresAt.getTime()) ? Number.NEGATIVE_INFINITY : Math.ceil((expiresAt.getTime() - now.getTime()) / MS_PER_DAY);
+  const status = statusForExceptionDays(daysUntilExpiry);
+  return {
+    id: exception.id,
+    rule: exception.rule,
+    owner: exception.owner,
+    reason: exception.reason,
+    expiresAt: exception.expires_at,
+    status,
+    daysUntilExpiry,
+    ...exception.scope ? { scope: exception.scope } : {},
+    ...exception.ticket ? { ticket: exception.ticket } : {}
+  };
+}
+function statusForExceptionDays(daysUntilExpiry) {
+  if (daysUntilExpiry < 0) return "expired";
+  if (daysUntilExpiry <= EXPIRING_SOON_DAYS) return "expiring_soon";
+  return "active";
+}
+function compareExceptionAuditEntries(a, b) {
+  const statusRank = {
+    expiring_soon: 0,
+    active: 1,
+    expired: 2
+  };
+  const statusDelta = statusRank[a.status] - statusRank[b.status];
+  if (statusDelta !== 0) return statusDelta;
+  const dayDelta = a.daysUntilExpiry - b.daysUntilExpiry;
+  if (dayDelta !== 0) return dayDelta;
+  return a.id.localeCompare(b.id);
+}
 function exceptionMatchesViolation(exception, violation) {
   if (exception.rule !== violation.rule) return false;
   if (exception.severity && exception.severity !== violation.severity) {
@@ -495,9 +541,31 @@ function renderPolicyEvaluation(evaluation) {
     }
     lines.push("");
   }
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    const summary = evaluation.exceptionSummary;
+    lines.push("  EXCEPTION AUDIT:");
+    lines.push(
+      `    total=${summary.total} active=${summary.active} expiring_soon=${summary.expiringSoon} expired=${summary.expired}`
+    );
+    for (const exception of summary.entries) {
+      const details = [
+        `status=${exception.status}`,
+        `owner=${exception.owner}`,
+        `expires=${exception.expiresAt}`,
+        `days=${formatExceptionDays2(exception.daysUntilExpiry)}`,
+        ...exception.scope ? [`scope=${exception.scope}`] : [],
+        ...exception.ticket ? [`ticket=${exception.ticket}`] : []
+      ];
+      lines.push(`    ${exception.id} (${exception.rule}) ${details.join(" ")}`);
+    }
+    lines.push("");
+  }
   lines.push(`  ${divider}`);
   lines.push("");
   return lines.join("\n");
+}
+function formatExceptionDays2(daysUntilExpiry) {
+  return Number.isFinite(daysUntilExpiry) ? String(daysUntilExpiry) : "invalid";
 }
 function generateExamplePolicy(pack = "enterprise", options = {}) {
   const policy = generatePolicyPack(pack, {
@@ -520,7 +588,7 @@ function generateExamplePolicy(pack = "enterprise", options = {}) {
   };
   return JSON.stringify(example, null, 2);
 }
-var SEVERITY_ORDER;
+var SEVERITY_ORDER, EXPIRING_SOON_DAYS, MS_PER_DAY;
 var init_evaluate = __esm({
   "src/policy/evaluate.ts"() {
     "use strict";
@@ -533,6 +601,8 @@ var init_evaluate = __esm({
       low: 3,
       info: 4
     };
+    EXPIRING_SOON_DAYS = 7;
+    MS_PER_DAY = 24 * 60 * 60 * 1e3;
   }
 });
 
@@ -9389,6 +9459,11 @@ function renderPolicyJobSummary(evaluation) {
   if (evaluation.exceptionsApplied && evaluation.exceptionsApplied.length > 0) {
     lines.push(`- Exceptions applied: ${evaluation.exceptionsApplied.length}`);
   }
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    lines.push(
+      `- Exceptions: ${evaluation.exceptionSummary.total} total, ${evaluation.exceptionSummary.active} active, ${evaluation.exceptionSummary.expiringSoon} expiring soon, ${evaluation.exceptionSummary.expired} expired`
+    );
+  }
   if (evaluation.violations.length > 0) {
     lines.push("", "### Policy Violations", "");
     for (const violation of evaluation.violations) {
@@ -9405,8 +9480,25 @@ function renderPolicyJobSummary(evaluation) {
       );
     }
   }
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    lines.push("", "### Exception Audit", "");
+    for (const exception of evaluation.exceptionSummary.entries) {
+      const details = [
+        `status=${exception.status}`,
+        `owner=${exception.owner}`,
+        `expires=${exception.expiresAt}`,
+        `days=${formatExceptionDays(exception.daysUntilExpiry)}`,
+        ...exception.scope ? [`scope=${exception.scope}`] : [],
+        ...exception.ticket ? [`ticket=${exception.ticket}`] : []
+      ];
+      lines.push(`- ${exception.id} (${exception.rule}) ${details.join(" ")}`);
+    }
+  }
   lines.push("");
   return lines.join("\n");
+}
+function formatExceptionDays(daysUntilExpiry) {
+  return Number.isFinite(daysUntilExpiry) ? String(daysUntilExpiry) : "invalid";
 }
 
 // src/action.ts

--- a/dist/index.js
+++ b/dist/index.js
@@ -11508,6 +11508,7 @@ function evaluatePolicy(policy, findings, score, files, options = {}) {
     passed: finalViolations.length === 0,
     violations: finalViolations,
     exceptionsApplied: exceptionResult.applied,
+    exceptionSummary: buildExceptionSummary(policy.exceptions ?? [], now),
     score: score.numericScore,
     minScore: policy.min_score
   };
@@ -11631,6 +11632,51 @@ function isExceptionActive(exception, now) {
   if (Number.isNaN(expiresAt.getTime())) return false;
   return expiresAt.getTime() >= now.getTime();
 }
+function buildExceptionSummary(exceptions, now) {
+  const entries = exceptions.map((exception) => buildExceptionAuditEntry(exception, now)).sort(compareExceptionAuditEntries);
+  return {
+    total: entries.length,
+    active: entries.filter(
+      (entry) => entry.status === "active" || entry.status === "expiring_soon"
+    ).length,
+    expiringSoon: entries.filter((entry) => entry.status === "expiring_soon").length,
+    expired: entries.filter((entry) => entry.status === "expired").length,
+    entries
+  };
+}
+function buildExceptionAuditEntry(exception, now) {
+  const expiresAt = new Date(exception.expires_at);
+  const daysUntilExpiry = Number.isNaN(expiresAt.getTime()) ? Number.NEGATIVE_INFINITY : Math.ceil((expiresAt.getTime() - now.getTime()) / MS_PER_DAY);
+  const status = statusForExceptionDays(daysUntilExpiry);
+  return {
+    id: exception.id,
+    rule: exception.rule,
+    owner: exception.owner,
+    reason: exception.reason,
+    expiresAt: exception.expires_at,
+    status,
+    daysUntilExpiry,
+    ...exception.scope ? { scope: exception.scope } : {},
+    ...exception.ticket ? { ticket: exception.ticket } : {}
+  };
+}
+function statusForExceptionDays(daysUntilExpiry) {
+  if (daysUntilExpiry < 0) return "expired";
+  if (daysUntilExpiry <= EXPIRING_SOON_DAYS) return "expiring_soon";
+  return "active";
+}
+function compareExceptionAuditEntries(a, b) {
+  const statusRank = {
+    expiring_soon: 0,
+    active: 1,
+    expired: 2
+  };
+  const statusDelta = statusRank[a.status] - statusRank[b.status];
+  if (statusDelta !== 0) return statusDelta;
+  const dayDelta = a.daysUntilExpiry - b.daysUntilExpiry;
+  if (dayDelta !== 0) return dayDelta;
+  return a.id.localeCompare(b.id);
+}
 function exceptionMatchesViolation(exception, violation) {
   if (exception.rule !== violation.rule) return false;
   if (exception.severity && exception.severity !== violation.severity) {
@@ -11686,9 +11732,31 @@ function renderPolicyEvaluation(evaluation) {
     }
     lines.push("");
   }
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    const summary = evaluation.exceptionSummary;
+    lines.push("  EXCEPTION AUDIT:");
+    lines.push(
+      `    total=${summary.total} active=${summary.active} expiring_soon=${summary.expiringSoon} expired=${summary.expired}`
+    );
+    for (const exception of summary.entries) {
+      const details = [
+        `status=${exception.status}`,
+        `owner=${exception.owner}`,
+        `expires=${exception.expiresAt}`,
+        `days=${formatExceptionDays(exception.daysUntilExpiry)}`,
+        ...exception.scope ? [`scope=${exception.scope}`] : [],
+        ...exception.ticket ? [`ticket=${exception.ticket}`] : []
+      ];
+      lines.push(`    ${exception.id} (${exception.rule}) ${details.join(" ")}`);
+    }
+    lines.push("");
+  }
   lines.push(`  ${divider}`);
   lines.push("");
   return lines.join("\n");
+}
+function formatExceptionDays(daysUntilExpiry) {
+  return Number.isFinite(daysUntilExpiry) ? String(daysUntilExpiry) : "invalid";
 }
 function generateExamplePolicy(pack = "enterprise", options = {}) {
   const policy = generatePolicyPack(pack, {
@@ -11711,7 +11779,7 @@ function generateExamplePolicy(pack = "enterprise", options = {}) {
   };
   return JSON.stringify(example, null, 2);
 }
-var SEVERITY_ORDER2;
+var SEVERITY_ORDER2, EXPIRING_SOON_DAYS, MS_PER_DAY;
 var init_evaluate = __esm({
   "src/policy/evaluate.ts"() {
     "use strict";
@@ -11724,6 +11792,8 @@ var init_evaluate = __esm({
       low: 3,
       info: 4
     };
+    EXPIRING_SOON_DAYS = 7;
+    MS_PER_DAY = 24 * 60 * 60 * 1e3;
   }
 });
 

--- a/src/action-policy.ts
+++ b/src/action-policy.ts
@@ -37,6 +37,15 @@ export function renderPolicyJobSummary(evaluation: PolicyEvaluation): string {
     lines.push(`- Exceptions applied: ${evaluation.exceptionsApplied.length}`);
   }
 
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    lines.push(
+      `- Exceptions: ${evaluation.exceptionSummary.total} total, ` +
+        `${evaluation.exceptionSummary.active} active, ` +
+        `${evaluation.exceptionSummary.expiringSoon} expiring soon, ` +
+        `${evaluation.exceptionSummary.expired} expired`
+    );
+  }
+
   if (evaluation.violations.length > 0) {
     lines.push("", "### Policy Violations", "");
     for (const violation of evaluation.violations) {
@@ -55,6 +64,25 @@ export function renderPolicyJobSummary(evaluation: PolicyEvaluation): string {
     }
   }
 
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    lines.push("", "### Exception Audit", "");
+    for (const exception of evaluation.exceptionSummary.entries) {
+      const details = [
+        `status=${exception.status}`,
+        `owner=${exception.owner}`,
+        `expires=${exception.expiresAt}`,
+        `days=${formatExceptionDays(exception.daysUntilExpiry)}`,
+        ...(exception.scope ? [`scope=${exception.scope}`] : []),
+        ...(exception.ticket ? [`ticket=${exception.ticket}`] : []),
+      ];
+      lines.push(`- ${exception.id} (${exception.rule}) ${details.join(" ")}`);
+    }
+  }
+
   lines.push("");
   return lines.join("\n");
+}
+
+function formatExceptionDays(daysUntilExpiry: number): string {
+  return Number.isFinite(daysUntilExpiry) ? String(daysUntilExpiry) : "invalid";
 }

--- a/src/policy/evaluate.ts
+++ b/src/policy/evaluate.ts
@@ -4,6 +4,9 @@ import { generatePolicyPack } from "./presets.js";
 import type {
   AppliedPolicyException,
   OrgPolicy,
+  PolicyExceptionAuditEntry,
+  PolicyExceptionLifecycleStatus,
+  PolicyExceptionSummary,
   PolicyException,
   PolicyPack,
   PolicyViolation,
@@ -14,6 +17,8 @@ import type { Finding, SecurityScore, ConfigFile, Severity } from "../types.js";
 const SEVERITY_ORDER: Record<Severity, number> = {
   critical: 0, high: 1, medium: 2, low: 3, info: 4,
 };
+const EXPIRING_SOON_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export type LoadPolicyResult =
   | { readonly success: true; readonly policy: OrgPolicy }
@@ -165,6 +170,7 @@ export function evaluatePolicy(
     passed: finalViolations.length === 0,
     violations: finalViolations,
     exceptionsApplied: exceptionResult.applied,
+    exceptionSummary: buildExceptionSummary(policy.exceptions ?? [], now),
     score: score.numericScore,
     minScore: policy.min_score,
   };
@@ -357,6 +363,70 @@ function isExceptionActive(exception: PolicyException, now: Date): boolean {
   return expiresAt.getTime() >= now.getTime();
 }
 
+function buildExceptionSummary(
+  exceptions: ReadonlyArray<PolicyException>,
+  now: Date
+): PolicyExceptionSummary {
+  const entries = exceptions
+    .map((exception) => buildExceptionAuditEntry(exception, now))
+    .sort(compareExceptionAuditEntries);
+
+  return {
+    total: entries.length,
+    active: entries.filter((entry) =>
+      entry.status === "active" || entry.status === "expiring_soon"
+    ).length,
+    expiringSoon: entries.filter((entry) => entry.status === "expiring_soon").length,
+    expired: entries.filter((entry) => entry.status === "expired").length,
+    entries,
+  };
+}
+
+function buildExceptionAuditEntry(
+  exception: PolicyException,
+  now: Date
+): PolicyExceptionAuditEntry {
+  const expiresAt = new Date(exception.expires_at);
+  const daysUntilExpiry = Number.isNaN(expiresAt.getTime())
+    ? Number.NEGATIVE_INFINITY
+    : Math.ceil((expiresAt.getTime() - now.getTime()) / MS_PER_DAY);
+  const status = statusForExceptionDays(daysUntilExpiry);
+
+  return {
+    id: exception.id,
+    rule: exception.rule,
+    owner: exception.owner,
+    reason: exception.reason,
+    expiresAt: exception.expires_at,
+    status,
+    daysUntilExpiry,
+    ...(exception.scope ? { scope: exception.scope } : {}),
+    ...(exception.ticket ? { ticket: exception.ticket } : {}),
+  };
+}
+
+function statusForExceptionDays(daysUntilExpiry: number): PolicyExceptionLifecycleStatus {
+  if (daysUntilExpiry < 0) return "expired";
+  if (daysUntilExpiry <= EXPIRING_SOON_DAYS) return "expiring_soon";
+  return "active";
+}
+
+function compareExceptionAuditEntries(
+  a: PolicyExceptionAuditEntry,
+  b: PolicyExceptionAuditEntry
+): number {
+  const statusRank: Record<PolicyExceptionLifecycleStatus, number> = {
+    expiring_soon: 0,
+    active: 1,
+    expired: 2,
+  };
+  const statusDelta = statusRank[a.status] - statusRank[b.status];
+  if (statusDelta !== 0) return statusDelta;
+  const dayDelta = a.daysUntilExpiry - b.daysUntilExpiry;
+  if (dayDelta !== 0) return dayDelta;
+  return a.id.localeCompare(b.id);
+}
+
 function exceptionMatchesViolation(
   exception: PolicyException,
   violation: PolicyViolation
@@ -429,10 +499,34 @@ export function renderPolicyEvaluation(evaluation: PolicyEvaluation): string {
     lines.push("");
   }
 
+  if (evaluation.exceptionSummary && evaluation.exceptionSummary.total > 0) {
+    const summary = evaluation.exceptionSummary;
+    lines.push("  EXCEPTION AUDIT:");
+    lines.push(
+      `    total=${summary.total} active=${summary.active} expiring_soon=${summary.expiringSoon} expired=${summary.expired}`
+    );
+    for (const exception of summary.entries) {
+      const details = [
+        `status=${exception.status}`,
+        `owner=${exception.owner}`,
+        `expires=${exception.expiresAt}`,
+        `days=${formatExceptionDays(exception.daysUntilExpiry)}`,
+        ...(exception.scope ? [`scope=${exception.scope}`] : []),
+        ...(exception.ticket ? [`ticket=${exception.ticket}`] : []),
+      ];
+      lines.push(`    ${exception.id} (${exception.rule}) ${details.join(" ")}`);
+    }
+    lines.push("");
+  }
+
   lines.push(`  ${divider}`);
   lines.push("");
 
   return lines.join("\n");
+}
+
+function formatExceptionDays(daysUntilExpiry: number): string {
+  return Number.isFinite(daysUntilExpiry) ? String(daysUntilExpiry) : "invalid";
 }
 
 /**

--- a/src/policy/types.ts
+++ b/src/policy/types.ts
@@ -92,6 +92,7 @@ export interface PolicyEvaluation {
   readonly passed: boolean;
   readonly violations: ReadonlyArray<PolicyViolation>;
   readonly exceptionsApplied?: ReadonlyArray<AppliedPolicyException>;
+  readonly exceptionSummary?: PolicyExceptionSummary;
   readonly score: number;
   readonly minScore: number;
 }
@@ -103,4 +104,29 @@ export interface AppliedPolicyException {
   readonly reason: string;
   readonly expiresAt: string;
   readonly violation: string;
+}
+
+export type PolicyExceptionLifecycleStatus =
+  | "active"
+  | "expiring_soon"
+  | "expired";
+
+export interface PolicyExceptionAuditEntry {
+  readonly id: string;
+  readonly rule: string;
+  readonly owner: string;
+  readonly reason: string;
+  readonly expiresAt: string;
+  readonly status: PolicyExceptionLifecycleStatus;
+  readonly daysUntilExpiry: number;
+  readonly scope?: string;
+  readonly ticket?: string;
+}
+
+export interface PolicyExceptionSummary {
+  readonly total: number;
+  readonly active: number;
+  readonly expiringSoon: number;
+  readonly expired: number;
+  readonly entries: ReadonlyArray<PolicyExceptionAuditEntry>;
 }

--- a/tests/action-policy.test.ts
+++ b/tests/action-policy.test.ts
@@ -76,4 +76,41 @@ describe("action policy helpers", () => {
     expect(summary).toContain("### Exceptions Applied");
     expect(summary).toContain("AS-EX-001");
   });
+
+  it("renders exception lifecycle audit counts for branch protection evidence", () => {
+    const summary = renderPolicyJobSummary(makeEvaluation({
+      exceptionSummary: {
+        total: 3,
+        active: 2,
+        expiringSoon: 1,
+        expired: 1,
+        entries: [
+          {
+            id: "AS-EX-SOON",
+            rule: "min_score",
+            owner: "security@example.com",
+            reason: "Migration window",
+            expiresAt: "2026-05-15T00:00:00.000Z",
+            status: "expiring_soon",
+            daysUntilExpiry: 3,
+          },
+          {
+            id: "AS-EX-OLD",
+            rule: "banned_tools",
+            owner: "security@example.com",
+            reason: "Expired exception",
+            expiresAt: "2026-05-01T00:00:00.000Z",
+            status: "expired",
+            daysUntilExpiry: -11,
+            ticket: "SEC-999",
+          },
+        ],
+      },
+    }));
+
+    expect(summary).toContain("- Exceptions: 3 total, 2 active, 1 expiring soon, 1 expired");
+    expect(summary).toContain("### Exception Audit");
+    expect(summary).toContain("AS-EX-SOON (min_score) status=expiring_soon owner=security@example.com expires=2026-05-15T00:00:00.000Z days=3");
+    expect(summary).toContain("AS-EX-OLD (banned_tools) status=expired owner=security@example.com expires=2026-05-01T00:00:00.000Z days=-11 ticket=SEC-999");
+  });
 });

--- a/tests/policy/evaluate.test.ts
+++ b/tests/policy/evaluate.test.ts
@@ -346,6 +346,65 @@ describe("evaluatePolicy", () => {
     expect(result.exceptionsApplied).toHaveLength(0);
     expect(result.violations.some((v) => v.rule === "banned_mcp_servers")).toBe(true);
   });
+
+  it("summarizes policy exception lifecycle for audit review", () => {
+    const policy = makePolicy({
+      exceptions: [
+        {
+          id: "AS-EX-ACTIVE",
+          rule: "required_hooks",
+          owner: "platform@example.com",
+          reason: "Long migration window",
+          expires_at: "2026-06-30T00:00:00.000Z",
+          ticket: "SEC-101",
+        },
+        {
+          id: "AS-EX-SOON",
+          rule: "min_score",
+          owner: "security@example.com",
+          reason: "Needs follow-up this week",
+          expires_at: "2026-05-15T00:00:00.000Z",
+          scope: "score",
+        },
+        {
+          id: "AS-EX-OLD",
+          rule: "banned_tools",
+          owner: "security@example.com",
+          reason: "Expired exception",
+          expires_at: "2026-05-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const result = evaluatePolicy(policy, [], makeScore(90), [], {
+      now: new Date("2026-05-12T00:00:00.000Z"),
+    });
+
+    expect(result.exceptionSummary).toMatchObject({
+      total: 3,
+      active: 2,
+      expiringSoon: 1,
+      expired: 1,
+    });
+    expect(result.exceptionSummary?.entries).toEqual([
+      expect.objectContaining({
+        id: "AS-EX-SOON",
+        status: "expiring_soon",
+        daysUntilExpiry: 3,
+        owner: "security@example.com",
+      }),
+      expect.objectContaining({
+        id: "AS-EX-ACTIVE",
+        status: "active",
+        daysUntilExpiry: 49,
+        ticket: "SEC-101",
+      }),
+      expect.objectContaining({
+        id: "AS-EX-OLD",
+        status: "expired",
+        daysUntilExpiry: -11,
+      }),
+    ]);
+  });
 });
 
 describe("renderPolicyEvaluation", () => {
@@ -410,6 +469,51 @@ describe("renderPolicyEvaluation", () => {
     expect(output).toContain("COMPLIANT (WITH EXCEPTIONS)");
     expect(output).toContain("AS-EX-001");
     expect(output).toContain("Migration window");
+  });
+
+  it("renders policy exception lifecycle audit details", () => {
+    const output = renderPolicyEvaluation({
+      policyName: "Exception Lifecycle Policy",
+      passed: false,
+      violations: [],
+      exceptionSummary: {
+        total: 2,
+        active: 1,
+        expiringSoon: 1,
+        expired: 0,
+        entries: [
+          {
+            id: "AS-EX-SOON",
+            rule: "min_score",
+            owner: "security@example.com",
+            reason: "Short migration window",
+            expiresAt: "2026-05-15T00:00:00.000Z",
+            status: "expiring_soon",
+            daysUntilExpiry: 3,
+            scope: "score",
+            ticket: "SEC-123",
+          },
+          {
+            id: "AS-EX-ACTIVE",
+            rule: "required_hooks",
+            owner: "platform@example.com",
+            reason: "Long migration window",
+            expiresAt: "2026-06-30T00:00:00.000Z",
+            status: "active",
+            daysUntilExpiry: 49,
+          },
+        ],
+      },
+      score: 80,
+      minScore: 90,
+    });
+
+    expect(output).toContain("EXCEPTION AUDIT");
+    expect(output).toContain("total=2 active=1 expiring_soon=1 expired=0");
+    expect(output).toContain("AS-EX-SOON");
+    expect(output).toContain("status=expiring_soon");
+    expect(output).toContain("days=3");
+    expect(output).toContain("ticket=SEC-123");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds first-class lifecycle visibility for organization policy exceptions/waivers:

- returns an exception summary from policy evaluation with total, active, expiring-soon, and expired counts
- sorts exception audit entries by expiring-soon, active, then expired so urgent waivers surface first
- renders owner, ticket, scope, expiry, and days-until-expiry in terminal policy output
- adds the same exception lifecycle evidence to GitHub Action job summaries for branch-protection review
- documents the enterprise policy behavior in the README
- rebuilds tracked GitHub Action bundles under dist/

## Research signal

This follows the common enterprise security pattern that temporary waivers need owners, expiration, expiring-soon visibility, and audit evidence so exceptions do not become silent permanent bypasses.

## Validation

- red-first 
 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/action-policy.test.ts (4 tests) 2ms
 ✓ tests/policy/evaluate.test.ts (27 tests) 7ms

 Test Files  2 passed (2)
      Tests  31 passed (31)
   Start at  12:14:28
   Duration  213ms (transform 48ms, setup 0ms, collect 69ms, tests 9ms, environment 0ms, prepare 54ms) failed on missing lifecycle summary/rendering
- 
 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/action-policy.test.ts (4 tests) 2ms
 ✓ tests/policy/evaluate.test.ts (27 tests) 8ms

 Test Files  2 passed (2)
      Tests  31 passed (31)
   Start at  12:14:28
   Duration  202ms (transform 56ms, setup 0ms, collect 75ms, tests 9ms, environment 0ms, prepare 66ms) passed: 31 tests
- 
> ecc-agentshield@1.4.0 typecheck
> tsc --noEmit passed
- 
> ecc-agentshield@1.4.0 lint
> eslint src/ passed
- 
> ecc-agentshield@1.4.0 test
> npm run test:batch:core && npm run test:batch:analysis && npm run test:batch:miniclaw-a && npm run test:batch:miniclaw-b && npm run test:batch:misc


> ecc-agentshield@1.4.0 test:batch:core
> vitest run tests/rules/*.test.ts tests/scanner/*.test.ts tests/reporter/*.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/reporter/score.test.ts (22 tests) 3ms
 ✓ tests/reporter/sarif.test.ts (6 tests) 3ms
 ✓ tests/reporter/html.test.ts (16 tests) 14ms
 ✓ tests/rules/prompt-defense.test.ts (5 tests) 4ms
 ✓ tests/reporter/json.test.ts (13 tests) 3ms
 ✓ tests/rules/permissions.test.ts (90 tests) 14ms
 ✓ tests/reporter/terminal.test.ts (14 tests) 3ms
 ✓ tests/rules/mcp.test.ts (136 tests) 18ms
 ✓ tests/rules/secrets.test.ts (86 tests) 13ms
 ✓ tests/scanner/discovery.test.ts (23 tests) 21ms
 ✓ tests/rules/hooks.test.ts (208 tests) 47ms
 ✓ tests/rules/skills.test.ts (24 tests) 24ms
 ✓ tests/rules/agents.test.ts (264 tests) 57ms
 ✓ tests/scanner/scanner.test.ts (34 tests) 139ms

 Test Files  14 passed (14)
      Tests  941 passed (941)
   Start at  12:14:31
   Duration  581ms (transform 915ms, setup 0ms, collect 1.87s, tests 363ms, environment 2ms, prepare 831ms)


> ecc-agentshield@1.4.0 test:batch:analysis
> vitest run tests/integration.test.ts tests/injection.test.ts tests/action.test.ts tests/action-policy.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/action.test.ts (15 tests) 3ms
 ✓ tests/action-policy.test.ts (4 tests) 2ms
 ✓ tests/injection.test.ts (52 tests) 11ms
 ✓ tests/integration.test.ts (23 tests) 61ms

 Test Files  4 passed (4)
      Tests  94 passed (94)
   Start at  12:14:32
   Duration  377ms (transform 179ms, setup 0ms, collect 293ms, tests 76ms, environment 0ms, prepare 127ms)


> ecc-agentshield@1.4.0 test:batch:miniclaw-a
> vitest run tests/miniclaw/index.test.ts tests/miniclaw/server.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/miniclaw/index.test.ts (17 tests) 15ms
 ✓ tests/miniclaw/server.test.ts (21 tests) 34ms

 Test Files  2 passed (2)
      Tests  38 passed (38)
   Start at  12:14:32
   Duration  233ms (transform 78ms, setup 0ms, collect 115ms, tests 49ms, environment 0ms, prepare 62ms)


> ecc-agentshield@1.4.0 test:batch:miniclaw-b
> vitest run tests/miniclaw/cli.test.ts tests/miniclaw/sandbox.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/miniclaw/sandbox.test.ts (28 tests) 15ms
 ✓ tests/miniclaw/cli.test.ts (7 tests) 231ms

 Test Files  2 passed (2)
      Tests  35 passed (35)
   Start at  12:14:33
   Duration  390ms (transform 32ms, setup 0ms, collect 38ms, tests 246ms, environment 0ms, prepare 57ms)


> ecc-agentshield@1.4.0 test:batch:misc
> vitest run tests/corpus.test.ts tests/logger.test.ts tests/init/init.test.ts tests/taint/taint.test.ts tests/opus/*.test.ts tests/fixer/*.test.ts tests/types.test.ts tests/skills/*.test.ts tests/miniclaw/router.test.ts tests/miniclaw/tools.test.ts tests/miniclaw/types.test.ts tests/sandbox/sandbox.test.ts tests/threat-intel/*.test.ts tests/watch/*.test.ts tests/runtime/*.test.ts tests/baseline/*.test.ts tests/supply-chain/*.test.ts tests/policy/*.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/taint/taint.test.ts (16 tests) 5ms
 ✓ tests/watch/alerts.test.ts (12 tests) 15ms
 ✓ tests/runtime/policy.test.ts (9 tests) 5ms
 ✓ tests/runtime/status.test.ts (7 tests) 10ms
 ✓ tests/runtime/install.test.ts (12 tests) 14ms
 ✓ tests/logger.test.ts (27 tests) 16ms
 ✓ tests/miniclaw/tools.test.ts (36 tests) 7ms
 ✓ tests/skills/health.test.ts (23 tests) 10ms
 ✓ tests/opus/structured.test.ts (31 tests) 5ms
 ✓ tests/types.test.ts (10 tests) 92ms
 ✓ tests/supply-chain/verify.test.ts (25 tests) 12ms
 ✓ tests/threat-intel/cve-database.test.ts (27 tests) 8ms
 ✓ tests/miniclaw/router.test.ts (35 tests) 8ms
 ✓ tests/runtime/repair.test.ts (2 tests) 6ms
 ✓ tests/policy/evaluate.test.ts (27 tests) 8ms
 ✓ tests/init/init.test.ts (15 tests) 7ms
 ✓ tests/threat-intel/tool-poisoning.test.ts (24 tests) 5ms
 ✓ tests/baseline/compare.test.ts (20 tests) 7ms
 ✓ tests/supply-chain/extract.test.ts (17 tests) 5ms
 ✓ tests/watch/watcher-fallback.test.ts (1 test) 297ms
 ✓ tests/watch/watcher-platform.test.ts (1 test) 301ms
   ✓ startWatcher recursive fallback > watches existing directories when recursive watch is unavailable  301ms
 ✓ tests/runtime/evaluator.test.ts (16 tests) 5ms
 ✓ tests/corpus.test.ts (73 tests) 36ms
 ✓ tests/watch/watcher.test.ts (5 tests) 65ms
 ✓ tests/policy/presets.test.ts (5 tests) 4ms
 ✓ tests/opus/render.test.ts (11 tests) 2ms
 ✓ tests/watch/diff.test.ts (12 tests) 4ms
 ✓ tests/miniclaw/types.test.ts (10 tests) 2ms
 ✓ tests/opus/prompts.test.ts (12 tests) 2ms
 ✓ tests/supply-chain/render.test.ts (7 tests) 2ms
 ✓ tests/fixer/transforms.test.ts (10 tests) 2ms
 ✓ tests/threat-intel/cve-mcp-rules.test.ts (9 tests) 3ms
 ✓ tests/fixer/fixer.test.ts (10 tests) 4ms
 ✓ tests/sandbox/sandbox.test.ts (43 tests) 1198ms
   ✓ executeHookInSandbox > enforces timeout on long-running commands  503ms
   ✓ analyzeExecution > returns malicious verdict for timeout  310ms

 Test Files  34 passed (34)
      Tests  600 passed (600)
   Start at  12:14:33
   Duration  1.47s (transform 930ms, setup 0ms, collect 2.20s, tests 2.17s, environment 7ms, prepare 1.72s) passed: 1,708 Vitest tests
- 
> ecc-agentshield@1.4.0 build
> tsup src/index.ts src/action.ts src/miniclaw/index.ts --format esm --dts --clean --no-splitting

CLI Building entry: src/action.ts, src/index.ts, src/miniclaw/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
ESM dist/miniclaw/index.js 28.44 KB
ESM dist/action.js         376.78 KB
ESM dist/index.js          676.70 KB
ESM ⚡️ Build success in 23ms
DTS Build start
DTS ⚡️ Build success in 1337ms
DTS dist/action.d.ts         13.00 B
DTS dist/miniclaw/index.d.ts 22.43 KB
DTS dist/index.d.ts          20.00 B passed
-  passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a lifecycle audit for policy exceptions and surfaces it in terminal output and GitHub Action summaries so expiring waivers are easy to spot and review.

- **New Features**
  - `evaluatePolicy` returns `exceptionSummary` with totals (total, active, expiring_soon ≤7 days, expired) and per-exception details (owner, ticket, scope, expiry, days).
  - Terminal output and GitHub Action job summaries show counts and a sorted audit: expiring_soon → active → expired.
  - README documents the behavior; action bundles rebuilt under `dist/`.

<sup>Written for commit 91a7f6e294c53bee863abb78540a28515ebe845b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added exception lifecycle audits to terminal and GitHub Action summaries, displaying aggregate counts (active, expiring soon, expired) and per-exception details including status, owner, expiry date, and days remaining.

* **Documentation**
  * Updated README documenting the new exception audit reporting capabilities.

* **Tests**
  * Added test coverage for exception audit functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->