### PR TITLE
fix: redact enterprise tokens from evidence packs

### DIFF
--- a/src/evidence-pack/index.ts
+++ b/src/evidence-pack/index.ts
@@ -239,6 +239,16 @@ function buildReplacements(targetPath: string): ReadonlyArray<[RegExp, string]> 
   const tokenReplacements: ReadonlyArray<[RegExp, string]> = [
     [/\bsk-[A-Za-z0-9_-]{12,}\b/g, "sk-<redacted>"],
     [/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{12,}\b/g, "gh_<redacted>"],
+    [/github_pat_[A-Za-z0-9_]{20,}\b/g, "<redacted-token>"],
+    [/glpat-[A-Za-z0-9_-]{12,}\b/g, "<redacted-token>"],
+    [/npm_[A-Za-z0-9]{20,}\b/g, "<redacted-token>"],
+    [/lin_api_[A-Za-z0-9]{20,}\b/g, "<redacted-token>"],
+    [/(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{12,}\b/g, "<redacted-token>"],
+    [/AIza[0-9A-Za-z_-]{20,}\b/g, "<redacted-token>"],
+    [/hf_[A-Za-z0-9]{20,}\b/g, "<redacted-token>"],
+    [/vercel_[A-Za-z0-9]{20,}\b/g, "<redacted-token>"],
+    [/AKIA[0-9A-Z]{16}\b/g, "<redacted-token>"],
+    [/eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, "<redacted-token>"],
     [/\b(?:xox[baprs]|slack)-[A-Za-z0-9-]{12,}\b/g, "<redacted-token>"],
     [/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, "<redacted-email>"],
   ];

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -183,6 +183,66 @@ describe("writeEvidencePack", () => {
     expect(sarifJson).not.toContain(targetPath);
   });
 
+  it("redacts common enterprise credential families from evidence packs", () => {
+    const targetPath = mkdtempSync(join(tmpdir(), "agentshield-enterprise-secrets-"));
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-evidence-pack-"));
+    const report = makeReport(targetPath);
+    const stripeToken = ["sk", "live", "1234567890abcdefghijklmnop"].join("_");
+    const githubToken = ["github", "pat", "11AAVERYLONGTOKENVALUE", "abcdefghijklmnopqrstuvwxyz0123456789"].join("_");
+    const npmToken = ["npm", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_");
+    const linearToken = ["lin", "api", "abcdefghijklmnopqrstuvwxyz123456"].join("_");
+    const googleToken = ["AI", "zaSyA1234567890abcdefghijklmnopqr"].join("");
+    const jwtToken = [
+      ["eyJ", "hbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"].join(""),
+      "eyJzdWIiOiIxMjM0NTY3ODkwIn0",
+      "signature123456789",
+    ].join(".");
+    report.findings = [
+      {
+        id: "secrets-enterprise-token",
+        severity: "critical",
+        category: "secrets",
+        title: "Enterprise token exposure",
+        description: [
+          `Stripe ${stripeToken}`,
+          `GitHub ${githubToken}`,
+          `npm ${npmToken}`,
+          `Linear ${linearToken}`,
+          `Google ${googleToken}`,
+          `JWT ${jwtToken}`,
+        ].join(" "),
+        file: join(targetPath, ".claude", "settings.json"),
+        evidence: [
+          stripeToken,
+          githubToken,
+          npmToken,
+          linearToken,
+          googleToken,
+          jwtToken,
+        ].join("\n"),
+      },
+    ];
+
+    writeEvidencePack({
+      outputDir,
+      report,
+      supplyChainReport: makeSupplyChainReport(),
+    });
+
+    const reportJson = readFileSync(join(outputDir, "agentshield-report.json"), "utf-8");
+    const sarifJson = readFileSync(join(outputDir, "agentshield-results.sarif"), "utf-8");
+
+    for (const artifact of [reportJson, sarifJson]) {
+      expect(artifact).not.toContain(stripeToken);
+      expect(artifact).not.toContain(githubToken);
+      expect(artifact).not.toContain(npmToken);
+      expect(artifact).not.toContain(linearToken);
+      expect(artifact).not.toContain(googleToken);
+      expect(artifact).not.toContain(jwtToken.split(".")[0]);
+      expect(artifact).toContain("<redacted-token>");
+    }
+  });
+
   it("writes explicit not-run markers for absent optional evidence", () => {
     const targetPath = mkdtempSync(join(tmpdir(), "agentshield-no-optional-target-"));
     const outputDir = mkdtempSync(join(tmpdir(), "agentshield-evidence-pack-"));


### PR DESCRIPTION
## Summary

- expand evidence-pack redaction for enterprise credential families before reports are shared as CI or buyer-review artifacts
- cover GitHub fine-grained PATs, GitLab PATs, npm tokens, Linear API keys, Stripe live/test keys, Google API keys, Hugging Face tokens, Vercel tokens, AWS access key IDs, and JWT-shaped credentials
- add a regression test that builds token-shaped fixtures from safe fragments so push protection is not bypassed or tripped by checked-in fake secrets

## Test plan

- `npx vitest run tests/evidence-pack/evidence-pack.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token and credential redaction in evidence packs to support additional enterprise services and credential formats, including GitHub PATs, npm tokens, OpenAI, Google, AWS keys, and JWT-style tokens.

* **Tests**
  * Added comprehensive tests to verify redaction of common enterprise credentials across JSON and SARIF output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/68)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands evidence-pack secret redaction to cover common enterprise tokens so shared reports and SARIF never leak credentials. Adds a regression test using token-shaped fixtures to verify redaction without triggering push protection.

- **Bug Fixes**
  - Redacts: GitHub fine-grained PATs (`github_pat_*`), GitLab PATs (`glpat-*`), `npm_*`, `lin_api_*`, Stripe `sk|pk|rk_(live|test)_*`, Google `AIza*`, `hf_*`, `vercel_*`, AWS `AKIA*`, and JWTs.

<sup>Written for commit cd640ee4e006efbc1c2e71a799ce5a5775f3fce9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

