### PR TITLE
feat: hash AgentShield baseline fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,11 @@ agentshield baseline write --path .claude --output baseline.json --json
 ```
 
 The baseline command is a first-class wrapper around the existing scan baseline
-format. Use it to create the accepted snapshot, then compare future scans with
+format. New baselines store stable hashed evidence fingerprints and omit raw
+evidence values, so teams can keep baseline snapshots in CI without copying
+token-shaped strings into long-lived artifacts. Existing raw-evidence baselines
+remain comparable during migration. Use it to create the accepted snapshot,
+then compare future scans with
 `agentshield scan --baseline .github/agentshield-baseline.json --gate`.
 
 Runtime monitor lifecycle:

--- a/dist/action.js
+++ b/dist/action.js
@@ -8,6 +8,26 @@ var __export = (target, all) => {
     __defProp(target, name, { get: all[name], enumerable: true });
 };
 
+// src/fingerprint.ts
+import { createHash } from "crypto";
+function fingerprintFinding(finding) {
+  return `${finding.id}::${finding.file}::${evidenceFingerprint(finding.evidence)}`;
+}
+function legacyEvidenceFingerprint(finding) {
+  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
+}
+function evidenceFingerprint(evidence) {
+  if (!evidence) {
+    return "sha256:no-evidence";
+  }
+  return `sha256:${createHash("sha256").update(evidence).digest("hex").slice(0, 16)}`;
+}
+var init_fingerprint = __esm({
+  "src/fingerprint.ts"() {
+    "use strict";
+  }
+});
+
 // src/policy/types.ts
 import { z } from "zod";
 var SeveritySchema, PolicyPackSchema, PolicyExceptionSchema, OrgPolicySchema;
@@ -646,9 +666,6 @@ var init_types2 = __esm({
 import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync5 } from "fs";
 import { dirname as dirname3 } from "path";
 import { mkdirSync as mkdirSync3 } from "fs";
-function fingerprintFinding(finding) {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
 function saveBaseline(findings, score, outputPath) {
   const serialized = {
     version: 1,
@@ -660,7 +677,6 @@ function saveBaseline(findings, score, outputPath) {
       category: f.category,
       title: f.title,
       file: f.file,
-      evidence: f.evidence,
       fingerprint: fingerprintFinding(f)
     }))
   };
@@ -685,16 +701,19 @@ function loadBaseline(baselinePath) {
 }
 function compareBaseline(baseline, currentFindings, currentScore) {
   const baselineFingerprints = new Set(
-    baseline.findings.map((f) => f.fingerprint)
+    baseline.findings.flatMap((finding) => baselineFingerprintsFor(finding))
   );
   const currentFingerprints = new Set(
-    currentFindings.map(fingerprintFinding)
+    currentFindings.flatMap((finding) => [
+      fingerprintFinding(finding),
+      legacyEvidenceFingerprint(finding)
+    ])
   );
   const newFindings = currentFindings.filter(
     (f) => !baselineFingerprints.has(fingerprintFinding(f))
   );
   const resolvedFindings = baseline.findings.filter(
-    (f) => !currentFingerprints.has(f.fingerprint)
+    (f) => baselineFingerprintsFor(f).every((fingerprint) => !currentFingerprints.has(fingerprint))
   );
   const unchangedCount = currentFindings.length - newFindings.length;
   const scoreDelta = currentScore.numericScore - baseline.score.numericScore;
@@ -718,6 +737,14 @@ function compareBaseline(baseline, currentFindings, currentScore) {
     newCriticalCount,
     newHighCount
   };
+}
+function baselineFingerprintsFor(finding) {
+  const fingerprints = /* @__PURE__ */ new Set([finding.fingerprint]);
+  if (finding.evidence !== void 0) {
+    fingerprints.add(fingerprintFinding(finding));
+    fingerprints.add(legacyEvidenceFingerprint(finding));
+  }
+  return [...fingerprints];
 }
 function evaluateGate(comparison, config = DEFAULT_GATE_CONFIG) {
   const reasons = [];
@@ -800,7 +827,9 @@ function renderGateResult(result) {
 var init_compare = __esm({
   "src/baseline/compare.ts"() {
     "use strict";
+    init_fingerprint();
     init_types2();
+    init_fingerprint();
   }
 });
 
@@ -9700,8 +9729,8 @@ import { basename as basename3, resolve as resolve3 } from "path";
 import { homedir as homedir2 } from "os";
 
 // src/remediation/index.ts
+init_fingerprint();
 import { mkdirSync, writeFileSync } from "fs";
-import { createHash } from "crypto";
 import { dirname as dirname2, resolve as resolve2 } from "path";
 var ZERO_BY_SEVERITY = {
   critical: 0,
@@ -9739,7 +9768,7 @@ function buildRemediationPlan(report, options = {}) {
 function toPlanFinding(finding) {
   const autoFixable = finding.fix?.auto === true;
   return {
-    fingerprint: fingerprintFindingForPlan(finding),
+    fingerprint: fingerprintFinding(finding),
     id: finding.id,
     severity: finding.severity,
     category: finding.category,
@@ -9756,10 +9785,6 @@ function toPlanFinding(finding) {
       auto: finding.fix.auto
     } : void 0
   };
-}
-function fingerprintFindingForPlan(finding) {
-  const evidenceHash = finding.evidence ? createHash("sha256").update(finding.evidence).digest("hex").slice(0, 16) : "no-evidence";
-  return `${finding.id}::${finding.file}::sha256:${evidenceHash}`;
 }
 function countBySeverity(findings) {
   const counts = { ...ZERO_BY_SEVERITY };

--- a/dist/index.js
+++ b/dist/index.js
@@ -8957,6 +8957,26 @@ var init_terminal = __esm({
   }
 });
 
+// src/fingerprint.ts
+import { createHash } from "crypto";
+function fingerprintFinding(finding) {
+  return `${finding.id}::${finding.file}::${evidenceFingerprint(finding.evidence)}`;
+}
+function legacyEvidenceFingerprint(finding) {
+  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
+}
+function evidenceFingerprint(evidence) {
+  if (!evidence) {
+    return "sha256:no-evidence";
+  }
+  return `sha256:${createHash("sha256").update(evidence).digest("hex").slice(0, 16)}`;
+}
+var init_fingerprint = __esm({
+  "src/fingerprint.ts"() {
+    "use strict";
+  }
+});
+
 // src/remediation/index.ts
 var remediation_exports = {};
 __export(remediation_exports, {
@@ -8964,7 +8984,6 @@ __export(remediation_exports, {
   writeRemediationPlan: () => writeRemediationPlan
 });
 import { mkdirSync, writeFileSync } from "fs";
-import { createHash } from "crypto";
 import { dirname as dirname2, resolve as resolve2 } from "path";
 function buildRemediationPlan(report, options = {}) {
   const findings = [...report.findings].sort(compareFindings).map((finding) => toPlanFinding(finding));
@@ -9001,7 +9020,7 @@ function writeRemediationPlan(options) {
 function toPlanFinding(finding) {
   const autoFixable = finding.fix?.auto === true;
   return {
-    fingerprint: fingerprintFindingForPlan(finding),
+    fingerprint: fingerprintFinding(finding),
     id: finding.id,
     severity: finding.severity,
     category: finding.category,
@@ -9019,10 +9038,6 @@ function toPlanFinding(finding) {
     } : void 0
   };
 }
-function fingerprintFindingForPlan(finding) {
-  const evidenceHash = finding.evidence ? createHash("sha256").update(finding.evidence).digest("hex").slice(0, 16) : "no-evidence";
-  return `${finding.id}::${finding.file}::sha256:${evidenceHash}`;
-}
 function countBySeverity(findings) {
   const counts = { ...ZERO_BY_SEVERITY };
   for (const finding of findings) {
@@ -9037,6 +9052,7 @@ var ZERO_BY_SEVERITY, SEVERITY_RANK;
 var init_remediation = __esm({
   "src/remediation/index.ts"() {
     "use strict";
+    init_fingerprint();
     ZERO_BY_SEVERITY = {
       critical: 0,
       high: 0,
@@ -12222,9 +12238,6 @@ var init_types2 = __esm({
 import { readFileSync as readFileSync8, writeFileSync as writeFileSync6, existsSync as existsSync11 } from "fs";
 import { dirname as dirname5 } from "path";
 import { mkdirSync as mkdirSync6 } from "fs";
-function fingerprintFinding2(finding) {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
 function saveBaseline(findings, score, outputPath) {
   const serialized = {
     version: 1,
@@ -12236,8 +12249,7 @@ function saveBaseline(findings, score, outputPath) {
       category: f.category,
       title: f.title,
       file: f.file,
-      evidence: f.evidence,
-      fingerprint: fingerprintFinding2(f)
+      fingerprint: fingerprintFinding(f)
     }))
   };
   const dir = dirname5(outputPath);
@@ -12261,16 +12273,19 @@ function loadBaseline(baselinePath) {
 }
 function compareBaseline(baseline2, currentFindings, currentScore) {
   const baselineFingerprints = new Set(
-    baseline2.findings.map((f) => f.fingerprint)
+    baseline2.findings.flatMap((finding) => baselineFingerprintsFor(finding))
   );
   const currentFingerprints = new Set(
-    currentFindings.map(fingerprintFinding2)
+    currentFindings.flatMap((finding) => [
+      fingerprintFinding(finding),
+      legacyEvidenceFingerprint(finding)
+    ])
   );
   const newFindings = currentFindings.filter(
-    (f) => !baselineFingerprints.has(fingerprintFinding2(f))
+    (f) => !baselineFingerprints.has(fingerprintFinding(f))
   );
   const resolvedFindings = baseline2.findings.filter(
-    (f) => !currentFingerprints.has(f.fingerprint)
+    (f) => baselineFingerprintsFor(f).every((fingerprint) => !currentFingerprints.has(fingerprint))
   );
   const unchangedCount = currentFindings.length - newFindings.length;
   const scoreDelta = currentScore.numericScore - baseline2.score.numericScore;
@@ -12294,6 +12309,14 @@ function compareBaseline(baseline2, currentFindings, currentScore) {
     newCriticalCount,
     newHighCount
   };
+}
+function baselineFingerprintsFor(finding) {
+  const fingerprints = /* @__PURE__ */ new Set([finding.fingerprint]);
+  if (finding.evidence !== void 0) {
+    fingerprints.add(fingerprintFinding(finding));
+    fingerprints.add(legacyEvidenceFingerprint(finding));
+  }
+  return [...fingerprints];
 }
 function evaluateGate(comparison, config = DEFAULT_GATE_CONFIG) {
   const reasons = [];
@@ -12376,7 +12399,9 @@ function renderGateResult(result) {
 var init_compare = __esm({
   "src/baseline/compare.ts"() {
     "use strict";
+    init_fingerprint();
     init_types2();
+    init_fingerprint();
   }
 });
 
@@ -12386,7 +12411,7 @@ __export(baseline_exports, {
   DEFAULT_GATE_CONFIG: () => DEFAULT_GATE_CONFIG,
   compareBaseline: () => compareBaseline,
   evaluateGate: () => evaluateGate,
-  fingerprintFinding: () => fingerprintFinding2,
+  fingerprintFinding: () => fingerprintFinding,
   loadBaseline: () => loadBaseline,
   renderComparison: () => renderComparison,
   renderGateResult: () => renderGateResult,
@@ -16499,9 +16524,8 @@ import { watch, existsSync as existsSync5, readdirSync as readdirSync2, statSync
 import { resolve as resolve7 } from "path";
 
 // src/watch/diff.ts
-function fingerprintFinding(finding) {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
+init_fingerprint();
+init_fingerprint();
 function createBaseline(findings, score) {
   const findingIds = new Set(findings.map(fingerprintFinding));
   return {

--- a/src/baseline/compare.ts
+++ b/src/baseline/compare.ts
@@ -1,6 +1,10 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { mkdirSync } from "node:fs";
+import {
+  fingerprintFinding,
+  legacyEvidenceFingerprint,
+} from "../fingerprint.js";
 import type { Finding, SecurityScore } from "../types.js";
 import type {
   SerializedBaseline,
@@ -10,12 +14,7 @@ import type {
 } from "./types.js";
 import { DEFAULT_GATE_CONFIG } from "./types.js";
 
-/**
- * Create a fingerprint for a finding (stable across scans).
- */
-export function fingerprintFinding(finding: Finding): string {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
+export { fingerprintFinding } from "../fingerprint.js";
 
 /**
  * Save current scan results as a baseline file.
@@ -35,7 +34,6 @@ export function saveBaseline(
       category: f.category,
       title: f.title,
       file: f.file,
-      evidence: f.evidence,
       fingerprint: fingerprintFinding(f),
     })),
   };
@@ -77,10 +75,13 @@ export function compareBaseline(
   currentScore: SecurityScore
 ): BaselineComparison {
   const baselineFingerprints = new Set(
-    baseline.findings.map((f) => f.fingerprint)
+    baseline.findings.flatMap((finding) => baselineFingerprintsFor(finding))
   );
   const currentFingerprints = new Set(
-    currentFindings.map(fingerprintFinding)
+    currentFindings.flatMap((finding) => [
+      fingerprintFinding(finding),
+      legacyEvidenceFingerprint(finding),
+    ])
   );
 
   const newFindings = currentFindings.filter(
@@ -88,7 +89,7 @@ export function compareBaseline(
   );
 
   const resolvedFindings = baseline.findings.filter(
-    (f) => !currentFingerprints.has(f.fingerprint)
+    (f) => baselineFingerprintsFor(f).every((fingerprint) => !currentFingerprints.has(fingerprint))
   );
 
   const unchangedCount =
@@ -120,6 +121,19 @@ export function compareBaseline(
     newCriticalCount,
     newHighCount,
   };
+}
+
+function baselineFingerprintsFor(
+  finding: SerializedBaseline["findings"][number]
+): string[] {
+  const fingerprints = new Set<string>([finding.fingerprint]);
+
+  if (finding.evidence !== undefined) {
+    fingerprints.add(fingerprintFinding(finding));
+    fingerprints.add(legacyEvidenceFingerprint(finding));
+  }
+
+  return [...fingerprints];
 }
 
 /**

--- a/src/fingerprint.ts
+++ b/src/fingerprint.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+import type { Finding } from "./types.js";
+
+type FingerprintFinding = Pick<Finding, "id" | "file" | "evidence">;
+
+export function fingerprintFinding(finding: FingerprintFinding): string {
+  return `${finding.id}::${finding.file}::${evidenceFingerprint(finding.evidence)}`;
+}
+
+export function legacyEvidenceFingerprint(finding: FingerprintFinding): string {
+  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
+}
+
+function evidenceFingerprint(evidence: string | undefined): string {
+  if (!evidence) {
+    return "sha256:no-evidence";
+  }
+
+  return `sha256:${createHash("sha256").update(evidence).digest("hex").slice(0, 16)}`;
+}

--- a/src/remediation/index.ts
+++ b/src/remediation/index.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync } from "node:fs";
-import { createHash } from "node:crypto";
 import { dirname, resolve } from "node:path";
+import { fingerprintFinding } from "../fingerprint.js";
 import type { Finding, SecurityReport, Severity } from "../types.js";
 
 export interface RemediationPlanOptions {
@@ -117,7 +117,7 @@ export function writeRemediationPlan(
 function toPlanFinding(finding: Finding): RemediationPlanFinding {
   const autoFixable = finding.fix?.auto === true;
   return {
-    fingerprint: fingerprintFindingForPlan(finding),
+    fingerprint: fingerprintFinding(finding),
     id: finding.id,
     severity: finding.severity,
     category: finding.category,
@@ -138,13 +138,6 @@ function toPlanFinding(finding: Finding): RemediationPlanFinding {
         }
       : undefined,
   };
-}
-
-function fingerprintFindingForPlan(finding: Finding): string {
-  const evidenceHash = finding.evidence
-    ? createHash("sha256").update(finding.evidence).digest("hex").slice(0, 16)
-    : "no-evidence";
-  return `${finding.id}::${finding.file}::sha256:${evidenceHash}`;
 }
 
 function countBySeverity(findings: ReadonlyArray<Finding>): Record<Severity, number> {

--- a/src/watch/diff.ts
+++ b/src/watch/diff.ts
@@ -1,13 +1,8 @@
+import { fingerprintFinding } from "../fingerprint.js";
 import type { Finding, SecurityScore } from "../types.js";
 import type { ScanBaseline, DriftResult } from "./types.js";
 
-/**
- * Generate a fingerprint for a finding that stays stable across scans.
- * Uses id + file + evidence to avoid false drift from ordering changes.
- */
-export function fingerprintFinding(finding: Finding): string {
-  return `${finding.id}::${finding.file}::${finding.evidence ?? ""}`;
-}
+export { fingerprintFinding } from "../fingerprint.js";
 
 /**
  * Create a baseline snapshot from a scan result.

--- a/tests/baseline/compare.test.ts
+++ b/tests/baseline/compare.test.ts
@@ -73,14 +73,15 @@ function cleanup(): void {
 afterEach(cleanup);
 
 describe("fingerprintFinding", () => {
-  it("generates stable fingerprint", () => {
+  it("generates stable hashed fingerprint", () => {
     const f = makeFinding({ id: "X", file: "y.json", evidence: "z" });
-    expect(fingerprintFinding(f)).toBe("X::y.json::z");
+    expect(fingerprintFinding(f)).toMatch(/^X::y\.json::sha256:[a-f0-9]{16}$/);
+    expect(fingerprintFinding(f)).not.toContain("::z");
   });
 
   it("handles missing evidence", () => {
     const f = makeFinding({ id: "X", file: "y.json", evidence: undefined });
-    expect(fingerprintFinding(f)).toBe("X::y.json::");
+    expect(fingerprintFinding(f)).toBe("X::y.json::sha256:no-evidence");
   });
 });
 
@@ -98,7 +99,10 @@ describe("saveBaseline / loadBaseline", () => {
     expect(loaded!.version).toBe(1);
     expect(loaded!.score.numericScore).toBe(85);
     expect(loaded!.findings).toHaveLength(1);
-    expect(loaded!.findings[0].fingerprint).toBe("R1::a.json::ev1");
+    expect(loaded!.findings[0].fingerprint).toMatch(
+      /^R1::a\.json::sha256:[a-f0-9]{16}$/
+    );
+    expect(loaded!.findings[0]).not.toHaveProperty("evidence");
   });
 
   it("creates parent directories", () => {
@@ -144,6 +148,19 @@ describe("compareBaseline", () => {
     expect(result.isRegression).toBe(true);
     expect(result.scoreDelta).toBe(-10);
     expect(result.newHighCount).toBe(1);
+  });
+
+  it("keeps old raw-evidence baselines comparable", () => {
+    const baseline = makeBaseline();
+    const currentFindings = [
+      makeFinding({ id: "R1", file: "a.json", evidence: "ev1" }),
+    ];
+
+    const result = compareBaseline(baseline, currentFindings, makeScore());
+
+    expect(result.newFindings).toHaveLength(0);
+    expect(result.resolvedFindings).toHaveLength(0);
+    expect(result.unchangedCount).toBe(1);
   });
 
   it("detects resolved findings", () => {

--- a/tests/watch/diff.test.ts
+++ b/tests/watch/diff.test.ts
@@ -35,14 +35,15 @@ function makeScore(overrides: Partial<SecurityScore> = {}): SecurityScore {
 }
 
 describe("fingerprintFinding", () => {
-  it("generates a stable fingerprint from id, file, and evidence", () => {
+  it("generates a stable hashed fingerprint from id, file, and evidence", () => {
     const finding = makeFinding({
       id: "SEC-001",
       file: "settings.json",
       evidence: "allow: Bash(*)",
     });
     const fp = fingerprintFinding(finding);
-    expect(fp).toBe("SEC-001::settings.json::allow: Bash(*)");
+    expect(fp).toMatch(/^SEC-001::settings\.json::sha256:[a-f0-9]{16}$/);
+    expect(fp).not.toContain("allow: Bash(*)");
   });
 
   it("handles missing evidence", () => {
@@ -52,7 +53,7 @@ describe("fingerprintFinding", () => {
       evidence: undefined,
     });
     const fp = fingerprintFinding(finding);
-    expect(fp).toBe("SEC-002::mcp.json::");
+    expect(fp).toBe("SEC-002::mcp.json::sha256:no-evidence");
   });
 
   it("produces different fingerprints for different findings", () => {
@@ -81,8 +82,10 @@ describe("createBaseline", () => {
     expect(baseline.findings).toEqual(findings);
     expect(baseline.score).toEqual(score);
     expect(baseline.findingIds.size).toBe(2);
-    expect(baseline.findingIds.has("R1::a.json::ev1")).toBe(true);
-    expect(baseline.findingIds.has("R2::b.json::ev2")).toBe(true);
+    expect([...baseline.findingIds]).toEqual([
+      expect.stringMatching(/^R1::a\.json::sha256:[a-f0-9]{16}$/),
+      expect.stringMatching(/^R2::b\.json::sha256:[a-f0-9]{16}$/),
+    ]);
     expect(baseline.timestamp).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

- add a shared hashed finding fingerprint helper for baseline, watch, and remediation flows
- stop writing raw finding evidence into newly saved baseline snapshots
- preserve compatibility with older raw-evidence baselines during comparison
- document that new baselines omit raw evidence values for CI-safe artifact retention

## Validation

- npm run typecheck
- npx vitest run tests/baseline/*.test.ts tests/watch/diff.test.ts tests/fixer/remediation-plan.test.ts tests/evidence-pack/evidence-pack.test.ts
- npm run lint
- npm run build
- npm test
- npm audit signatures
- npm audit --audit-level=high

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hash finding fingerprints for baselines, watch, and remediation to remove raw evidence from snapshots. Improves CI safety while keeping comparisons compatible with older raw-evidence baselines.

- New Features
  - Introduced `src/fingerprint.ts` with `fingerprintFinding` and `legacyEvidenceFingerprint` (uses `sha256`, 16-char prefix; `sha256:no-evidence` when missing).
  - Baselines now store only hashed `fingerprint` and omit `evidence`.
  - Baseline comparison accepts both hashed and legacy raw-evidence fingerprints to avoid churn.
  - Remediation plan and watch diff switched to the shared hashed fingerprint helper.
  - README updated to note CI-safe baseline storage.

- Migration
  - No action required; existing baselines still compare.
  - New baselines omit raw evidence; regenerate when ready for CI artifact retention.

<sup>Written for commit 5558abde1458a5353082dd454eccc0f346342c57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Baselines now store hashed evidence fingerprints instead of raw values, enabling secure CI snapshots without embedding sensitive token-shaped strings
  * Legacy baselines remain compatible with the new fingerprint-based comparison logic

* **Documentation**
  * Updated baseline command documentation to clarify the new fingerprinting behavior and migration guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/79)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->