### PR TITLE
feat: add evidence pack integrity manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,9 +395,12 @@ Requires `ANTHROPIC_API_KEY` environment variable.
 Evidence packs write a deterministic directory containing `manifest.json`,
 `README.md`, `agentshield-report.json`, `agentshield-report.html`,
 `agentshield-results.sarif`, `policy-evaluation.json`,
-`baseline-comparison.json`, and `supply-chain.json`. Redaction is enabled by
-default for local paths, usernames, emails, and token-shaped strings; use
-`--no-evidence-redact` only for private internal bundles.
+`baseline-comparison.json`, `supply-chain.json`, and
+`remediation-plan.json`. The manifest records SHA-256 digests and byte counts
+for bundle artifacts plus a bundle digest over the machine-readable evidence.
+Redaction is enabled by default for local paths, usernames, emails, and
+token-shaped strings; use `--no-evidence-redact` only for private internal
+bundles.
 
 Remediation plans write a JSON queue of findings with stable hashed
 fingerprints, severity, file, fixability, and the recommended next command.

--- a/dist/index.js
+++ b/dist/index.js
@@ -14473,6 +14473,7 @@ function normalizeUri(uri) {
 
 // src/evidence-pack/index.ts
 init_remediation();
+import { createHash as createHash2 } from "crypto";
 import { mkdirSync as mkdirSync2, writeFileSync as writeFileSync2 } from "fs";
 import { basename as basename3, resolve as resolve3 } from "path";
 import { homedir as homedir2 } from "os";
@@ -14523,6 +14524,7 @@ var ARTIFACTS = [
     description: "Stable-fingerprint remediation queue for ticketing and CI handoffs."
   }
 ];
+var BUNDLE_DIGEST_EXCLUDED_FILES = /* @__PURE__ */ new Set(["manifest.json", "README.md"]);
 function writeEvidencePack(options) {
   const outputDir = resolve3(options.outputDir);
   const generatedAt = options.generatedAt ?? (/* @__PURE__ */ new Date()).toISOString();
@@ -14539,39 +14541,77 @@ function writeEvidencePack(options) {
   };
   const supplyChainReport = redactor.value(options.supplyChainReport);
   const remediationPlan = buildRemediationPlan(report, { generatedAt });
-  const manifest = {
+  const artifactContents = /* @__PURE__ */ new Map([
+    ["agentshield-report.json", normalizeText(renderJsonReport(report))],
+    ["agentshield-report.html", normalizeText(renderHtmlReport(report))],
+    [
+      "agentshield-results.sarif",
+      normalizeText(renderSarifReport(report, {
+        policyEvaluation: options.policyEvaluation ? policyEvaluation : void 0,
+        policyUri: options.policyPath ? redactor.string(options.policyPath) : void 0
+      }))
+    ],
+    ["policy-evaluation.json", normalizeText(redactor.json(policyEvaluation))],
+    ["baseline-comparison.json", normalizeText(redactor.json(baselineComparison))],
+    ["supply-chain.json", normalizeText(redactor.json(supplyChainReport))],
+    ["remediation-plan.json", normalizeText(redactor.json(remediationPlan))]
+  ]);
+  const bundleDigest = buildBundleDigest(artifactContents);
+  const readmeManifest = {
     schemaVersion: 1,
     generatedAt,
     generator: "agentshield",
     redacted,
     targetPath: redactor.string(options.report.targetPath),
-    artifacts: ARTIFACTS
+    bundleDigest,
+    artifacts: buildArtifactManifestEntries(artifactContents)
   };
+  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options)));
+  const manifest = {
+    ...readmeManifest,
+    artifacts: buildArtifactManifestEntries(artifactContents)
+  };
+  artifactContents.set("manifest.json", normalizeText(redactor.json(manifest)));
   mkdirSync2(outputDir, { recursive: true });
-  writeText(outputDir, "manifest.json", redactor.json(manifest));
-  writeText(outputDir, "README.md", renderReadme(manifest, options));
-  writeText(outputDir, "agentshield-report.json", renderJsonReport(report));
-  writeText(outputDir, "agentshield-report.html", renderHtmlReport(report));
-  writeText(
-    outputDir,
-    "agentshield-results.sarif",
-    renderSarifReport(report, {
-      policyEvaluation: options.policyEvaluation ? policyEvaluation : void 0,
-      policyUri: options.policyPath ? redactor.string(options.policyPath) : void 0
-    })
-  );
-  writeText(outputDir, "policy-evaluation.json", redactor.json(policyEvaluation));
-  writeText(outputDir, "baseline-comparison.json", redactor.json(baselineComparison));
-  writeText(outputDir, "supply-chain.json", redactor.json(supplyChainReport));
-  writeText(outputDir, "remediation-plan.json", redactor.json(remediationPlan));
+  for (const artifact of ARTIFACTS) {
+    writeText(outputDir, artifact.file, artifactContents.get(artifact.file) ?? "");
+  }
   return {
     outputDir,
     files: ARTIFACTS.map((artifact) => artifact.file)
   };
 }
 function writeText(outputDir, fileName, content) {
-  writeFileSync2(resolve3(outputDir, fileName), content.endsWith("\n") ? content : `${content}
-`);
+  writeFileSync2(resolve3(outputDir, fileName), normalizeText(content));
+}
+function normalizeText(content) {
+  return content.endsWith("\n") ? content : `${content}
+`;
+}
+function buildArtifactManifestEntries(artifactContents) {
+  return ARTIFACTS.map((artifact) => {
+    if (artifact.file === "manifest.json") {
+      return { ...artifact, sha256: null, bytes: null };
+    }
+    const content = artifactContents.get(artifact.file);
+    return content ? { ...artifact, ...hashContent(content) } : { ...artifact, sha256: null, bytes: null };
+  });
+}
+function buildBundleDigest(artifactContents) {
+  const bundleEntries = ARTIFACTS.filter((artifact) => !BUNDLE_DIGEST_EXCLUDED_FILES.has(artifact.file)).map((artifact) => {
+    const content = artifactContents.get(artifact.file);
+    return {
+      file: artifact.file,
+      ...content ? hashContent(content) : { sha256: null, bytes: null }
+    };
+  });
+  return `sha256:${createHash2("sha256").update(JSON.stringify(bundleEntries)).digest("hex")}`;
+}
+function hashContent(content) {
+  return {
+    sha256: createHash2("sha256").update(content).digest("hex"),
+    bytes: Buffer.byteLength(content, "utf8")
+  };
 }
 function renderReadme(manifest, options) {
   const policyStatus = options.policyEvaluation ? options.policyEvaluation.passed ? "passed" : "failed" : "not run";
@@ -14582,6 +14622,7 @@ function renderReadme(manifest, options) {
     `Generated: ${manifest.generatedAt}`,
     `Target: ${manifest.targetPath}`,
     `Redacted: ${manifest.redacted ? "yes" : "no"}`,
+    `Bundle digest: ${manifest.bundleDigest}`,
     "",
     "## Summary",
     "",

--- a/src/evidence-pack/index.ts
+++ b/src/evidence-pack/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -33,11 +34,8 @@ interface EvidencePackManifest {
   readonly generator: "agentshield";
   readonly redacted: boolean;
   readonly targetPath: string;
-  readonly artifacts: ReadonlyArray<{
-    readonly file: string;
-    readonly kind: string;
-    readonly description: string;
-  }>;
+  readonly bundleDigest: string;
+  readonly artifacts: ReadonlyArray<EvidencePackArtifactManifestEntry>;
 }
 
 const ARTIFACTS = [
@@ -88,6 +86,15 @@ const ARTIFACTS = [
   },
 ] as const;
 
+type EvidencePackArtifactDefinition = (typeof ARTIFACTS)[number];
+
+type EvidencePackArtifactManifestEntry = EvidencePackArtifactDefinition & {
+  readonly sha256: string | null;
+  readonly bytes: number | null;
+};
+
+const BUNDLE_DIGEST_EXCLUDED_FILES = new Set(["manifest.json", "README.md"]);
+
 export function writeEvidencePack(options: EvidencePackOptions): EvidencePackResult {
   const outputDir = resolve(options.outputDir);
   const generatedAt = options.generatedAt ?? new Date().toISOString();
@@ -108,33 +115,43 @@ export function writeEvidencePack(options: EvidencePackOptions): EvidencePackRes
       };
   const supplyChainReport = redactor.value(options.supplyChainReport);
   const remediationPlan = buildRemediationPlan(report, { generatedAt });
-  const manifest: EvidencePackManifest = {
+  const artifactContents = new Map<string, string>([
+    ["agentshield-report.json", normalizeText(renderJsonReport(report))],
+    ["agentshield-report.html", normalizeText(renderHtmlReport(report))],
+    [
+      "agentshield-results.sarif",
+      normalizeText(renderSarifReport(report, {
+        policyEvaluation: options.policyEvaluation ? (policyEvaluation as PolicyEvaluation) : undefined,
+        policyUri: options.policyPath ? redactor.string(options.policyPath) : undefined,
+      })),
+    ],
+    ["policy-evaluation.json", normalizeText(redactor.json(policyEvaluation))],
+    ["baseline-comparison.json", normalizeText(redactor.json(baselineComparison))],
+    ["supply-chain.json", normalizeText(redactor.json(supplyChainReport))],
+    ["remediation-plan.json", normalizeText(redactor.json(remediationPlan))],
+  ]);
+  const bundleDigest = buildBundleDigest(artifactContents);
+  const readmeManifest: EvidencePackManifest = {
     schemaVersion: 1,
     generatedAt,
     generator: "agentshield",
     redacted,
     targetPath: redactor.string(options.report.targetPath),
-    artifacts: ARTIFACTS,
+    bundleDigest,
+    artifacts: buildArtifactManifestEntries(artifactContents),
   };
+  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options)));
+  const manifest: EvidencePackManifest = {
+    ...readmeManifest,
+    artifacts: buildArtifactManifestEntries(artifactContents),
+  };
+  artifactContents.set("manifest.json", normalizeText(redactor.json(manifest)));
 
   mkdirSync(outputDir, { recursive: true });
 
-  writeText(outputDir, "manifest.json", redactor.json(manifest));
-  writeText(outputDir, "README.md", renderReadme(manifest, options));
-  writeText(outputDir, "agentshield-report.json", renderJsonReport(report));
-  writeText(outputDir, "agentshield-report.html", renderHtmlReport(report));
-  writeText(
-    outputDir,
-    "agentshield-results.sarif",
-    renderSarifReport(report, {
-      policyEvaluation: options.policyEvaluation ? (policyEvaluation as PolicyEvaluation) : undefined,
-      policyUri: options.policyPath ? redactor.string(options.policyPath) : undefined,
-    })
-  );
-  writeText(outputDir, "policy-evaluation.json", redactor.json(policyEvaluation));
-  writeText(outputDir, "baseline-comparison.json", redactor.json(baselineComparison));
-  writeText(outputDir, "supply-chain.json", redactor.json(supplyChainReport));
-  writeText(outputDir, "remediation-plan.json", redactor.json(remediationPlan));
+  for (const artifact of ARTIFACTS) {
+    writeText(outputDir, artifact.file, artifactContents.get(artifact.file) ?? "");
+  }
 
   return {
     outputDir,
@@ -143,7 +160,46 @@ export function writeEvidencePack(options: EvidencePackOptions): EvidencePackRes
 }
 
 function writeText(outputDir: string, fileName: string, content: string): void {
-  writeFileSync(resolve(outputDir, fileName), content.endsWith("\n") ? content : `${content}\n`);
+  writeFileSync(resolve(outputDir, fileName), normalizeText(content));
+}
+
+function normalizeText(content: string): string {
+  return content.endsWith("\n") ? content : `${content}\n`;
+}
+
+function buildArtifactManifestEntries(
+  artifactContents: ReadonlyMap<string, string>
+): EvidencePackManifest["artifacts"] {
+  return ARTIFACTS.map((artifact) => {
+    if (artifact.file === "manifest.json") {
+      return { ...artifact, sha256: null, bytes: null };
+    }
+
+    const content = artifactContents.get(artifact.file);
+    return content
+      ? { ...artifact, ...hashContent(content) }
+      : { ...artifact, sha256: null, bytes: null };
+  });
+}
+
+function buildBundleDigest(artifactContents: ReadonlyMap<string, string>): string {
+  const bundleEntries = ARTIFACTS
+    .filter((artifact) => !BUNDLE_DIGEST_EXCLUDED_FILES.has(artifact.file))
+    .map((artifact) => {
+      const content = artifactContents.get(artifact.file);
+      return {
+        file: artifact.file,
+        ...(content ? hashContent(content) : { sha256: null, bytes: null }),
+      };
+    });
+  return `sha256:${createHash("sha256").update(JSON.stringify(bundleEntries)).digest("hex")}`;
+}
+
+function hashContent(content: string): { readonly sha256: string; readonly bytes: number } {
+  return {
+    sha256: createHash("sha256").update(content).digest("hex"),
+    bytes: Buffer.byteLength(content, "utf8"),
+  };
 }
 
 function renderReadme(
@@ -163,6 +219,7 @@ function renderReadme(
     `Generated: ${manifest.generatedAt}`,
     `Target: ${manifest.targetPath}`,
     `Redacted: ${manifest.redacted ? "yes" : "no"}`,
+    `Bundle digest: ${manifest.bundleDigest}`,
     "",
     "## Summary",
     "",

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -143,12 +144,32 @@ describe("writeEvidencePack", () => {
       targetPath: "<target-path>",
     });
     expect(manifest.artifacts.map((artifact: { file: string }) => artifact.file)).toEqual(result.files);
+    expect(manifest.bundleDigest).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(manifest.artifacts).toEqual(
+      expect.arrayContaining(
+        result.files
+          .filter((file) => file !== "manifest.json")
+          .map((file) => expect.objectContaining({
+            file,
+            sha256: createHash("sha256")
+              .update(readFileSync(join(outputDir, file), "utf-8"))
+              .digest("hex"),
+            bytes: Buffer.byteLength(readFileSync(join(outputDir, file), "utf-8"), "utf8"),
+          }))
+      )
+    );
+    expect(manifest.artifacts.find((artifact: { file: string }) => artifact.file === "manifest.json")).toMatchObject({
+      file: "manifest.json",
+      sha256: null,
+      bytes: null,
+    });
 
     const readme = readFileSync(join(outputDir, "README.md"), "utf-8");
     expect(readme).toContain("# AgentShield Evidence Pack");
     expect(readme).toContain("Policy: failed");
     expect(readme).toContain("Baseline: regressed");
     expect(readme).toContain("Remediation plan");
+    expect(readme).toContain("Bundle digest:");
 
     const remediationPlan = JSON.parse(readFileSync(join(outputDir, "remediation-plan.json"), "utf-8"));
     expect(remediationPlan.summary.totalFindings).toBe(1);


### PR DESCRIPTION
## Summary
- add SHA-256 digests and byte counts for evidence-pack artifacts in `manifest.json`
- add a bundle digest over the machine-readable evidence files for tamper detection
- document the integrity fields and cover them in evidence-pack tests

## Validation
- `npx vitest run tests/evidence-pack/evidence-pack.test.ts`
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run test:batch:misc`
- `npm test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an integrity manifest to evidence packs with per-file SHA-256 digests and byte counts, plus a `bundleDigest` to detect tampering. README now shows the bundle digest; docs and tests updated.

- New Features
  - `manifest.json` includes `sha256` and `bytes` for each artifact; `manifest.json` itself is recorded with nulls.
  - Adds `bundleDigest` computed over machine-readable artifacts only (excludes `manifest.json` and `README.md`).
  - Ensures deterministic outputs via newline normalization and writes artifacts from a single in-memory map.
  - Updates README to display the bundle digest and documents the new integrity fields; adds tests for digests and byte sizes.

<sup>Written for commit 13e7bc1c6cebfffbb9d73141db4020572932fff5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence bundles now include integrity metadata: a bundle-level digest and per-artifact SHA-256 hashes plus byte counts for verification purposes.

* **Documentation**
  * Clarified evidence bundle manifest structure and reiterated that evidence redaction remains enabled by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/74)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->