### PR TITLE
[codex] add CI provenance to AgentShield evidence packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,8 +397,11 @@ Evidence packs write a deterministic directory containing `manifest.json`,
 `README.md`, `agentshield-report.json`, `agentshield-report.html`,
 `agentshield-results.sarif`, `policy-evaluation.json`,
 `baseline-comparison.json`, `supply-chain.json`, and
-`remediation-plan.json`. The manifest records SHA-256 digests and byte counts
-for bundle artifacts plus a bundle digest over the machine-readable evidence.
+`ci-context.json`, and `remediation-plan.json`. The manifest records SHA-256
+digests and byte counts for bundle artifacts plus a bundle digest over the
+machine-readable evidence. `ci-context.json` records whitelisted GitHub Actions
+workflow, commit, run, and runner provenance without copying arbitrary
+environment variables into the bundle.
 Redaction is enabled by default for local paths, usernames, emails, and
 token-shaped strings; use `--no-evidence-redact` only for private internal
 bundles.

--- a/dist/action.js
+++ b/dist/action.js
@@ -11765,6 +11765,11 @@ var ARTIFACTS = [
     description: "MCP package provenance and supply-chain verification summary."
   },
   {
+    file: "ci-context.json",
+    kind: "ci-context",
+    description: "Whitelisted CI, commit, workflow, and runner provenance for the scan."
+  },
+  {
     file: "remediation-plan.json",
     kind: "remediation",
     description: "Stable-fingerprint remediation queue for ticketing and CI handoffs."
@@ -11786,6 +11791,9 @@ function writeEvidencePack(options) {
     reason: "No --baseline file was provided for this scan."
   };
   const supplyChainReport = redactor.value(options.supplyChainReport);
+  const ciContext = redactor.value(
+    options.ciContext ?? buildCiContext(options.environment ?? process.env, generatedAt)
+  );
   const remediationPlan = buildRemediationPlan(report, { generatedAt });
   const artifactContents = /* @__PURE__ */ new Map([
     ["agentshield-report.json", normalizeText(renderJsonReport(report))],
@@ -11800,6 +11808,7 @@ function writeEvidencePack(options) {
     ["policy-evaluation.json", normalizeText(redactor.json(policyEvaluation))],
     ["baseline-comparison.json", normalizeText(redactor.json(baselineComparison))],
     ["supply-chain.json", normalizeText(redactor.json(supplyChainReport))],
+    ["ci-context.json", normalizeText(redactor.json(ciContext))],
     ["remediation-plan.json", normalizeText(redactor.json(remediationPlan))]
   ]);
   const bundleDigest = buildBundleDigest(artifactContents);
@@ -11812,7 +11821,7 @@ function writeEvidencePack(options) {
     bundleDigest,
     artifacts: buildArtifactManifestEntries(artifactContents)
   };
-  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options)));
+  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options, ciContext)));
   const manifest = {
     ...readmeManifest,
     artifacts: buildArtifactManifestEntries(artifactContents)
@@ -11907,6 +11916,51 @@ function verifyEvidencePack(outputDir) {
     errors
   };
 }
+function buildCiContext(environment, generatedAt) {
+  const github = compact({
+    repository: environment.GITHUB_REPOSITORY,
+    repositoryId: environment.GITHUB_REPOSITORY_ID,
+    workflow: environment.GITHUB_WORKFLOW,
+    workflowRef: environment.GITHUB_WORKFLOW_REF,
+    job: environment.GITHUB_JOB,
+    runId: environment.GITHUB_RUN_ID,
+    runAttempt: environment.GITHUB_RUN_ATTEMPT,
+    runNumber: environment.GITHUB_RUN_NUMBER,
+    actor: environment.GITHUB_ACTOR,
+    eventName: environment.GITHUB_EVENT_NAME,
+    ref: environment.GITHUB_REF,
+    sha: environment.GITHUB_SHA,
+    headRef: environment.GITHUB_HEAD_REF,
+    baseRef: environment.GITHUB_BASE_REF,
+    serverUrl: environment.GITHUB_SERVER_URL
+  });
+  const runtime = {
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    cwd: process.cwd(),
+    ...compact({
+      name: environment.RUNNER_NAME,
+      os: environment.RUNNER_OS,
+      archLabel: environment.RUNNER_ARCH,
+      environment: environment.RUNNER_ENVIRONMENT,
+      temp: environment.RUNNER_TEMP,
+      toolCache: environment.RUNNER_TOOL_CACHE
+    })
+  };
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    provider: environment.GITHUB_ACTIONS === "true" ? "github-actions" : "local",
+    source: "process-environment",
+    github: Object.keys(github).length > 0 ? github : void 0,
+    runtime
+  };
+}
+function compact(value) {
+  const entries = Object.entries(value).filter(([, entryValue]) => typeof entryValue === "string" && entryValue.length > 0);
+  return Object.fromEntries(entries);
+}
 function writeText(outputDir, fileName, content) {
   writeFileSync2(resolve3(outputDir, fileName), normalizeText(content));
 }
@@ -11939,7 +11993,7 @@ function hashContent(content) {
     bytes: Buffer.byteLength(content, "utf8")
   };
 }
-function renderReadme(manifest, options) {
+function renderReadme(manifest, options, ciContext) {
   const policyStatus = options.policyEvaluation ? options.policyEvaluation.passed ? "passed" : "failed" : "not run";
   const baselineStatus = options.baselineComparison ? options.baselineComparison.isRegression ? "regressed" : "passed" : "not run";
   return [
@@ -11960,6 +12014,7 @@ function renderReadme(manifest, options) {
     `- Baseline: ${baselineStatus}`,
     `- Supply-chain packages: ${options.supplyChainReport.totalPackages}`,
     `- Risky packages: ${options.supplyChainReport.riskyPackages}`,
+    `- CI context: ${ciContext.provider}`,
     "- Remediation plan: included",
     "",
     "## Artifacts",
@@ -11975,6 +12030,7 @@ function renderReadme(manifest, options) {
     "- Use `policy-evaluation.json` to confirm organization-policy status.",
     "- Use `baseline-comparison.json` to review drift from the accepted baseline.",
     "- Use `supply-chain.json` to review MCP package provenance and package risk.",
+    "- Use `ci-context.json` to confirm workflow, commit, and runner provenance.",
     "- Use `remediation-plan.json` for stable-fingerprint fix queues and ticket handoffs.",
     "",
     "This bundle is designed for audit handoffs, buyer security reviews, and CI artifacts."

--- a/dist/index.js
+++ b/dist/index.js
@@ -15016,6 +15016,11 @@ var ARTIFACTS = [
     description: "MCP package provenance and supply-chain verification summary."
   },
   {
+    file: "ci-context.json",
+    kind: "ci-context",
+    description: "Whitelisted CI, commit, workflow, and runner provenance for the scan."
+  },
+  {
     file: "remediation-plan.json",
     kind: "remediation",
     description: "Stable-fingerprint remediation queue for ticketing and CI handoffs."
@@ -15037,6 +15042,9 @@ function writeEvidencePack(options) {
     reason: "No --baseline file was provided for this scan."
   };
   const supplyChainReport = redactor.value(options.supplyChainReport);
+  const ciContext = redactor.value(
+    options.ciContext ?? buildCiContext(options.environment ?? process.env, generatedAt)
+  );
   const remediationPlan = buildRemediationPlan(report, { generatedAt });
   const artifactContents = /* @__PURE__ */ new Map([
     ["agentshield-report.json", normalizeText(renderJsonReport(report))],
@@ -15051,6 +15059,7 @@ function writeEvidencePack(options) {
     ["policy-evaluation.json", normalizeText(redactor.json(policyEvaluation))],
     ["baseline-comparison.json", normalizeText(redactor.json(baselineComparison))],
     ["supply-chain.json", normalizeText(redactor.json(supplyChainReport))],
+    ["ci-context.json", normalizeText(redactor.json(ciContext))],
     ["remediation-plan.json", normalizeText(redactor.json(remediationPlan))]
   ]);
   const bundleDigest = buildBundleDigest(artifactContents);
@@ -15063,7 +15072,7 @@ function writeEvidencePack(options) {
     bundleDigest,
     artifacts: buildArtifactManifestEntries(artifactContents)
   };
-  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options)));
+  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options, ciContext)));
   const manifest = {
     ...readmeManifest,
     artifacts: buildArtifactManifestEntries(artifactContents)
@@ -15158,6 +15167,51 @@ function verifyEvidencePack(outputDir) {
     errors
   };
 }
+function buildCiContext(environment, generatedAt) {
+  const github = compact({
+    repository: environment.GITHUB_REPOSITORY,
+    repositoryId: environment.GITHUB_REPOSITORY_ID,
+    workflow: environment.GITHUB_WORKFLOW,
+    workflowRef: environment.GITHUB_WORKFLOW_REF,
+    job: environment.GITHUB_JOB,
+    runId: environment.GITHUB_RUN_ID,
+    runAttempt: environment.GITHUB_RUN_ATTEMPT,
+    runNumber: environment.GITHUB_RUN_NUMBER,
+    actor: environment.GITHUB_ACTOR,
+    eventName: environment.GITHUB_EVENT_NAME,
+    ref: environment.GITHUB_REF,
+    sha: environment.GITHUB_SHA,
+    headRef: environment.GITHUB_HEAD_REF,
+    baseRef: environment.GITHUB_BASE_REF,
+    serverUrl: environment.GITHUB_SERVER_URL
+  });
+  const runtime2 = {
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    cwd: process.cwd(),
+    ...compact({
+      name: environment.RUNNER_NAME,
+      os: environment.RUNNER_OS,
+      archLabel: environment.RUNNER_ARCH,
+      environment: environment.RUNNER_ENVIRONMENT,
+      temp: environment.RUNNER_TEMP,
+      toolCache: environment.RUNNER_TOOL_CACHE
+    })
+  };
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    provider: environment.GITHUB_ACTIONS === "true" ? "github-actions" : "local",
+    source: "process-environment",
+    github: Object.keys(github).length > 0 ? github : void 0,
+    runtime: runtime2
+  };
+}
+function compact(value) {
+  const entries = Object.entries(value).filter(([, entryValue]) => typeof entryValue === "string" && entryValue.length > 0);
+  return Object.fromEntries(entries);
+}
 function writeText(outputDir, fileName, content) {
   writeFileSync2(resolve3(outputDir, fileName), normalizeText(content));
 }
@@ -15190,7 +15244,7 @@ function hashContent(content) {
     bytes: Buffer.byteLength(content, "utf8")
   };
 }
-function renderReadme(manifest, options) {
+function renderReadme(manifest, options, ciContext) {
   const policyStatus = options.policyEvaluation ? options.policyEvaluation.passed ? "passed" : "failed" : "not run";
   const baselineStatus = options.baselineComparison ? options.baselineComparison.isRegression ? "regressed" : "passed" : "not run";
   return [
@@ -15211,6 +15265,7 @@ function renderReadme(manifest, options) {
     `- Baseline: ${baselineStatus}`,
     `- Supply-chain packages: ${options.supplyChainReport.totalPackages}`,
     `- Risky packages: ${options.supplyChainReport.riskyPackages}`,
+    `- CI context: ${ciContext.provider}`,
     "- Remediation plan: included",
     "",
     "## Artifacts",
@@ -15226,6 +15281,7 @@ function renderReadme(manifest, options) {
     "- Use `policy-evaluation.json` to confirm organization-policy status.",
     "- Use `baseline-comparison.json` to review drift from the accepted baseline.",
     "- Use `supply-chain.json` to review MCP package provenance and package risk.",
+    "- Use `ci-context.json` to confirm workflow, commit, and runner provenance.",
     "- Use `remediation-plan.json` for stable-fingerprint fix queues and ticket handoffs.",
     "",
     "This bundle is designed for audit handoffs, buyer security reviews, and CI artifacts."

--- a/src/evidence-pack/index.ts
+++ b/src/evidence-pack/index.ts
@@ -21,6 +21,8 @@ export interface EvidencePackOptions {
   readonly supplyChainReport: SupplyChainReport;
   readonly redact?: boolean;
   readonly generatedAt?: string;
+  readonly ciContext?: EvidencePackCiContext;
+  readonly environment?: EvidencePackEnvironment;
 }
 
 export interface EvidencePackResult {
@@ -45,6 +47,48 @@ export interface EvidencePackVerificationResult {
   readonly artifacts: ReadonlyArray<EvidencePackVerificationArtifact>;
   readonly errors: ReadonlyArray<string>;
 }
+
+export interface EvidencePackCiContext {
+  readonly schemaVersion: 1;
+  readonly generatedAt: string;
+  readonly provider: "github-actions" | "local";
+  readonly source: "provided" | "process-environment";
+  readonly github?: EvidencePackGitHubContext;
+  readonly runtime: EvidencePackRuntimeContext;
+}
+
+export interface EvidencePackGitHubContext {
+  readonly repository?: string;
+  readonly repositoryId?: string;
+  readonly workflow?: string;
+  readonly workflowRef?: string;
+  readonly job?: string;
+  readonly runId?: string;
+  readonly runAttempt?: string;
+  readonly runNumber?: string;
+  readonly actor?: string;
+  readonly eventName?: string;
+  readonly ref?: string;
+  readonly sha?: string;
+  readonly headRef?: string;
+  readonly baseRef?: string;
+  readonly serverUrl?: string;
+}
+
+export interface EvidencePackRuntimeContext {
+  readonly nodeVersion: string;
+  readonly platform: string;
+  readonly arch: string;
+  readonly cwd: string;
+  readonly name?: string;
+  readonly os?: string;
+  readonly archLabel?: string;
+  readonly environment?: string;
+  readonly temp?: string;
+  readonly toolCache?: string;
+}
+
+type EvidencePackEnvironment = Readonly<Record<string, string | undefined>>;
 
 interface EvidencePackManifest {
   readonly schemaVersion: 1;
@@ -98,6 +142,11 @@ const ARTIFACTS = [
     description: "MCP package provenance and supply-chain verification summary.",
   },
   {
+    file: "ci-context.json",
+    kind: "ci-context",
+    description: "Whitelisted CI, commit, workflow, and runner provenance for the scan.",
+  },
+  {
     file: "remediation-plan.json",
     kind: "remediation",
     description: "Stable-fingerprint remediation queue for ticketing and CI handoffs.",
@@ -132,6 +181,9 @@ export function writeEvidencePack(options: EvidencePackOptions): EvidencePackRes
         reason: "No --baseline file was provided for this scan.",
       };
   const supplyChainReport = redactor.value(options.supplyChainReport);
+  const ciContext = redactor.value(
+    options.ciContext ?? buildCiContext(options.environment ?? process.env, generatedAt)
+  ) as EvidencePackCiContext;
   const remediationPlan = buildRemediationPlan(report, { generatedAt });
   const artifactContents = new Map<string, string>([
     ["agentshield-report.json", normalizeText(renderJsonReport(report))],
@@ -146,6 +198,7 @@ export function writeEvidencePack(options: EvidencePackOptions): EvidencePackRes
     ["policy-evaluation.json", normalizeText(redactor.json(policyEvaluation))],
     ["baseline-comparison.json", normalizeText(redactor.json(baselineComparison))],
     ["supply-chain.json", normalizeText(redactor.json(supplyChainReport))],
+    ["ci-context.json", normalizeText(redactor.json(ciContext))],
     ["remediation-plan.json", normalizeText(redactor.json(remediationPlan))],
   ]);
   const bundleDigest = buildBundleDigest(artifactContents);
@@ -158,7 +211,7 @@ export function writeEvidencePack(options: EvidencePackOptions): EvidencePackRes
     bundleDigest,
     artifacts: buildArtifactManifestEntries(artifactContents),
   };
-  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options)));
+  artifactContents.set("README.md", normalizeText(renderReadme(readmeManifest, options, ciContext)));
   const manifest: EvidencePackManifest = {
     ...readmeManifest,
     artifacts: buildArtifactManifestEntries(artifactContents),
@@ -266,6 +319,61 @@ export function verifyEvidencePack(outputDir: string): EvidencePackVerificationR
   };
 }
 
+function buildCiContext(
+  environment: EvidencePackEnvironment,
+  generatedAt: string
+): EvidencePackCiContext {
+  const github = compact({
+    repository: environment.GITHUB_REPOSITORY,
+    repositoryId: environment.GITHUB_REPOSITORY_ID,
+    workflow: environment.GITHUB_WORKFLOW,
+    workflowRef: environment.GITHUB_WORKFLOW_REF,
+    job: environment.GITHUB_JOB,
+    runId: environment.GITHUB_RUN_ID,
+    runAttempt: environment.GITHUB_RUN_ATTEMPT,
+    runNumber: environment.GITHUB_RUN_NUMBER,
+    actor: environment.GITHUB_ACTOR,
+    eventName: environment.GITHUB_EVENT_NAME,
+    ref: environment.GITHUB_REF,
+    sha: environment.GITHUB_SHA,
+    headRef: environment.GITHUB_HEAD_REF,
+    baseRef: environment.GITHUB_BASE_REF,
+    serverUrl: environment.GITHUB_SERVER_URL,
+  });
+
+  const runtime: EvidencePackRuntimeContext = {
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    cwd: process.cwd(),
+    ...compact({
+      name: environment.RUNNER_NAME,
+      os: environment.RUNNER_OS,
+      archLabel: environment.RUNNER_ARCH,
+      environment: environment.RUNNER_ENVIRONMENT,
+      temp: environment.RUNNER_TEMP,
+      toolCache: environment.RUNNER_TOOL_CACHE,
+    }),
+  };
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    provider: environment.GITHUB_ACTIONS === "true" ? "github-actions" : "local",
+    source: "process-environment",
+    github: Object.keys(github).length > 0 ? github : undefined,
+    runtime,
+  };
+}
+
+function compact<T extends Record<string, string | undefined>>(value: T): {
+  readonly [K in keyof T]?: string;
+} {
+  const entries = Object.entries(value)
+    .filter(([, entryValue]) => typeof entryValue === "string" && entryValue.length > 0);
+  return Object.fromEntries(entries) as { readonly [K in keyof T]?: string };
+}
+
 function writeText(outputDir: string, fileName: string, content: string): void {
   writeFileSync(resolve(outputDir, fileName), normalizeText(content));
 }
@@ -311,7 +419,8 @@ function hashContent(content: string): { readonly sha256: string; readonly bytes
 
 function renderReadme(
   manifest: EvidencePackManifest,
-  options: EvidencePackOptions
+  options: EvidencePackOptions,
+  ciContext: EvidencePackCiContext
 ): string {
   const policyStatus = options.policyEvaluation
     ? options.policyEvaluation.passed ? "passed" : "failed"
@@ -338,6 +447,7 @@ function renderReadme(
     `- Baseline: ${baselineStatus}`,
     `- Supply-chain packages: ${options.supplyChainReport.totalPackages}`,
     `- Risky packages: ${options.supplyChainReport.riskyPackages}`,
+    `- CI context: ${ciContext.provider}`,
     "- Remediation plan: included",
     "",
     "## Artifacts",
@@ -353,6 +463,7 @@ function renderReadme(
     "- Use `policy-evaluation.json` to confirm organization-policy status.",
     "- Use `baseline-comparison.json` to review drift from the accepted baseline.",
     "- Use `supply-chain.json` to review MCP package provenance and package risk.",
+    "- Use `ci-context.json` to confirm workflow, commit, and runner provenance.",
     "- Use `remediation-plan.json` for stable-fingerprint fix queues and ticket handoffs.",
     "",
     "This bundle is designed for audit handoffs, buyer security reviews, and CI artifacts.",

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -106,6 +106,33 @@ function makeSupplyChainReport(): SupplyChainReport {
   };
 }
 
+function makeGitHubEnvironment(targetPath: string): Record<string, string> {
+  return {
+    GITHUB_ACTIONS: "true",
+    GITHUB_REPOSITORY: "affaan-m/agentshield",
+    GITHUB_REPOSITORY_ID: "123456789",
+    GITHUB_WORKFLOW: "AgentShield",
+    GITHUB_WORKFLOW_REF: "affaan-m/agentshield/.github/workflows/agentshield.yml@refs/heads/main",
+    GITHUB_JOB: "security",
+    GITHUB_RUN_ID: "987654321",
+    GITHUB_RUN_ATTEMPT: "2",
+    GITHUB_RUN_NUMBER: "42",
+    GITHUB_ACTOR: "security-owner",
+    GITHUB_EVENT_NAME: "pull_request",
+    GITHUB_REF: "refs/pull/12/merge",
+    GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+    GITHUB_HEAD_REF: "feature/evidence-pack",
+    GITHUB_BASE_REF: "main",
+    GITHUB_SERVER_URL: "https://github.com",
+    GITHUB_TOKEN: "ghp_should_never_enter_evidence_pack",
+    RUNNER_NAME: "GitHub Actions 4",
+    RUNNER_OS: "macOS",
+    RUNNER_ARCH: "ARM64",
+    RUNNER_TEMP: join(targetPath, "runner-temp"),
+    RUNNER_TOOL_CACHE: join(targetPath, "tool-cache"),
+  };
+}
+
 describe("writeEvidencePack", () => {
   it("writes a deterministic portable evidence bundle", () => {
     const targetPath = mkdtempSync(join(tmpdir(), "agentshield-target-"));
@@ -120,6 +147,7 @@ describe("writeEvidencePack", () => {
       baselinePath: join(targetPath, ".agentshield", "baseline.json"),
       supplyChainReport: makeSupplyChainReport(),
       generatedAt: "2026-05-13T05:01:00.000Z",
+      environment: makeGitHubEnvironment(targetPath),
     });
 
     expect(result.files).toEqual([
@@ -131,6 +159,7 @@ describe("writeEvidencePack", () => {
       "policy-evaluation.json",
       "baseline-comparison.json",
       "supply-chain.json",
+      "ci-context.json",
       "remediation-plan.json",
     ]);
     expect(readdirSync(outputDir).sort()).toEqual([...result.files].sort());
@@ -173,6 +202,7 @@ describe("writeEvidencePack", () => {
     expect(readme).toContain("Baseline: regressed");
     expect(readme).toContain("Remediation plan");
     expect(readme).toContain("Bundle digest:");
+    expect(readme).toContain("CI context: github-actions");
 
     const remediationPlan = JSON.parse(readFileSync(join(outputDir, "remediation-plan.json"), "utf-8"));
     expect(remediationPlan.summary.totalFindings).toBe(1);
@@ -180,6 +210,29 @@ describe("writeEvidencePack", () => {
       /^secrets-hardcoded-api-key::<target-path>\/\.claude\/settings\.json::sha256:[a-f0-9]{16}$/
     );
     expect(JSON.stringify(remediationPlan)).not.toContain("sk-1234567890abcdef");
+
+    const ciContextRaw = readFileSync(join(outputDir, "ci-context.json"), "utf-8");
+    const ciContext = JSON.parse(ciContextRaw);
+    expect(ciContext).toMatchObject({
+      schemaVersion: 1,
+      generatedAt: "2026-05-13T05:01:00.000Z",
+      provider: "github-actions",
+      source: "process-environment",
+      github: {
+        repository: "affaan-m/agentshield",
+        workflow: "AgentShield",
+        runId: "987654321",
+        runAttempt: "2",
+        sha: "0123456789abcdef0123456789abcdef01234567",
+      },
+      runtime: {
+        os: "macOS",
+        archLabel: "ARM64",
+      },
+    });
+    expect(ciContextRaw).not.toContain("GITHUB_TOKEN");
+    expect(ciContextRaw).not.toContain("ghp_should_never_enter_evidence_pack");
+    expect(ciContextRaw).not.toContain(targetPath);
   });
 
   it("redacts local paths, emails, and token-shaped strings by default", () => {


### PR DESCRIPTION
## Summary
- add ci-context.json to AgentShield evidence packs with whitelisted GitHub Actions, commit, workflow, and runner metadata
- include CI provenance in evidence-pack README summaries and bundle digests
- cover token/env redaction and whitelist behavior in evidence-pack tests

## Validation
- npm run build
- npx vitest run tests/evidence-pack/evidence-pack.test.ts tests/action.test.ts
- npm run typecheck
- npm run lint
- npm test
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI provenance to AgentShield evidence packs via a new `ci-context.json` that captures whitelisted GitHub Actions and runtime details. The artifact is included in the manifest, bundle digest, and README without copying tokens or arbitrary env vars.

- **New Features**
  - Generate `ci-context.json` from process env by default; supports `options.ciContext` or `options.environment` overrides; sets `provider` to "github-actions" when `GITHUB_ACTIONS=true`, else "local", and records `source`.
  - Capture GitHub workflow/commit/run fields and runtime info (Node version, platform, arch, cwd, runner name/OS/arch/temp/toolcache); surfaced in README summary and artifacts list.
  - Tests cover redaction of tokens/paths, whitelisting, runtime fields, and deterministic output.

<sup>Written for commit 78571c07e6661f8b58a49b52fc8a4ba2f09eb159. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/86?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evidence packs now include a `ci-context.json` artifact that records CI provenance (provider, runtime, and selected GitHub Actions metadata) while excluding arbitrary environment variables.

* **Documentation**
  * README updated to document the `ci-context.json` artifact and surface the CI provider in the evidence pack summary and interpretation.

* **Tests**
  * Added tests validating CI context generation, README output, and that sensitive env variables are not included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/86)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->