### PR TITLE
feat: add corpus accuracy gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Rule-design guidelines:
 When you change rule accuracy, update both:
 - [`false-positive-audit.md`](./false-positive-audit.md) with the new baseline and remaining gaps
 - the targeted regression tests for the specific rule family you changed
+- `agentshield scan --corpus-gate` in CI so the built-in attack corpus must stay fully detected
 - if you are filing a scanner-noise bug, start from the audit doc's [`False-Positive Issue Template`](./false-positive-audit.md#false-positive-issue-template)
 
 #### Reducing False Positives In Practice
@@ -527,6 +528,7 @@ agentshield scan [options]         Scan configuration directory
   --log <path>                     Write structured scan logs to a file
   --log-format <format>            Log format: ndjson or json
   --corpus                         Run built-in attack corpus benchmark
+  --corpus-gate                    Fail if the built-in attack corpus regresses
   --baseline <path>                Compare against a baseline file
   --save-baseline <path>           Save current scan results as a baseline file
   --gate                           Fail on new critical/high findings or score drop

--- a/dist/index.js
+++ b/dist/index.js
@@ -11345,6 +11345,7 @@ var init_vulnerable_configs = __esm({
 var corpus_exports = {};
 __export(corpus_exports, {
   defaultRuleScanFn: () => defaultRuleScanFn,
+  evaluateCorpusGate: () => evaluateCorpusGate,
   getCorpusConfig: () => getCorpusConfig,
   getCorpusConfigs: () => getCorpusConfigs,
   validateCorpus: () => validateCorpus,
@@ -11367,6 +11368,33 @@ function validateCorpus(ruleScanFn, rules) {
     readyForRegressionGate: failed === 0,
     categoryBreakdown: buildCategoryBreakdown(results),
     results
+  };
+}
+function evaluateCorpusGate(validation, options = {}) {
+  const minDetectionRate = options.minDetectionRate ?? 1;
+  const failedConfigs = validation.results.filter((result) => !result.passed);
+  const failedCategories = validation.categoryBreakdown.filter((category) => category.missed > 0);
+  const reasons = [];
+  if (validation.detectionRate < minDetectionRate) {
+    reasons.push(
+      `Detection rate ${formatRate(validation.detectionRate)} is below required ${formatRate(minDetectionRate)}.`
+    );
+  }
+  if (!validation.readyForRegressionGate) {
+    reasons.push(`Missed ${failedConfigs.length} corpus configs.`);
+  }
+  for (const category of failedCategories) {
+    reasons.push(
+      `Category "${category.category}" missed ${category.missed}/${category.totalConfigs} configs.`
+    );
+  }
+  return {
+    passed: reasons.length === 0,
+    minDetectionRate,
+    detectionRate: validation.detectionRate,
+    failedConfigs,
+    failedCategories,
+    reasons
   };
 }
 function validateSingleConfig(config, ruleScanFn, rules) {
@@ -11428,6 +11456,9 @@ function buildCategoryBreakdown(results) {
       detectionRate: counts.total > 0 ? counts.detected / counts.total : 1
     };
   });
+}
+function formatRate(rate) {
+  return `${(rate * 100).toFixed(1)}%`;
 }
 function getCorpusConfigs() {
   return vulnerableConfigs;
@@ -17054,7 +17085,7 @@ function emptySupplyChainReport() {
     }
   };
 }
-program.command("scan").description("Scan a Claude Code configuration directory for security issues").option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)").option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal").option("-o, --output <path>", "Write the primary report output to a file").option("--fix", "Auto-apply safe fixes", false).option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false).option("--stream", "Stream Opus analysis in real-time", false).option("--injection", "Run active prompt injection testing against the config", false).option("--sandbox", "Execute hooks in sandbox and observe behavior", false).option("--taint", "Run taint analysis (data flow tracking)", false).option("--deep", "Run ALL analysis (injection + sandbox + taint + opus)", false).option("--log <path>", "Write structured scan log to file").option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson").option("--corpus", "Run scanner validation against built-in attack corpus", false).option("--baseline <path>", "Compare against a baseline file and report regressions").option("--save-baseline <path>", "Save current scan results as a baseline file").option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false).option("--supply-chain", "Verify MCP npm packages against known-bad list and typosquatting", false).option("--supply-chain-online", "Also query npm registry for metadata (requires network)", false).option("--policy <path>", "Validate against an organization policy file").option("--evidence-pack <dir>", "Write a portable evidence bundle for audits and security reviews").option("--no-evidence-redact", "Disable evidence-pack redaction of local paths, usernames, emails, and token-shaped strings").option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info").option("-v, --verbose", "Show detailed output", false).action(async (options) => {
+program.command("scan").description("Scan a Claude Code configuration directory for security issues").option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)").option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal").option("-o, --output <path>", "Write the primary report output to a file").option("--fix", "Auto-apply safe fixes", false).option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false).option("--stream", "Stream Opus analysis in real-time", false).option("--injection", "Run active prompt injection testing against the config", false).option("--sandbox", "Execute hooks in sandbox and observe behavior", false).option("--taint", "Run taint analysis (data flow tracking)", false).option("--deep", "Run ALL analysis (injection + sandbox + taint + opus)", false).option("--log <path>", "Write structured scan log to file").option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson").option("--corpus", "Run scanner validation against built-in attack corpus", false).option("--corpus-gate", "Run built-in attack corpus and fail if scanner accuracy regresses", false).option("--baseline <path>", "Compare against a baseline file and report regressions").option("--save-baseline <path>", "Save current scan results as a baseline file").option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false).option("--supply-chain", "Verify MCP npm packages against known-bad list and typosquatting", false).option("--supply-chain-online", "Also query npm registry for metadata (requires network)", false).option("--policy <path>", "Validate against an organization policy file").option("--evidence-pack <dir>", "Write a portable evidence bundle for audits and security reviews").option("--no-evidence-redact", "Disable evidence-pack redaction of local paths, usernames, emails, and token-shaped strings").option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info").option("-v, --verbose", "Show detailed output", false).action(async (options) => {
   const targetPath = resolveTargetPath(options.path);
   if (!existsSync11(targetPath)) {
     console.error(`Error: Path does not exist: ${targetPath}`);
@@ -17314,7 +17345,7 @@ Opus analysis failed: ${message}`);
     }
   }
   let corpusResult = null;
-  if (options.corpus) {
+  if (options.corpus || options.corpusGate) {
     logger.log({ level: "info", phase: "corpus", message: "Running corpus validation" });
     corpusResult = await runCorpusValidation(targetPath);
     if (corpusResult) {
@@ -17325,6 +17356,15 @@ Opus analysis failed: ${message}`);
         phase: "corpus",
         message: `Corpus: ${corpusResult.detected}/${corpusResult.totalAttacks} detected (${(corpusResult.detectionRate * 100).toFixed(1)}%)`
       });
+      if (options.corpusGate && !corpusResult.readyForRegressionGate) {
+        const missedAttacks = corpusResult.results.filter((result2) => !result2.detected).map((result2) => result2.attackId).join(", ");
+        const reason = missedAttacks ? `Missed corpus attacks: ${missedAttacks}` : "Corpus validation did not meet the regression gate.";
+        logger.log({ level: "error", phase: "corpus", message: `Gate FAILED: ${reason}` });
+        console.error(`
+  Error: Corpus regression gate failed. ${reason}
+`);
+        process.exit(6);
+      }
     }
   }
   if (options.deep) {

--- a/src/corpus/index.ts
+++ b/src/corpus/index.ts
@@ -36,6 +36,19 @@ export interface CorpusValidation {
   readonly results: ReadonlyArray<CorpusValidationResult>;
 }
 
+export interface CorpusGateOptions {
+  readonly minDetectionRate?: number;
+}
+
+export interface CorpusGateResult {
+  readonly passed: boolean;
+  readonly minDetectionRate: number;
+  readonly detectionRate: number;
+  readonly failedConfigs: ReadonlyArray<CorpusValidationResult>;
+  readonly failedCategories: ReadonlyArray<CorpusCategoryBreakdown>;
+  readonly reasons: ReadonlyArray<string>;
+}
+
 // ─── Scan Function Types ──────────────────────────────────
 
 /**
@@ -84,6 +97,48 @@ export function validateCorpus(ruleScanFn: RuleScanFn, rules: ReadonlyArray<Rule
     readyForRegressionGate: failed === 0,
     categoryBreakdown: buildCategoryBreakdown(results),
     results,
+  };
+}
+
+/**
+ * Evaluate whether the built-in corpus is strong enough to gate a release/CI run.
+ *
+ * The default is intentionally strict: every corpus config must pass. A lower
+ * threshold can be supplied for temporary migration windows while still keeping
+ * the failed configs/categories visible to automation.
+ */
+export function evaluateCorpusGate(
+  validation: CorpusValidation,
+  options: CorpusGateOptions = {}
+): CorpusGateResult {
+  const minDetectionRate = options.minDetectionRate ?? 1;
+  const failedConfigs = validation.results.filter((result) => !result.passed);
+  const failedCategories = validation.categoryBreakdown.filter((category) => category.missed > 0);
+  const reasons: string[] = [];
+
+  if (validation.detectionRate < minDetectionRate) {
+    reasons.push(
+      `Detection rate ${formatRate(validation.detectionRate)} is below required ${formatRate(minDetectionRate)}.`
+    );
+  }
+
+  if (!validation.readyForRegressionGate) {
+    reasons.push(`Missed ${failedConfigs.length} corpus configs.`);
+  }
+
+  for (const category of failedCategories) {
+    reasons.push(
+      `Category "${category.category}" missed ${category.missed}/${category.totalConfigs} configs.`
+    );
+  }
+
+  return {
+    passed: reasons.length === 0,
+    minDetectionRate,
+    detectionRate: validation.detectionRate,
+    failedConfigs,
+    failedCategories,
+    reasons,
   };
 }
 
@@ -170,6 +225,10 @@ function buildCategoryBreakdown(
         detectionRate: counts.total > 0 ? counts.detected / counts.total : 1,
       };
     });
+}
+
+function formatRate(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`;
 }
 
 // ─── Helpers ──────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,7 @@ program
   .option("--log <path>", "Write structured scan log to file")
   .option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson")
   .option("--corpus", "Run scanner validation against built-in attack corpus", false)
+  .option("--corpus-gate", "Run built-in attack corpus and fail if scanner accuracy regresses", false)
   .option("--baseline <path>", "Compare against a baseline file and report regressions")
   .option("--save-baseline <path>", "Save current scan results as a baseline file")
   .option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false)
@@ -575,7 +576,7 @@ program
 
     // ── Phase 7: Corpus validation ──────────────────────────
     let corpusResult: CorpusValidationResult | null = null;
-    if (options.corpus) {
+    if (options.corpus || options.corpusGate) {
       logger.log({ level: "info", phase: "corpus", message: "Running corpus validation" });
       corpusResult = await runCorpusValidation(targetPath);
       if (corpusResult) {
@@ -586,6 +587,19 @@ program
           phase: "corpus",
           message: `Corpus: ${corpusResult.detected}/${corpusResult.totalAttacks} detected (${(corpusResult.detectionRate * 100).toFixed(1)}%)`,
         });
+
+        if (options.corpusGate && !corpusResult.readyForRegressionGate) {
+          const missedAttacks = corpusResult.results
+            .filter((result) => !result.detected)
+            .map((result) => result.attackId)
+            .join(", ");
+          const reason = missedAttacks
+            ? `Missed corpus attacks: ${missedAttacks}`
+            : "Corpus validation did not meet the regression gate.";
+          logger.log({ level: "error", phase: "corpus", message: `Gate FAILED: ${reason}` });
+          console.error(`\n  Error: Corpus regression gate failed. ${reason}\n`);
+          process.exit(6);
+        }
       }
     }
 

--- a/tests/corpus.test.ts
+++ b/tests/corpus.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 import {
   vulnerableConfigs,
   validateCorpus,
+  evaluateCorpusGate,
   getCorpusConfig,
   getCorpusConfigs,
   defaultRuleScanFn,
@@ -13,6 +18,7 @@ import { getBuiltinRules } from "../src/rules/index.js";
 
 // ─── Helpers ──────────────────────────────────────────────
 
+const CLI_PATH = resolve(import.meta.dirname, "../dist/index.js");
 const allRules = getBuiltinRules();
 
 /**
@@ -105,6 +111,34 @@ describe("corpus structure", () => {
         expect(file.path.length).toBeGreaterThan(0);
       }
     }
+  });
+});
+
+// ─── Corpus Gate CLI ──────────────────────────────────────
+
+describe("corpus gate CLI", () => {
+  it("lets CI gate scanner accuracy with --corpus-gate", () => {
+    const targetDir = mkdtempSync(join(tmpdir(), "agentshield-corpus-gate-"));
+    mkdirSync(join(targetDir, ".claude"), { recursive: true });
+
+    const result = spawnSync(process.execPath, [
+      CLI_PATH,
+      "scan",
+      "--path",
+      targetDir,
+      "--corpus-gate",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Corpus Validation");
+    expect(result.stdout).toContain("Regression gate: READY");
   });
 });
 
@@ -249,5 +283,32 @@ describe("validateCorpus", () => {
       expect(result.missingRules.length).toBeGreaterThan(0);
       expect(result.actualFindings).toBe(0);
     }
+  });
+
+  it("passes the corpus gate when every expected finding is covered", () => {
+    const validation = validateCorpus(defaultRuleScanFn, allRules);
+    const gate = evaluateCorpusGate(validation);
+
+    expect(gate.passed).toBe(true);
+    expect(gate.reasons).toEqual([]);
+    expect(gate.failedConfigs).toEqual([]);
+    expect(gate.failedCategories).toEqual([]);
+    expect(gate.detectionRate).toBe(1);
+    expect(gate.minDetectionRate).toBe(1);
+  });
+
+  it("fails the corpus gate with actionable misses when scanner coverage regresses", () => {
+    const emptyFn = () => new Map<string, ReadonlyArray<Finding>>();
+    const validation = validateCorpus(emptyFn, allRules);
+    const gate = evaluateCorpusGate(validation);
+
+    expect(gate.passed).toBe(false);
+    expect(gate.reasons).toContain("Detection rate 0.0% is below required 100.0%.");
+    expect(gate.reasons).toContain(`Missed ${vulnerableConfigs.length} corpus configs.`);
+    expect(gate.failedConfigs.map((config) => config.configId)).toEqual(
+      vulnerableConfigs.map((config) => config.id)
+    );
+    expect(gate.failedCategories.length).toBeGreaterThan(0);
+    expect(gate.failedCategories.every((category) => category.missed > 0)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- add a corpus gate helper that evaluates built-in attack-corpus readiness with actionable failed configs/categories
- add `agentshield scan --corpus-gate` so CI can fail when scanner accuracy regresses
- document the gate in README and rebuild the shipped CLI bundle

## Validation

- `npx vitest run tests/corpus.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run test:batch:misc`
- `npm test`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a corpus accuracy gate so CI can fail when the built-in attack corpus coverage regresses. Introduces `--corpus-gate` in `agentshield scan` and a programmatic `evaluateCorpusGate` helper for stricter accuracy checks.

- **New Features**
  - Added `evaluateCorpusGate(validation, { minDetectionRate })` to assess corpus readiness; default requires 100% detection and returns failed configs/categories with reasons.
  - Added `--corpus-gate` to `agentshield scan` to run corpus validation and exit with code 6 on regression; can be used with `--corpus`.
  - Updated README and rebuilt the CLI bundle.
  - Added tests for the gate (CLI and helper).

- **Migration**
  - Add `agentshield scan --corpus-gate` to CI to block merges on accuracy regressions.
  - For programmatic use, you can lower `minDetectionRate` during rollout; the CLI gate remains strict by default.

<sup>Written for commit 0eac311a2e0868c330e0da5ce3cf4d6770cae3f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--corpus-gate` flag to `agentshield scan` command for CI hardening. When enabled, the scan fails if built-in attack corpus detection regresses, with detailed output of missed attacks.
  * Updated documentation to describe corpus gating functionality.

* **Tests**
  * Added test coverage for corpus gate evaluation and CLI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/70)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->