### PR TITLE
feat: add remediation workflow phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,10 @@ token-shaped strings; use `--no-evidence-redact` only for private internal
 bundles.
 
 Remediation plans write a JSON queue of findings with stable hashed
-fingerprints, severity, file, fixability, and the recommended next command.
+fingerprints, severity, file, fixability, ordered workflow phases, and the
+recommended next command. The workflow phases route safe auto-fixes first,
+manual-review findings second, and verification last so maintainers can attach
+the plan to CI tickets without turning every finding into a separate thread.
 They intentionally omit raw evidence and fix before/after values so teams can
 attach the plan to tickets without copying token-shaped strings.
 

--- a/dist/action.js
+++ b/dist/action.js
@@ -9762,6 +9762,7 @@ function buildRemediationPlan(report, options = {}) {
       manualReview: findings.filter((finding) => finding.action === "manual-review").length,
       bySeverity: countBySeverity(report.findings)
     },
+    workflow: buildWorkflow(findings),
     findings
   };
 }
@@ -9792,6 +9793,45 @@ function countBySeverity(findings) {
     counts[finding.severity] += 1;
   }
   return counts;
+}
+function buildWorkflow(findings) {
+  const autoFixable = findings.filter((finding) => finding.action === "auto-fix");
+  const manualReview = findings.filter((finding) => finding.action === "manual-review");
+  const phases = [];
+  if (autoFixable.length > 0) {
+    phases.push({
+      id: "auto-fix",
+      title: "Apply safe auto-fixes",
+      description: "Run the fix engine first for findings explicitly marked auto-fixable, then review the diff before committing.",
+      command: "agentshield scan --fix",
+      findingCount: autoFixable.length,
+      findingFingerprints: autoFixable.map((finding) => finding.fingerprint),
+      blocking: false
+    });
+  }
+  if (manualReview.length > 0) {
+    phases.push({
+      id: "manual-review",
+      title: "Resolve manual findings",
+      description: "Apply the finding-specific remediation notes in source control for items that require maintainer judgment.",
+      command: "Review finding-specific remediation notes in source control.",
+      findingCount: manualReview.length,
+      findingFingerprints: manualReview.map((finding) => finding.fingerprint),
+      blocking: true
+    });
+  }
+  if (findings.length > 0) {
+    phases.push({
+      id: "verify",
+      title: "Verify clean scan",
+      description: "Re-run AgentShield after remediation and gate on the updated result before merging or publishing.",
+      command: "agentshield scan --gate",
+      findingCount: findings.length,
+      findingFingerprints: findings.map((finding) => finding.fingerprint),
+      blocking: true
+    });
+  }
+  return { phases };
 }
 function compareFindings(left, right) {
   return SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity] || left.file.localeCompare(right.file) || left.id.localeCompare(right.id) || (left.evidence ?? "").localeCompare(right.evidence ?? "");

--- a/dist/index.js
+++ b/dist/index.js
@@ -9021,6 +9021,7 @@ function buildRemediationPlan(report, options = {}) {
       manualReview: findings.filter((finding) => finding.action === "manual-review").length,
       bySeverity: countBySeverity(report.findings)
     },
+    workflow: buildWorkflow(findings),
     findings
   };
 }
@@ -9064,6 +9065,45 @@ function countBySeverity(findings) {
     counts[finding.severity] += 1;
   }
   return counts;
+}
+function buildWorkflow(findings) {
+  const autoFixable = findings.filter((finding) => finding.action === "auto-fix");
+  const manualReview = findings.filter((finding) => finding.action === "manual-review");
+  const phases = [];
+  if (autoFixable.length > 0) {
+    phases.push({
+      id: "auto-fix",
+      title: "Apply safe auto-fixes",
+      description: "Run the fix engine first for findings explicitly marked auto-fixable, then review the diff before committing.",
+      command: "agentshield scan --fix",
+      findingCount: autoFixable.length,
+      findingFingerprints: autoFixable.map((finding) => finding.fingerprint),
+      blocking: false
+    });
+  }
+  if (manualReview.length > 0) {
+    phases.push({
+      id: "manual-review",
+      title: "Resolve manual findings",
+      description: "Apply the finding-specific remediation notes in source control for items that require maintainer judgment.",
+      command: "Review finding-specific remediation notes in source control.",
+      findingCount: manualReview.length,
+      findingFingerprints: manualReview.map((finding) => finding.fingerprint),
+      blocking: true
+    });
+  }
+  if (findings.length > 0) {
+    phases.push({
+      id: "verify",
+      title: "Verify clean scan",
+      description: "Re-run AgentShield after remediation and gate on the updated result before merging or publishing.",
+      command: "agentshield scan --gate",
+      findingCount: findings.length,
+      findingFingerprints: findings.map((finding) => finding.fingerprint),
+      blocking: true
+    });
+  }
+  return { phases };
 }
 function compareFindings(left, right) {
   return SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity] || left.file.localeCompare(right.file) || left.id.localeCompare(right.id) || (left.evidence ?? "").localeCompare(right.evidence ?? "");

--- a/src/remediation/index.ts
+++ b/src/remediation/index.ts
@@ -26,6 +26,7 @@ export interface RemediationPlan {
     readonly numericScore: number;
   };
   readonly summary: RemediationPlanSummary;
+  readonly workflow: RemediationWorkflow;
   readonly findings: ReadonlyArray<RemediationPlanFinding>;
 }
 
@@ -53,6 +54,20 @@ export interface RemediationPlanFinding {
     readonly description: string;
     readonly auto: boolean;
   };
+}
+
+export interface RemediationWorkflow {
+  readonly phases: ReadonlyArray<RemediationWorkflowPhase>;
+}
+
+export interface RemediationWorkflowPhase {
+  readonly id: "auto-fix" | "manual-review" | "verify";
+  readonly title: string;
+  readonly description: string;
+  readonly command: string;
+  readonly findingCount: number;
+  readonly findingFingerprints: ReadonlyArray<string>;
+  readonly blocking: boolean;
 }
 
 const ZERO_BY_SEVERITY: Record<Severity, number> = {
@@ -93,6 +108,7 @@ export function buildRemediationPlan(
       manualReview: findings.filter((finding) => finding.action === "manual-review").length,
       bySeverity: countBySeverity(report.findings),
     },
+    workflow: buildWorkflow(findings),
     findings,
   };
 }
@@ -146,6 +162,55 @@ function countBySeverity(findings: ReadonlyArray<Finding>): Record<Severity, num
     counts[finding.severity] += 1;
   }
   return counts;
+}
+
+function buildWorkflow(
+  findings: ReadonlyArray<RemediationPlanFinding>
+): RemediationWorkflow {
+  const autoFixable = findings.filter((finding) => finding.action === "auto-fix");
+  const manualReview = findings.filter((finding) => finding.action === "manual-review");
+  const phases: RemediationWorkflowPhase[] = [];
+
+  if (autoFixable.length > 0) {
+    phases.push({
+      id: "auto-fix",
+      title: "Apply safe auto-fixes",
+      description:
+        "Run the fix engine first for findings explicitly marked auto-fixable, then review the diff before committing.",
+      command: "agentshield scan --fix",
+      findingCount: autoFixable.length,
+      findingFingerprints: autoFixable.map((finding) => finding.fingerprint),
+      blocking: false,
+    });
+  }
+
+  if (manualReview.length > 0) {
+    phases.push({
+      id: "manual-review",
+      title: "Resolve manual findings",
+      description:
+        "Apply the finding-specific remediation notes in source control for items that require maintainer judgment.",
+      command: "Review finding-specific remediation notes in source control.",
+      findingCount: manualReview.length,
+      findingFingerprints: manualReview.map((finding) => finding.fingerprint),
+      blocking: true,
+    });
+  }
+
+  if (findings.length > 0) {
+    phases.push({
+      id: "verify",
+      title: "Verify clean scan",
+      description:
+        "Re-run AgentShield after remediation and gate on the updated result before merging or publishing.",
+      command: "agentshield scan --gate",
+      findingCount: findings.length,
+      findingFingerprints: findings.map((finding) => finding.fingerprint),
+      blocking: true,
+    });
+  }
+
+  return { phases };
 }
 
 function compareFindings(left: Finding, right: Finding): number {

--- a/tests/fixer/remediation-plan.test.ts
+++ b/tests/fixer/remediation-plan.test.ts
@@ -87,6 +87,34 @@ describe("buildRemediationPlan", () => {
       "secrets-hardcoded",
       "permissions-no-deny-list",
     ]);
+    expect(plan.workflow.phases.map((phase) => phase.id)).toEqual([
+      "auto-fix",
+      "manual-review",
+      "verify",
+    ]);
+    expect(plan.workflow.phases[0]).toMatchObject({
+      id: "auto-fix",
+      command: "agentshield scan --fix",
+      findingCount: 1,
+      blocking: false,
+    });
+    expect(plan.workflow.phases[0].findingFingerprints).toEqual([
+      expect.stringMatching(
+        /^secrets-hardcoded::\.claude\/settings\.json::sha256:[a-f0-9]{16}$/
+      ),
+    ]);
+    expect(plan.workflow.phases[1]).toMatchObject({
+      id: "manual-review",
+      command: "Review finding-specific remediation notes in source control.",
+      findingCount: 1,
+      blocking: true,
+    });
+    expect(plan.workflow.phases[2]).toMatchObject({
+      id: "verify",
+      command: "agentshield scan --gate",
+      findingCount: 2,
+      blocking: true,
+    });
     expect(plan.findings[0]).toMatchObject({
       fingerprint: expect.stringMatching(
         /^secrets-hardcoded::\.claude\/settings\.json::sha256:[a-f0-9]{16}$/
@@ -102,6 +130,37 @@ describe("buildRemediationPlan", () => {
     expect(plan.findings[0].fix).not.toHaveProperty("before");
     expect(JSON.stringify(plan)).not.toContain("sk-test-sensitive-value");
     expect(JSON.stringify(plan)).not.toContain("${OPENAI_API_KEY}");
+  });
+
+  it("omits empty workflow phases when only manual remediation is available", () => {
+    const report = makeReport([
+      makeFinding({
+        severity: "high",
+        fix: {
+          description: "Add explicit deny rules for destructive shell commands.",
+          before: "",
+          after: "",
+          auto: false,
+        },
+      }),
+    ]);
+
+    const plan = buildRemediationPlan(report, {
+      generatedAt: "2026-05-13T09:13:00.000Z",
+    });
+
+    expect(plan.workflow.phases.map((phase) => phase.id)).toEqual([
+      "manual-review",
+      "verify",
+    ]);
+    expect(plan.workflow.phases[0]).toMatchObject({
+      findingCount: 1,
+      blocking: true,
+    });
+    expect(plan.workflow.phases[1]).toMatchObject({
+      findingCount: 1,
+      blocking: true,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- add ordered remediation workflow phases to remediation-plan JSON
- route auto-fixable findings first, manual-review findings second, and verification last
- keep workflow references on stable hashed fingerprints only, preserving existing no-raw-evidence behavior
- document the workflow phase semantics in README

## Test plan

- [x] 
 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/fixer/remediation-plan.test.ts (4 tests) 77ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  08:32:53
   Duration  246ms (transform 26ms, setup 0ms, collect 29ms, tests 77ms, environment 0ms, prepare 28ms)
- [x] 
 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/fixer/remediation-plan.test.ts (4 tests) 75ms
 ✓ tests/evidence-pack/evidence-pack.test.ts (7 tests) 159ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  08:32:53
   Duration  357ms (transform 61ms, setup 0ms, collect 78ms, tests 234ms, environment 0ms, prepare 53ms)
- [x] 
 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/fixer/fixer.test.ts (10 tests) 4ms
 ✓ tests/fixer/remediation-plan.test.ts (4 tests) 80ms
 ✓ tests/evidence-pack/evidence-pack.test.ts (7 tests) 172ms

 Test Files  3 passed (3)
      Tests  21 passed (21)
   Start at  08:32:54
   Duration  370ms (transform 75ms, setup 0ms, collect 125ms, tests 255ms, environment 0ms, prepare 82ms)
- [x] 
> ecc-agentshield@1.4.0 typecheck
> tsc --noEmit
- [x] 
> ecc-agentshield@1.4.0 build
> tsup src/index.ts src/action.ts src/miniclaw/index.ts --format esm --dts --clean --no-splitting

CLI Building entry: src/action.ts, src/index.ts, src/miniclaw/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
ESM dist/action.js         435.54 KB
ESM dist/miniclaw/index.js 28.44 KB
ESM dist/index.js          718.76 KB
ESM ⚡️ Build success in 28ms
DTS Build start
DTS ⚡️ Build success in 1535ms
DTS dist/action.d.ts         13.00 B
DTS dist/miniclaw/index.d.ts 22.43 KB
DTS dist/index.d.ts          20.00 B
- [x] 
> ecc-agentshield@1.4.0 lint
> eslint src/
- [x] 
> ecc-agentshield@1.4.0 test
> npm run test:batch:core && npm run test:batch:analysis && npm run test:batch:miniclaw-a && npm run test:batch:miniclaw-b && npm run test:batch:misc


> ecc-agentshield@1.4.0 test:batch:core
> vitest run tests/rules/*.test.ts tests/scanner/*.test.ts tests/reporter/*.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/reporter/json.test.ts (15 tests) 3ms
 ✓ tests/reporter/html.test.ts (16 tests) 14ms
 ✓ tests/rules/prompt-defense.test.ts (5 tests) 4ms
 ✓ tests/reporter/score.test.ts (22 tests) 3ms
 ✓ tests/reporter/sarif.test.ts (6 tests) 3ms
 ✓ tests/scanner/discovery.test.ts (23 tests) 15ms
 ✓ tests/rules/secrets.test.ts (86 tests) 10ms
 ✓ tests/rules/permissions.test.ts (90 tests) 13ms
 ✓ tests/reporter/terminal.test.ts (14 tests) 3ms
 ✓ tests/rules/mcp.test.ts (136 tests) 17ms
 ✓ tests/rules/skills.test.ts (24 tests) 17ms
 ✓ tests/rules/hooks.test.ts (208 tests) 61ms
 ✓ tests/rules/agents.test.ts (264 tests) 57ms
 ✓ tests/scanner/harness-adapters.test.ts (4 tests) 10ms
 ✓ tests/scanner/scanner.test.ts (34 tests) 143ms

 Test Files  15 passed (15)
      Tests  947 passed (947)
   Start at  08:32:59
   Duration  592ms (transform 1.02s, setup 0ms, collect 2.17s, tests 376ms, environment 1ms, prepare 758ms)


> ecc-agentshield@1.4.0 test:batch:analysis
> vitest run tests/integration.test.ts tests/injection.test.ts tests/action.test.ts tests/action-policy.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/action-policy.test.ts (4 tests) 2ms
 ✓ tests/injection.test.ts (52 tests) 12ms
 ✓ tests/action.test.ts (18 tests) 61ms
 ✓ tests/integration.test.ts (23 tests) 63ms

 Test Files  4 passed (4)
      Tests  97 passed (97)
   Start at  08:33:00
   Duration  374ms (transform 169ms, setup 0ms, collect 308ms, tests 138ms, environment 0ms, prepare 120ms)


> ecc-agentshield@1.4.0 test:batch:miniclaw-a
> vitest run tests/miniclaw/index.test.ts tests/miniclaw/server.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/miniclaw/index.test.ts (17 tests) 13ms
 ✓ tests/miniclaw/server.test.ts (21 tests) 35ms

 Test Files  2 passed (2)
      Tests  38 passed (38)
   Start at  08:33:00
   Duration  225ms (transform 60ms, setup 0ms, collect 82ms, tests 48ms, environment 0ms, prepare 51ms)


> ecc-agentshield@1.4.0 test:batch:miniclaw-b
> vitest run tests/miniclaw/cli.test.ts tests/miniclaw/sandbox.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/miniclaw/sandbox.test.ts (28 tests) 16ms
 ✓ tests/miniclaw/cli.test.ts (7 tests) 225ms

 Test Files  2 passed (2)
      Tests  35 passed (35)
   Start at  08:33:01
   Duration  401ms (transform 33ms, setup 0ms, collect 43ms, tests 241ms, environment 0ms, prepare 51ms)


> ecc-agentshield@1.4.0 test:batch:misc
> vitest run tests/corpus.test.ts tests/logger.test.ts tests/init/init.test.ts tests/taint/taint.test.ts tests/opus/*.test.ts tests/fixer/*.test.ts tests/types.test.ts tests/skills/*.test.ts tests/miniclaw/router.test.ts tests/miniclaw/tools.test.ts tests/miniclaw/types.test.ts tests/sandbox/sandbox.test.ts tests/threat-intel/*.test.ts tests/watch/*.test.ts tests/runtime/*.test.ts tests/baseline/*.test.ts tests/evidence-pack/*.test.ts tests/supply-chain/*.test.ts tests/policy/*.test.ts


 RUN  v3.2.4 /Users/affoon/GitHub/ECC/agentshield

 ✓ tests/watch/alerts.test.ts (12 tests) 14ms
 ✓ tests/miniclaw/tools.test.ts (36 tests) 8ms
 ✓ tests/logger.test.ts (27 tests) 13ms
 ✓ tests/skills/health.test.ts (23 tests) 14ms
 ✓ tests/runtime/status.test.ts (7 tests) 9ms
 ✓ tests/runtime/install.test.ts (12 tests) 13ms
 ✓ tests/types.test.ts (10 tests) 96ms
 ✓ tests/fixer/remediation-plan.test.ts (4 tests) 102ms
 ✓ tests/threat-intel/cve-database.test.ts (27 tests) 5ms
 ✓ tests/init/init.test.ts (15 tests) 11ms
 ✓ tests/supply-chain/verify.test.ts (25 tests) 15ms
 ✓ tests/baseline/compare.test.ts (21 tests) 7ms
 ✓ tests/miniclaw/router.test.ts (35 tests) 7ms
 ✓ tests/policy/evaluate.test.ts (27 tests) 8ms
 ✓ tests/taint/taint.test.ts (16 tests) 5ms
 ✓ tests/evidence-pack/evidence-pack.test.ts (7 tests) 228ms
 ✓ tests/runtime/evaluator.test.ts (16 tests) 5ms
 ✓ tests/watch/watcher-fallback.test.ts (1 test) 309ms
   ✓ startWatcher recursive fallback > falls back to per-directory watches when recursive mode is unavailable  308ms
 ✓ tests/watch/watcher-platform.test.ts (1 test) 318ms
   ✓ startWatcher recursive fallback > watches existing directories when recursive watch is unavailable  317ms
 ✓ tests/baseline/cli-command.test.ts (3 tests) 326ms
 ✓ tests/watch/watcher.test.ts (5 tests) 46ms
 ✓ tests/runtime/policy.test.ts (9 tests) 5ms
 ✓ tests/threat-intel/tool-poisoning.test.ts (24 tests) 7ms
 ✓ tests/supply-chain/extract.test.ts (17 tests) 6ms
 ✓ tests/watch/diff.test.ts (12 tests) 4ms
 ✓ tests/policy/presets.test.ts (5 tests) 4ms
 ✓ tests/runtime/repair.test.ts (2 tests) 9ms
 ✓ tests/fixer/fixer.test.ts (10 tests) 4ms
 ✓ tests/opus/prompts.test.ts (12 tests) 2ms
 ✓ tests/threat-intel/cve-mcp-rules.test.ts (9 tests) 3ms
 ✓ tests/miniclaw/types.test.ts (10 tests) 2ms
 ✓ tests/fixer/transforms.test.ts (10 tests) 2ms
 ✓ tests/opus/render.test.ts (11 tests) 3ms
 ✓ tests/opus/structured.test.ts (31 tests) 5ms
 ✓ tests/supply-chain/render.test.ts (7 tests) 10ms
 ✓ tests/corpus.test.ts (77 tests) 309ms
 ✓ tests/sandbox/sandbox.test.ts (43 tests) 1310ms
   ✓ executeHookInSandbox > enforces timeout on long-running commands  503ms
   ✓ analyzeExecution > returns malicious verdict for timeout  307ms

 Test Files  37 passed (37)
      Tests  619 passed (619)
   Start at  08:33:01
   Duration  1.59s (transform 1.20s, setup 0ms, collect 2.82s, tests 3.24s, environment 4ms, prepare 1.57s) (1,736 tests)
- [x] audited 286 packages in 1s

286 packages have verified registry signatures

55 packages have verified attestations
- [x] found 0 vulnerabilities


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ordered remediation workflow phases to the remediation plan JSON. Auto-fixable findings come first, manual review second, and verification last, all keyed by stable hashed fingerprints with no raw evidence.

- **New Features**
  - Adds `workflow.phases` with ordered steps: `auto-fix`, `manual-review`, `verify`, each with `command`, `findingCount`, `findingFingerprints`, and `blocking`.
  - Omits empty phases to keep plans minimal and CI-friendly.
  - Preserves privacy: only stable hashed fingerprints; no raw evidence.
  - Updates README and adds tests for phase ordering and filtering.

<sup>Written for commit 1de6e7bb65956d7a304b56ec1c6d74b4cf704707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remediation plans now include a structured workflow with ordered phases: auto-fix, manual-review, and verify. Safe fixes execute first, followed by manual-review findings, then verification steps.

* **Documentation**
  * Updated remediation plan documentation to clarify the workflow phase ordering and structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/81)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->