### PR TITLE
feat: expose baseline drift in GitHub Action

### DIFF
--- a/API.md
+++ b/API.md
@@ -113,6 +113,14 @@ adds policy results to the job summary, emits policy violations into SARIF as
 fails on non-compliance by default. Set `fail-on-policy: "false"` to collect
 policy evidence without failing the workflow.
 
+The GitHub Action also exposes baseline drift through the `baseline` and
+`save-baseline` inputs. It reports `baseline-path`, `baseline-status`,
+`new-findings`, `resolved-findings`, `unchanged-findings`, and `score-delta`
+outputs, appends a baseline drift block to the job summary, and emits
+annotations for newly introduced findings. Set `fail-on-findings: "false"` when
+the workflow should fail only on baseline drift instead of every current
+finding.
+
 Policy files use schema version `1`. Enterprise policy metadata is optional but
 recommended for CI gates:
 
@@ -150,6 +158,10 @@ The supported machine-readable scanner contract today is the JSON report returne
 ```bash
 agentshield scan --format json
 ```
+
+Baseline comparison output is treated as auxiliary output. When JSON or SARIF is
+written to stdout, baseline save/compare and gate text is written to stderr so
+the primary machine-readable report remains parseable.
 
 Top-level shape:
 

--- a/README.md
+++ b/README.md
@@ -475,12 +475,27 @@ Detailed request/response and schema notes live in [`API.md`](./API.md).
 | `fail-on-findings` | `true` | Fail the action if findings meet severity threshold |
 | `format` | `terminal` | Output format: terminal, json, markdown, sarif |
 | `sarif-output` | `agentshield-results.sarif` | SARIF output path when `format` is `sarif` |
+| `baseline` | `""` | Optional AgentShield baseline JSON path for drift comparison |
+| `save-baseline` | `""` | Optional path to write the current scan as a new baseline |
 | `policy` | `""` | Optional organization policy JSON path |
 | `fail-on-policy` | `true` | Fail the action if the organization policy is non-compliant |
 
-**Outputs:** `score` (0–100), `grade` (A–F), `total-findings`, `critical-count`, `sarif-path`, `policy-status`, `policy-violations`
+**Outputs:** `score` (0–100), `grade` (A–F), `total-findings`, `critical-count`, `sarif-path`, `baseline-path`, `baseline-status`, `new-findings`, `resolved-findings`, `unchanged-findings`, `score-delta`, `policy-status`, `policy-violations`
 
-The action writes a markdown job summary and emits GitHub annotations inline on affected files. When `format: sarif` is set, it also writes a SARIF 2.1.0 report that can be uploaded to GitHub code scanning with `github/codeql-action/upload-sarif`. When `policy` is set, the SARIF report includes organization-policy violations as `agentshield-policy/*` code-scanning results, appends the organization policy result to the job summary, emits policy violation annotations, and fails by default unless `fail-on-policy: "false"` is set.
+The action writes a markdown job summary and emits GitHub annotations inline on affected files. When `format: sarif` is set, it also writes a SARIF 2.1.0 report that can be uploaded to GitHub code scanning with `github/codeql-action/upload-sarif`. When `baseline` is set, the action appends a baseline drift summary, emits regression annotations for new findings, and reports `baseline-status` as `passed`, `failed`, `missing`, or `not-run`. When `policy` is set, the SARIF report includes organization-policy violations as `agentshield-policy/*` code-scanning results, appends the organization policy result to the job summary, emits policy violation annotations, and fails by default unless `fail-on-policy: "false"` is set.
+
+Baseline drift gate:
+
+```yaml
+- name: AgentShield Drift Gate
+  uses: affaan-m/agentshield@v1
+  with:
+    path: "."
+    baseline: ".github/agentshield-baseline.json"
+    fail-on-findings: "false"
+```
+
+Use `fail-on-findings: "false"` when the workflow should fail only on drift from the baseline. Keep the default `fail-on-findings: "true"` when any current finding at or above `min-severity` should still fail the action.
 
 ## CLI Reference
 
@@ -499,6 +514,9 @@ agentshield scan [options]         Scan configuration directory
   --log <path>                     Write structured scan logs to a file
   --log-format <format>            Log format: ndjson or json
   --corpus                         Run built-in attack corpus benchmark
+  --baseline <path>                Compare against a baseline file
+  --save-baseline <path>           Save current scan results as a baseline file
+  --gate                           Fail on new critical/high findings or score drop
   --supply-chain                   Verify MCP package provenance and risk
   --supply-chain-online            Include npm registry metadata
   --policy <path>                  Validate against an organization policy

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: "Path to write SARIF results when format is sarif"
     required: false
     default: "agentshield-results.sarif"
+  baseline:
+    description: "Path to an AgentShield baseline JSON file for drift comparison"
+    required: false
+    default: ""
+  save-baseline:
+    description: "Path to write the current scan as a new AgentShield baseline JSON file"
+    required: false
+    default: ""
   policy:
     description: "Path to an AgentShield organization policy JSON file"
     required: false
@@ -47,6 +55,18 @@ outputs:
     description: "Number of critical findings"
   sarif-path:
     description: "Path to the generated SARIF file when format is sarif"
+  baseline-path:
+    description: "Path to the generated baseline file when save-baseline is set"
+  baseline-status:
+    description: "Baseline drift status: not-run, missing, passed, or failed"
+  new-findings:
+    description: "Number of findings introduced since the baseline"
+  resolved-findings:
+    description: "Number of baseline findings resolved by the current scan"
+  unchanged-findings:
+    description: "Number of findings unchanged since the baseline"
+  score-delta:
+    description: "Numeric score delta relative to the baseline"
   policy-status:
     description: "Organization policy status: not-run, compliant, non-compliant, or error"
   policy-violations:

--- a/dist/action.js
+++ b/dist/action.js
@@ -9501,6 +9501,71 @@ function formatExceptionDays(daysUntilExpiry) {
   return Number.isFinite(daysUntilExpiry) ? String(daysUntilExpiry) : "invalid";
 }
 
+// src/action-baseline.ts
+function statusForBaselineGate(result) {
+  return result.passed ? "passed" : "failed";
+}
+function renderBaselineJobSummary(comparison, gateResult) {
+  const status = statusForBaselineGate(gateResult);
+  const lines = [
+    "",
+    "",
+    "## AgentShield Baseline Drift",
+    "",
+    `- Status: ${status}`,
+    `- Baseline timestamp: ${comparison.baselineTimestamp}`,
+    `- Score: ${comparison.baselineScore} -> ${comparison.currentScore} (${formatScoreDelta(comparison.scoreDelta)})`,
+    `- New findings: ${comparison.newFindings.length}`,
+    `- Resolved findings: ${comparison.resolvedFindings.length}`,
+    `- Unchanged findings: ${comparison.unchangedCount}`,
+    `- New critical findings: ${comparison.newCriticalCount}`,
+    `- New high findings: ${comparison.newHighCount}`
+  ];
+  if (gateResult.reasons.length > 0) {
+    lines.push("", "### Gate Reasons", "");
+    for (const reason of gateResult.reasons) {
+      lines.push(`- ${reason}`);
+    }
+  }
+  if (comparison.newFindings.length > 0) {
+    lines.push("", "### New Findings", "");
+    for (const finding of comparison.newFindings.slice(0, 20)) {
+      lines.push(
+        `- ${finding.severity}: ${finding.title} (${finding.file})`
+      );
+    }
+    if (comparison.newFindings.length > 20) {
+      lines.push(`- ...${comparison.newFindings.length - 20} more`);
+    }
+  }
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push("", "### Resolved Findings", "");
+    for (const finding of comparison.resolvedFindings.slice(0, 20)) {
+      lines.push(`- ${finding.severity}: ${finding.title} (${finding.file})`);
+    }
+    if (comparison.resolvedFindings.length > 20) {
+      lines.push(`- ...${comparison.resolvedFindings.length - 20} more`);
+    }
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+function renderMissingBaselineJobSummary(baselinePath) {
+  return [
+    "",
+    "",
+    "## AgentShield Baseline Drift",
+    "",
+    "- Status: missing",
+    `- Baseline path: ${baselinePath}`,
+    "- Comparison skipped because the baseline file could not be loaded.",
+    ""
+  ].join("\n");
+}
+function formatScoreDelta(delta) {
+  return delta > 0 ? `+${delta}` : String(delta);
+}
+
 // src/action.ts
 function getInput(name, fallback) {
   const envKey = `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
@@ -9587,6 +9652,11 @@ async function run() {
   setOutput("grade", report.score.grade);
   setOutput("total-findings", String(report.summary.totalFindings));
   setOutput("critical-count", String(report.summary.critical));
+  setOutput("baseline-status", "not-run");
+  setOutput("new-findings", "0");
+  setOutput("resolved-findings", "0");
+  setOutput("unchanged-findings", "0");
+  setOutput("score-delta", "0");
   setOutput("policy-status", "not-run");
   setOutput("policy-violations", "0");
   let policyEvaluation = null;
@@ -9673,6 +9743,7 @@ async function run() {
       const comparison = compareBaseline2(baseline, filteredResult.findings, report.score);
       setOutput("new-findings", String(comparison.newFindings.length));
       setOutput("resolved-findings", String(comparison.resolvedFindings.length));
+      setOutput("unchanged-findings", String(comparison.unchangedCount));
       setOutput("score-delta", String(comparison.scoreDelta));
       if (comparison.newFindings.length > 0) {
         console.log("");
@@ -9680,6 +9751,8 @@ async function run() {
         emitAnnotations(comparison.newFindings);
       }
       const gateResult = evaluateGate2(comparison);
+      setOutput("baseline-status", statusForBaselineGate(gateResult));
+      writeJobSummary(renderBaselineJobSummary(comparison, gateResult));
       if (!gateResult.passed) {
         console.log("");
         console.log(`::error::AgentShield gate FAILED: ${gateResult.reasons.join("; ")}`);
@@ -9689,6 +9762,8 @@ async function run() {
         console.log("Baseline gate: PASSED");
       }
     } else {
+      setOutput("baseline-status", "missing");
+      writeJobSummary(renderMissingBaselineJobSummary(baselinePath));
       console.log(`::warning::Could not load baseline from ${baselinePath}. Skipping comparison.`);
     }
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -16569,6 +16569,7 @@ program.command("scan").description("Scan a Claude Code configuration directory 
       console.log(message);
     }
   };
+  const writeAuxiliaryOutput = writePolicyOutput;
   if (options.policy) {
     logger.log({ level: "info", phase: "policy", message: "Validating against organization policy" });
     try {
@@ -16631,7 +16632,7 @@ program.command("scan").description("Scan a Claude Code configuration directory 
   if (options.saveBaseline) {
     const { saveBaseline: saveBaseline2 } = await Promise.resolve().then(() => (init_baseline(), baseline_exports));
     saveBaseline2(filteredResult.findings, report.score, options.saveBaseline);
-    console.log(`
+    writeAuxiliaryOutput(`
   Baseline saved to: ${options.saveBaseline}
 `);
     logger.log({ level: "info", phase: "baseline", message: `Baseline saved to ${options.saveBaseline}` });
@@ -16645,7 +16646,7 @@ program.command("scan").description("Scan a Claude Code configuration directory 
 `);
     } else {
       const comparison = compareBaseline2(baseline, filteredResult.findings, report.score);
-      console.log(renderComparison2(comparison));
+      writeAuxiliaryOutput(renderComparison2(comparison));
       logger.log({
         level: comparison.isRegression ? "warn" : "info",
         phase: "baseline",
@@ -16653,7 +16654,7 @@ program.command("scan").description("Scan a Claude Code configuration directory 
       });
       if (options.gate) {
         const gateResult = evaluateGate2(comparison);
-        console.log(renderGateResult2(gateResult));
+        writeAuxiliaryOutput(renderGateResult2(gateResult));
         if (!gateResult.passed) {
           logger.log({ level: "error", phase: "gate", message: `Gate FAILED: ${gateResult.reasons.join("; ")}` });
           process.exit(3);

--- a/src/action-baseline.ts
+++ b/src/action-baseline.ts
@@ -1,0 +1,81 @@
+import type { BaselineComparison, GateResult } from "./baseline/index.js";
+
+export type ActionBaselineStatus =
+  | "not-run"
+  | "missing"
+  | "passed"
+  | "failed";
+
+export function statusForBaselineGate(result: GateResult): ActionBaselineStatus {
+  return result.passed ? "passed" : "failed";
+}
+
+export function renderBaselineJobSummary(
+  comparison: BaselineComparison,
+  gateResult: GateResult
+): string {
+  const status = statusForBaselineGate(gateResult);
+  const lines = [
+    "",
+    "",
+    "## AgentShield Baseline Drift",
+    "",
+    `- Status: ${status}`,
+    `- Baseline timestamp: ${comparison.baselineTimestamp}`,
+    `- Score: ${comparison.baselineScore} -> ${comparison.currentScore} (${formatScoreDelta(comparison.scoreDelta)})`,
+    `- New findings: ${comparison.newFindings.length}`,
+    `- Resolved findings: ${comparison.resolvedFindings.length}`,
+    `- Unchanged findings: ${comparison.unchangedCount}`,
+    `- New critical findings: ${comparison.newCriticalCount}`,
+    `- New high findings: ${comparison.newHighCount}`,
+  ];
+
+  if (gateResult.reasons.length > 0) {
+    lines.push("", "### Gate Reasons", "");
+    for (const reason of gateResult.reasons) {
+      lines.push(`- ${reason}`);
+    }
+  }
+
+  if (comparison.newFindings.length > 0) {
+    lines.push("", "### New Findings", "");
+    for (const finding of comparison.newFindings.slice(0, 20)) {
+      lines.push(
+        `- ${finding.severity}: ${finding.title} (${finding.file})`
+      );
+    }
+    if (comparison.newFindings.length > 20) {
+      lines.push(`- ...${comparison.newFindings.length - 20} more`);
+    }
+  }
+
+  if (comparison.resolvedFindings.length > 0) {
+    lines.push("", "### Resolved Findings", "");
+    for (const finding of comparison.resolvedFindings.slice(0, 20)) {
+      lines.push(`- ${finding.severity}: ${finding.title} (${finding.file})`);
+    }
+    if (comparison.resolvedFindings.length > 20) {
+      lines.push(`- ...${comparison.resolvedFindings.length - 20} more`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function renderMissingBaselineJobSummary(baselinePath: string): string {
+  return [
+    "",
+    "",
+    "## AgentShield Baseline Drift",
+    "",
+    "- Status: missing",
+    `- Baseline path: ${baselinePath}`,
+    "- Comparison skipped because the baseline file could not be loaded.",
+    "",
+  ].join("\n");
+}
+
+function formatScoreDelta(delta: number): string {
+  return delta > 0 ? `+${delta}` : String(delta);
+}

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,6 +18,11 @@ import {
   renderPolicyJobSummary,
   statusForPolicyEvaluation,
 } from "./action-policy.js";
+import {
+  renderBaselineJobSummary,
+  renderMissingBaselineJobSummary,
+  statusForBaselineGate,
+} from "./action-baseline.js";
 import type { PolicyEvaluation } from "./policy/index.js";
 import type { Finding, Severity } from "./types.js";
 
@@ -143,6 +148,11 @@ async function run(): Promise<void> {
   setOutput("grade", report.score.grade);
   setOutput("total-findings", String(report.summary.totalFindings));
   setOutput("critical-count", String(report.summary.critical));
+  setOutput("baseline-status", "not-run");
+  setOutput("new-findings", "0");
+  setOutput("resolved-findings", "0");
+  setOutput("unchanged-findings", "0");
+  setOutput("score-delta", "0");
   setOutput("policy-status", "not-run");
   setOutput("policy-violations", "0");
 
@@ -246,6 +256,7 @@ async function run(): Promise<void> {
 
       setOutput("new-findings", String(comparison.newFindings.length));
       setOutput("resolved-findings", String(comparison.resolvedFindings.length));
+      setOutput("unchanged-findings", String(comparison.unchangedCount));
       setOutput("score-delta", String(comparison.scoreDelta));
 
       // Emit annotations only for NEW findings (regression-only mode)
@@ -256,6 +267,8 @@ async function run(): Promise<void> {
       }
 
       const gateResult = evaluateGate(comparison);
+      setOutput("baseline-status", statusForBaselineGate(gateResult));
+      writeJobSummary(renderBaselineJobSummary(comparison, gateResult));
       if (!gateResult.passed) {
         console.log("");
         console.log(`::error::AgentShield gate FAILED: ${gateResult.reasons.join("; ")}`);
@@ -265,6 +278,8 @@ async function run(): Promise<void> {
         console.log("Baseline gate: PASSED");
       }
     } else {
+      setOutput("baseline-status", "missing");
+      writeJobSummary(renderMissingBaselineJobSummary(baselinePath));
       console.log(`::warning::Could not load baseline from ${baselinePath}. Skipping comparison.`);
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,6 +294,7 @@ program
         console.log(message);
       }
     };
+    const writeAuxiliaryOutput = writePolicyOutput;
 
     // ── Phase 1c: Organization policy validation ──────────
     if (options.policy) {
@@ -362,7 +363,7 @@ program
     if (options.saveBaseline) {
       const { saveBaseline } = await import("./baseline/index.js");
       saveBaseline(filteredResult.findings, report.score, options.saveBaseline);
-      console.log(`\n  Baseline saved to: ${options.saveBaseline}\n`);
+      writeAuxiliaryOutput(`\n  Baseline saved to: ${options.saveBaseline}\n`);
       logger.log({ level: "info", phase: "baseline", message: `Baseline saved to ${options.saveBaseline}` });
     }
 
@@ -374,7 +375,7 @@ program
         console.error(`\n  Error: Could not load baseline from ${options.baseline}\n`);
       } else {
         const comparison = compareBaseline(baseline, filteredResult.findings, report.score);
-        console.log(renderComparison(comparison));
+        writeAuxiliaryOutput(renderComparison(comparison));
         logger.log({
           level: comparison.isRegression ? "warn" : "info",
           phase: "baseline",
@@ -383,7 +384,7 @@ program
 
         if (options.gate) {
           const gateResult = evaluateGate(comparison);
-          console.log(renderGateResult(gateResult));
+          writeAuxiliaryOutput(renderGateResult(gateResult));
           if (!gateResult.passed) {
             logger.log({ level: "error", phase: "gate", message: `Gate FAILED: ${gateResult.reasons.join("; ")}` });
             process.exit(3);

--- a/tests/action-baseline.test.ts
+++ b/tests/action-baseline.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  renderBaselineJobSummary,
+  renderMissingBaselineJobSummary,
+  statusForBaselineGate,
+} from "../src/action-baseline.js";
+import type { BaselineComparison, GateResult } from "../src/baseline/index.js";
+import type { Finding } from "../src/types.js";
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: "permissions-wildcard",
+    severity: "high",
+    category: "permissions",
+    title: "Wildcard permission",
+    description: "Wildcard permission is unsafe",
+    file: ".claude/settings.json",
+    evidence: "Bash(*)",
+    ...overrides,
+  };
+}
+
+function makeComparison(
+  overrides: Partial<BaselineComparison> = {}
+): BaselineComparison {
+  return {
+    timestamp: "2026-05-12T12:00:00.000Z",
+    baselineTimestamp: "2026-05-11T12:00:00.000Z",
+    newFindings: [makeFinding()],
+    resolvedFindings: [
+      {
+        id: "old-rule",
+        severity: "medium",
+        category: "hooks",
+        title: "Old hook issue",
+        file: ".claude/settings.json",
+        evidence: "2>/dev/null",
+        fingerprint: "old-rule::.claude/settings.json::2>/dev/null",
+      },
+    ],
+    unchangedCount: 3,
+    scoreDelta: -6,
+    baselineScore: 90,
+    currentScore: 84,
+    isRegression: true,
+    newCriticalCount: 0,
+    newHighCount: 1,
+    ...overrides,
+  };
+}
+
+function makeGateResult(overrides: Partial<GateResult> = {}): GateResult {
+  const comparison = makeComparison();
+  return {
+    passed: false,
+    reasons: ["1 new high finding(s) introduced"],
+    comparison,
+    ...overrides,
+  };
+}
+
+describe("action baseline helpers", () => {
+  it("reports passed or failed baseline status from the gate result", () => {
+    expect(statusForBaselineGate(makeGateResult({ passed: true }))).toBe(
+      "passed"
+    );
+    expect(statusForBaselineGate(makeGateResult({ passed: false }))).toBe(
+      "failed"
+    );
+  });
+
+  it("renders baseline drift details for the GitHub Actions job summary", () => {
+    const comparison = makeComparison();
+    const output = renderBaselineJobSummary(comparison, makeGateResult());
+
+    expect(output).toContain("## AgentShield Baseline Drift");
+    expect(output).toContain("- Status: failed");
+    expect(output).toContain("- Score: 90 -> 84 (-6)");
+    expect(output).toContain("- New findings: 1");
+    expect(output).toContain("- Resolved findings: 1");
+    expect(output).toContain("- Unchanged findings: 3");
+    expect(output).toContain("### Gate Reasons");
+    expect(output).toContain("1 new high finding(s) introduced");
+    expect(output).toContain("Wildcard permission");
+    expect(output).toContain("Old hook issue");
+  });
+
+  it("renders a missing-baseline summary", () => {
+    const output = renderMissingBaselineJobSummary("security/baseline.json");
+
+    expect(output).toContain("## AgentShield Baseline Drift");
+    expect(output).toContain("- Status: missing");
+    expect(output).toContain("- Baseline path: security/baseline.json");
+    expect(output).toContain("Comparison skipped");
+  });
+});

--- a/tests/action.test.ts
+++ b/tests/action.test.ts
@@ -42,6 +42,19 @@ describe("action helpers (logic verification)", () => {
     expect(actionYaml).toContain("policy-violations:");
   });
 
+  it("documents baseline drift inputs and outputs in action.yml", () => {
+    const actionYaml = readFileSync(resolve(process.cwd(), "action.yml"), "utf-8");
+
+    expect(actionYaml).toContain("baseline:");
+    expect(actionYaml).toContain("save-baseline:");
+    expect(actionYaml).toContain("baseline-path:");
+    expect(actionYaml).toContain("baseline-status:");
+    expect(actionYaml).toContain("new-findings:");
+    expect(actionYaml).toContain("resolved-findings:");
+    expect(actionYaml).toContain("unchanged-findings:");
+    expect(actionYaml).toContain("score-delta:");
+  });
+
   describe("escapeAnnotation", () => {
     it("escapes percent signs", () => {
       expect(escapeAnnotation("100%")).toBe("100%25");


### PR DESCRIPTION
## Summary

Expose AgentShield baseline drift as a first-class GitHub Action surface.

## Changes

- document `baseline` and `save-baseline` action inputs plus baseline drift outputs in `action.yml`
- emit `baseline-status`, `new-findings`, `resolved-findings`, `unchanged-findings`, and `score-delta` from the action
- append a baseline drift block to the GitHub Actions job summary, including gate reasons plus new/resolved finding samples
- keep CLI JSON/SARIF stdout machine-readable by writing baseline save/compare/gate text to stderr when the primary report is stdout
- update README/API docs for drift-only workflow usage
- include updated `dist/` action bundle

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test -- tests/action-baseline.test.ts tests/action.test.ts tests/baseline/compare.test.ts tests/action-policy.test.ts`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose AgentShield baseline drift in the GitHub Action to gate on regressions and surface results in CI. Adds simple inputs/outputs, job summary details, and annotations while keeping JSON/SARIF stdout parseable.

- **New Features**
  - Added `baseline` and `save-baseline` inputs and exposed outputs: `baseline-path`, `baseline-status` (`not-run`, `missing`, `passed`, `failed`), `new-findings`, `resolved-findings`, `unchanged-findings`, `score-delta`.
  - Appends a baseline drift block to the job summary with gate reasons and samples; emits annotations for newly introduced findings.
  - When output format is JSON or SARIF, writes baseline save/compare/gate text to stderr so the primary report on stdout remains machine-readable.
  - Updated `README.md` and `API.md`; added tests and included the updated `dist/` action bundle.

- **Migration**
  - To fail only on drift from a saved baseline: set `baseline: "<path>"` and `fail-on-findings: "false"`. Optionally set `save-baseline` to write a new baseline.
  - No action needed if you don’t use baselines; `baseline-status` defaults to `not-run`.

<sup>Written for commit 03d3831135cd6fed60385241eaabdde1e481f63f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added baseline drift detection to compare scan results against saved baselines
  * New CLI options: `--baseline` to load a baseline for comparison and `--save-baseline` to save current results as a new baseline
  * GitHub Action now outputs baseline metrics: new findings, resolved findings, unchanged findings, and score delta
  * Ability to fail workflows only on baseline drift by configuring `fail-on-findings: "false"`

* **Documentation**
  * Updated CLI and GitHub Action documentation with baseline drift examples and configuration guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->