### PR TITLE
ci: disable cache in release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: package-lock.json
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- remove npm cache restore/write from the privileged release workflow
- keep npm provenance publishing and pinned third-party actions unchanged

## Security note

Release jobs hold npm publish credentials and OIDC permissions. Avoiding dependency cache restore in that path reduces cache-poisoning blast radius while keeping normal CI caches intact.

## Validation

- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml OK'"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `npm` dependency caching in the privileged release publish job to reduce cache-poisoning risk. Removed cache options from `actions/setup-node`; normal CI caches, provenance publishing, and pinned third-party actions remain unchanged.

<sup>Written for commit a84ad0edf81d59ac1fc56704d6b865f30b6f5c24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to use explicit npm registry settings and streamlined build pipeline setup.

---

**Note:** This release contains internal infrastructure improvements with no direct impact to end-user functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->