### PR TITLE
feat: add corpus accuracy recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Rule-design guidelines:
 When you change rule accuracy, update both:
 - [`false-positive-audit.md`](./false-positive-audit.md) with the new baseline and remaining gaps
 - the targeted regression tests for the specific rule family you changed
-- `agentshield scan --corpus-gate` in CI so the built-in attack corpus must stay fully detected
+- `agentshield scan --corpus-gate` in CI so the built-in attack corpus must stay fully detected; failed corpus gates now include a prioritized accuracy improvement plan by category, missing rule, and missed config
 - if you are filing a scanner-noise bug, start from the audit doc's [`False-Positive Issue Template`](./false-positive-audit.md#false-positive-issue-template)
 
 #### Reducing False Positives In Practice

--- a/dist/index.js
+++ b/dist/index.js
@@ -8812,6 +8812,26 @@ function renderCorpusResults(result) {
     }
     lines.push("");
   }
+  if (result.accuracyRecommendations.length > 0) {
+    lines.push(chalk.bold("  Accuracy Improvement Plan"));
+    lines.push("");
+    for (const recommendation of result.accuracyRecommendations) {
+      const priority = recommendation.priority.toUpperCase();
+      const rate2 = (recommendation.detectionRate * 100).toFixed(0);
+      const priorityColor = recommendation.priority === "critical" ? chalk.red : recommendation.priority === "high" ? chalk.yellow : chalk.cyan;
+      lines.push(
+        `    ${priorityColor(`${priority} ${recommendation.category}`)} (${recommendation.missedConfigs}/${recommendation.totalConfigs} missed, ${rate2}% detected)`
+      );
+      if (recommendation.missingRules.length > 0) {
+        lines.push(chalk.dim(`      Missing rules: ${recommendation.missingRules.join(", ")}`));
+      }
+      if (recommendation.configIds.length > 0) {
+        lines.push(chalk.dim(`      Configs: ${recommendation.configIds.join(", ")}`));
+      }
+      lines.push(chalk.dim(`      Action: ${recommendation.action}`));
+    }
+    lines.push("");
+  }
   return lines.join("\n");
 }
 function renderDeepScanSummary(result) {
@@ -11480,6 +11500,7 @@ function validateCorpus(ruleScanFn, rules) {
     detectionRate,
     readyForRegressionGate: failed === 0,
     categoryBreakdown: buildCategoryBreakdown(results),
+    accuracyRecommendations: buildAccuracyRecommendations(results),
     results
   };
 }
@@ -11507,6 +11528,7 @@ function evaluateCorpusGate(validation, options = {}) {
     detectionRate: validation.detectionRate,
     failedConfigs,
     failedCategories,
+    accuracyRecommendations: validation.accuracyRecommendations,
     reasons
   };
 }
@@ -11569,6 +11591,69 @@ function buildCategoryBreakdown(results) {
       detectionRate: counts.total > 0 ? counts.detected / counts.total : 1
     };
   });
+}
+function buildAccuracyRecommendations(results) {
+  const failedByCategory = /* @__PURE__ */ new Map();
+  for (const result of results) {
+    if (result.passed) {
+      continue;
+    }
+    const current = failedByCategory.get(result.category) ?? [];
+    current.push(result);
+    failedByCategory.set(result.category, current);
+  }
+  return [...failedByCategory.entries()].map(([category, failedResults]) => {
+    const categoryResults = results.filter((result) => result.category === category);
+    const totalConfigs = categoryResults.length;
+    const missedConfigs = failedResults.length;
+    const detected = totalConfigs - missedConfigs;
+    const detectionRate = totalConfigs > 0 ? detected / totalConfigs : 1;
+    const missingRules = uniqueValues(
+      failedResults.flatMap((result) => result.missingRules.map(parseMissingRuleId))
+    );
+    const configIds = failedResults.map((result) => result.configId);
+    return {
+      category,
+      priority: priorityForCorpusGap(detectionRate, missedConfigs),
+      missedConfigs,
+      totalConfigs,
+      detectionRate,
+      configIds,
+      missingRules,
+      action: buildAccuracyRecommendationAction(category, missingRules, configIds)
+    };
+  }).sort(
+    (left, right) => priorityRank(left.priority) - priorityRank(right.priority) || right.missedConfigs - left.missedConfigs || left.detectionRate - right.detectionRate || left.category.localeCompare(right.category)
+  );
+}
+function parseMissingRuleId(missingRule) {
+  return missingRule.split(" ")[0] ?? missingRule;
+}
+function uniqueValues(values) {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+function priorityForCorpusGap(detectionRate, missedConfigs) {
+  if (detectionRate === 0 || missedConfigs >= 3) {
+    return "critical";
+  }
+  if (detectionRate < 0.8 || missedConfigs >= 2) {
+    return "high";
+  }
+  return "medium";
+}
+function priorityRank(priority) {
+  switch (priority) {
+    case "critical":
+      return 0;
+    case "high":
+      return 1;
+    case "medium":
+      return 2;
+  }
+}
+function buildAccuracyRecommendationAction(category, missingRules, configIds) {
+  const ruleScope = missingRules.length > 0 ? `missing rule coverage for ${missingRules.join(", ")}` : `missed configs ${configIds.join(", ")}`;
+  return `Improve ${category} corpus coverage by adding or fixing scanner fixtures and rules for ${ruleScope}.`;
 }
 function formatRate(rate) {
   return `${(rate * 100).toFixed(1)}%`;
@@ -17259,6 +17344,7 @@ async function runCorpusValidation(_targetPath) {
       detectionRate: totalAttacks > 0 ? detected / totalAttacks : 0,
       readyForRegressionGate: validation.readyForRegressionGate,
       categoryBreakdown: validation.categoryBreakdown,
+      accuracyRecommendations: validation.accuracyRecommendations,
       results: validation.results.map((r) => ({
         attackId: r.configId,
         attackName: r.configName,

--- a/src/corpus/index.ts
+++ b/src/corpus/index.ts
@@ -26,6 +26,19 @@ export interface CorpusCategoryBreakdown {
   readonly detectionRate: number;
 }
 
+export type CorpusAccuracyPriority = "critical" | "high" | "medium";
+
+export interface CorpusAccuracyRecommendation {
+  readonly category: string;
+  readonly priority: CorpusAccuracyPriority;
+  readonly missedConfigs: number;
+  readonly totalConfigs: number;
+  readonly detectionRate: number;
+  readonly configIds: ReadonlyArray<string>;
+  readonly missingRules: ReadonlyArray<string>;
+  readonly action: string;
+}
+
 export interface CorpusValidation {
   readonly totalConfigs: number;
   readonly passed: number;
@@ -33,6 +46,7 @@ export interface CorpusValidation {
   readonly detectionRate: number;
   readonly readyForRegressionGate: boolean;
   readonly categoryBreakdown: ReadonlyArray<CorpusCategoryBreakdown>;
+  readonly accuracyRecommendations: ReadonlyArray<CorpusAccuracyRecommendation>;
   readonly results: ReadonlyArray<CorpusValidationResult>;
 }
 
@@ -46,6 +60,7 @@ export interface CorpusGateResult {
   readonly detectionRate: number;
   readonly failedConfigs: ReadonlyArray<CorpusValidationResult>;
   readonly failedCategories: ReadonlyArray<CorpusCategoryBreakdown>;
+  readonly accuracyRecommendations: ReadonlyArray<CorpusAccuracyRecommendation>;
   readonly reasons: ReadonlyArray<string>;
 }
 
@@ -96,6 +111,7 @@ export function validateCorpus(ruleScanFn: RuleScanFn, rules: ReadonlyArray<Rule
     detectionRate,
     readyForRegressionGate: failed === 0,
     categoryBreakdown: buildCategoryBreakdown(results),
+    accuracyRecommendations: buildAccuracyRecommendations(results),
     results,
   };
 }
@@ -138,6 +154,7 @@ export function evaluateCorpusGate(
     detectionRate: validation.detectionRate,
     failedConfigs,
     failedCategories,
+    accuracyRecommendations: validation.accuracyRecommendations,
     reasons,
   };
 }
@@ -225,6 +242,98 @@ function buildCategoryBreakdown(
         detectionRate: counts.total > 0 ? counts.detected / counts.total : 1,
       };
     });
+}
+
+function buildAccuracyRecommendations(
+  results: ReadonlyArray<CorpusValidationResult>
+): ReadonlyArray<CorpusAccuracyRecommendation> {
+  const failedByCategory = new Map<string, CorpusValidationResult[]>();
+
+  for (const result of results) {
+    if (result.passed) {
+      continue;
+    }
+
+    const current = failedByCategory.get(result.category) ?? [];
+    current.push(result);
+    failedByCategory.set(result.category, current);
+  }
+
+  return [...failedByCategory.entries()]
+    .map(([category, failedResults]) => {
+      const categoryResults = results.filter((result) => result.category === category);
+      const totalConfigs = categoryResults.length;
+      const missedConfigs = failedResults.length;
+      const detected = totalConfigs - missedConfigs;
+      const detectionRate = totalConfigs > 0 ? detected / totalConfigs : 1;
+      const missingRules = uniqueValues(
+        failedResults.flatMap((result) => result.missingRules.map(parseMissingRuleId))
+      );
+      const configIds = failedResults.map((result) => result.configId);
+
+      return {
+        category,
+        priority: priorityForCorpusGap(detectionRate, missedConfigs),
+        missedConfigs,
+        totalConfigs,
+        detectionRate,
+        configIds,
+        missingRules,
+        action: buildAccuracyRecommendationAction(category, missingRules, configIds),
+      } satisfies CorpusAccuracyRecommendation;
+    })
+    .sort((left, right) =>
+      priorityRank(left.priority) - priorityRank(right.priority) ||
+      right.missedConfigs - left.missedConfigs ||
+      left.detectionRate - right.detectionRate ||
+      left.category.localeCompare(right.category)
+    );
+}
+
+function parseMissingRuleId(missingRule: string): string {
+  return missingRule.split(" ")[0] ?? missingRule;
+}
+
+function uniqueValues(values: ReadonlyArray<string>): string[] {
+  return [...new Set(values.filter(Boolean))].sort();
+}
+
+function priorityForCorpusGap(
+  detectionRate: number,
+  missedConfigs: number
+): CorpusAccuracyPriority {
+  if (detectionRate === 0 || missedConfigs >= 3) {
+    return "critical";
+  }
+
+  if (detectionRate < 0.8 || missedConfigs >= 2) {
+    return "high";
+  }
+
+  return "medium";
+}
+
+function priorityRank(priority: CorpusAccuracyPriority): number {
+  switch (priority) {
+    case "critical":
+      return 0;
+    case "high":
+      return 1;
+    case "medium":
+      return 2;
+  }
+}
+
+function buildAccuracyRecommendationAction(
+  category: string,
+  missingRules: ReadonlyArray<string>,
+  configIds: ReadonlyArray<string>
+): string {
+  const ruleScope = missingRules.length > 0
+    ? `missing rule coverage for ${missingRules.join(", ")}`
+    : `missed configs ${configIds.join(", ")}`;
+
+  return `Improve ${category} corpus coverage by adding or fixing scanner fixtures and rules for ${ruleScope}.`;
 }
 
 function formatRate(rate: number): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ async function runCorpusValidation(
       detectionRate: totalAttacks > 0 ? detected / totalAttacks : 0,
       readyForRegressionGate: validation.readyForRegressionGate,
       categoryBreakdown: validation.categoryBreakdown,
+      accuracyRecommendations: validation.accuracyRecommendations,
       results: validation.results.map((r: { configId: string; configName: string; passed: boolean; missingRules: ReadonlyArray<string> }) => ({
         attackId: r.configId,
         attackName: r.configName,

--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -425,6 +425,30 @@ export function renderCorpusResults(
     lines.push("");
   }
 
+  if (result.accuracyRecommendations.length > 0) {
+    lines.push(chalk.bold("  Accuracy Improvement Plan"));
+    lines.push("");
+    for (const recommendation of result.accuracyRecommendations) {
+      const priority = recommendation.priority.toUpperCase();
+      const rate = (recommendation.detectionRate * 100).toFixed(0);
+      const priorityColor = recommendation.priority === "critical" ? chalk.red
+        : recommendation.priority === "high" ? chalk.yellow
+        : chalk.cyan;
+      lines.push(
+        `    ${priorityColor(`${priority} ${recommendation.category}`)} ` +
+        `(${recommendation.missedConfigs}/${recommendation.totalConfigs} missed, ${rate}% detected)`
+      );
+      if (recommendation.missingRules.length > 0) {
+        lines.push(chalk.dim(`      Missing rules: ${recommendation.missingRules.join(", ")}`));
+      }
+      if (recommendation.configIds.length > 0) {
+        lines.push(chalk.dim(`      Configs: ${recommendation.configIds.join(", ")}`));
+      }
+      lines.push(chalk.dim(`      Action: ${recommendation.action}`));
+    }
+    lines.push("");
+  }
+
   return lines.join("\n");
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -374,6 +374,7 @@ export interface CorpusValidationResult {
   readonly detectionRate: number;
   readonly readyForRegressionGate: boolean;
   readonly categoryBreakdown: ReadonlyArray<CorpusCategoryBreakdown>;
+  readonly accuracyRecommendations: ReadonlyArray<CorpusAccuracyRecommendation>;
   readonly results: ReadonlyArray<{
     readonly attackId: string;
     readonly attackName: string;
@@ -388,6 +389,17 @@ export interface CorpusCategoryBreakdown {
   readonly detected: number;
   readonly missed: number;
   readonly detectionRate: number;
+}
+
+export interface CorpusAccuracyRecommendation {
+  readonly category: string;
+  readonly priority: "critical" | "high" | "medium";
+  readonly missedConfigs: number;
+  readonly totalConfigs: number;
+  readonly detectionRate: number;
+  readonly configIds: ReadonlyArray<string>;
+  readonly missingRules: ReadonlyArray<string>;
+  readonly action: string;
 }
 
 // ─── Scan Log Entry ───────────────────────────────────────

--- a/tests/corpus.test.ts
+++ b/tests/corpus.test.ts
@@ -311,4 +311,22 @@ describe("validateCorpus", () => {
     expect(gate.failedCategories.length).toBeGreaterThan(0);
     expect(gate.failedCategories.every((category) => category.missed > 0)).toBe(true);
   });
+
+  it("prioritizes corpus accuracy recommendations by missed coverage", () => {
+    const emptyFn = () => new Map<string, ReadonlyArray<Finding>>();
+    const validation = validateCorpus(emptyFn, allRules);
+    const gate = evaluateCorpusGate(validation);
+
+    expect(validation.accuracyRecommendations.length).toBeGreaterThan(0);
+    expect(gate.accuracyRecommendations).toEqual(validation.accuracyRecommendations);
+
+    const firstRecommendation = gate.accuracyRecommendations[0];
+    expect(firstRecommendation.priority).toBe("critical");
+    expect(firstRecommendation.missedConfigs).toBeGreaterThan(0);
+    expect(firstRecommendation.totalConfigs).toBeGreaterThanOrEqual(firstRecommendation.missedConfigs);
+    expect(firstRecommendation.detectionRate).toBe(0);
+    expect(firstRecommendation.configIds.length).toBe(firstRecommendation.missedConfigs);
+    expect(firstRecommendation.missingRules.length).toBeGreaterThan(0);
+    expect(firstRecommendation.action).toContain(firstRecommendation.category);
+  });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -167,6 +167,18 @@ function makeCorpusResult(
       { category: "secrets", totalConfigs: 1, detected: 1, missed: 0, detectionRate: 1 },
       { category: "injection", totalConfigs: 2, detected: 1, missed: 1, detectionRate: 0.5 },
     ],
+    accuracyRecommendations: [
+      {
+        category: "injection",
+        priority: "high",
+        missedConfigs: 1,
+        totalConfigs: 2,
+        detectionRate: 0.5,
+        configIds: ["ATK-050"],
+        missingRules: ["prompt-injection-hidden-instructions"],
+        action: "Improve injection corpus coverage for prompt-injection-hidden-instructions."
+      },
+    ],
     results: [
       { attackId: "ATK-001", attackName: "Hardcoded API key", detected: true, ruleId: "SEC-001" },
       { attackId: "ATK-002", attackName: "Bash(*) wildcard", detected: true, ruleId: "PERM-001" },
@@ -368,6 +380,9 @@ describe("integration", () => {
       expect(output).toContain("Regression gate: FAILED");
       expect(output).toContain("Missed Attacks");
       expect(output).toContain("Indirect prompt injection");
+      expect(output).toContain("Accuracy Improvement Plan");
+      expect(output).toContain("HIGH injection");
+      expect(output).toContain("prompt-injection-hidden-instructions");
     });
 
     it("renderCorpusResults handles perfect detection", () => {
@@ -380,6 +395,7 @@ describe("integration", () => {
         categoryBreakdown: [
           { category: "injection", totalConfigs: 10, detected: 10, missed: 0, detectionRate: 1 },
         ],
+        accuracyRecommendations: [],
         results: [
           { attackId: "ATK-001", attackName: "Test", detected: true, ruleId: "R-001" },
         ],
@@ -504,6 +520,7 @@ describe("integration", () => {
       expect(result.totalAttacks).toBe(50);
       expect(result.detectionRate).toBe(0.94);
       expect(result.categoryBreakdown[0].category).toBe("secrets");
+      expect(result.accuracyRecommendations[0].category).toBe("injection");
       expect(result.readyForRegressionGate).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

- add prioritized corpus accuracy recommendations to validation and gate results
- render an Accuracy Improvement Plan in terminal corpus output when scanner coverage regresses
- document the new corpus-gate remediation signal in the README
- rebuild the published CLI bundle

## Test plan

- `npm run typecheck`
- `npx vitest run tests/corpus.test.ts tests/integration.test.ts`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm audit signatures`
- `npm audit --audit-level=high`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add prioritized corpus accuracy recommendations to corpus validation and gate results. The CLI now prints an Accuracy Improvement Plan to guide fixes when coverage regresses.

- New Features
  - Generate category-level recommendations from failed corpus results with priorities: critical, high, medium.
  - Include missed/total configs, detection rate, missing rules, config IDs, and a suggested action.
  - Expose `accuracyRecommendations` on `CorpusValidation` and `CorpusGateResult` and in public types.
  - Render an "Accuracy Improvement Plan" section in the terminal reporter with color-coded priorities.
  - Update README to document the new corpus-gate remediation signal; add tests; rebuild CLI bundle.

<sup>Written for commit 17932500781c53578dd643d6c613c27be0ece598. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Corpus validation failures now include an Accuracy Improvement Plan with prioritized recommendations organized by category, displaying missed configuration coverage, detection rates, missing rule information, and actionable improvement guidance.

* **Tests**
  * Added test coverage for accuracy recommendations and terminal output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/80)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->