### PR TITLE
feat: classify plugin cache scan findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,10 @@ Structured JSON under `.claude/subagents/` and `.claude/slash-commands/` is anal
 - Cross-file hook-manifest awareness now suppresses settings-only `hooks-no-pretooluse` when a companion `hooks/hooks.json` manifest defines PreToolUse hooks.
 - Manifest-referenced hook implementations are now discovered from `hooks/hooks.json`-style indirection; shell targets continue through hook rules, and non-shell `hook-code` targets now emit targeted findings for explicit `output(...)` context injection, transcript input access, and remote shell payloads executed via child-process wrappers.
 - Current known high-signal caveats are broader non-shell hook execution that still needs language-aware analysis beyond those current `hook-code` signals, and `skill-md` prompt text that still bypasses most agent/injection rules.
-- `runtimeConfidence` now appears on MCP findings, `settings.local.json`, docs/examples, plugin manifests, and manifest-resolved non-shell hook code. Scoring discounts non-secret `template-example` and `docs-example` findings at `0.25x`, non-secret `project-local-optional` findings at `0.75x`, and non-secret `plugin-manifest` findings at `0.5x`. Non-secret `template-example` findings are also capped at `10` deduction points per file and score category so one catalog file cannot dominate the grade. `hook-code` findings currently stay at full weight, but the active rules there are narrow language-aware implementation signals.
+- `runtimeConfidence` now appears on MCP findings, `settings.local.json`, docs/examples, installed Claude plugin caches, plugin manifests, and manifest-resolved non-shell hook code. Scoring discounts non-secret `template-example` and `docs-example` findings at `0.25x`, non-secret `project-local-optional` findings at `0.75x`, and non-secret `plugin-cache` / `plugin-manifest` findings at `0.5x`. Non-secret `template-example` findings are also capped at `10` deduction points per file and score category so one catalog file cannot dominate the grade. `hook-code` findings currently stay at full weight, but the active rules there are narrow language-aware implementation signals.
 - Practical reading rule: `template-example` means "repo ships this risky template", not "this is definitely enabled right now."
 - Practical reading rule: `docs-example` means "repo ships risky sample guidance", not "this example is active runtime config."
+- Practical reading rule: `plugin-cache` means "installed plugin content is present on disk", not "this file is top-level runtime config"; real secrets still stay critical.
 - Practical reading rule: `plugin-manifest` means "the repo declares this hook behavior", while `hook-code` means "the scanner reached the referenced non-shell implementation."
 - Current edge case: docs-only example trees now re-add the standalone `CLAUDE.md` example file for scanning, but still suppress the rest of the nested example subtree unless a runtime companion exists.
 - Current edge case: tutorial/example bundles outside the current `docs/`, `commands/`, `examples/`, `samples/`, `demo/`, `tutorial/`, `guide/`, `cookbook/`, and `playground/` heuristics can still be treated as live config until broader example-root classification lands.
@@ -260,13 +261,13 @@ jq '.findings
 
 # Lower-confidence inventory that usually needs interpretation, not suppression
 jq '.findings
-  | map(select((.runtimeConfidence // "") | IN("template-example","docs-example","plugin-manifest")))
+  | map(select((.runtimeConfidence // "") | IN("template-example","docs-example","plugin-cache","plugin-manifest")))
   | map({file, severity, runtimeConfidence, title})' report.json
 ```
 
 Recommended audit order:
 - `active-runtime` and `project-local-optional`: treat as highest-signal findings first.
-- `template-example` and `docs-example`: confirm whether the repo is shipping risky guidance versus actually enabling it.
+- `template-example`, `docs-example`, and `plugin-cache`: confirm whether the repo or installed plugin cache is shipping risky guidance versus actually enabling it.
 - `plugin-manifest`: confirm whether the risk is in declarative hook wiring or the referenced implementation.
 - `hook-code`: confirm whether the implementation actually injects context, reads transcripts, or shells out in a risky way.
 
@@ -324,7 +325,7 @@ Repo conventions that help AgentShield scan accurately:
 
 Current high-value places to audit first:
 - files with the highest finding count
-- files with `runtimeConfidence: template-example`
+- files with `runtimeConfidence: template-example` or `plugin-cache`
 - `settings.local.json` findings that may be project-local rather than repo-wide
 - `plugin-manifest` findings that need confirmation in the referenced implementation
 - `hook-code` findings that involve context injection, transcript access, or child-process execution

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ agentshield scan --opus --stream
 agentshield init
 ```
 
-JSON reports now expose `findings[].runtimeConfidence` when AgentShield can distinguish active runtime config from project-local settings, template/example inventories, declarative plugin manifests, and manifest-resolved non-shell hook implementations. Reports also include local harness adapter evidence for Claude Code, OpenCode, Codex, Gemini, dmux, terminal-agent wrappers, and project-local templates when matching markers are present.
+JSON reports now expose `findings[].runtimeConfidence` when AgentShield can distinguish active runtime config from project-local settings, template/example inventories, installed Claude plugin caches, declarative plugin manifests, and manifest-resolved non-shell hook implementations. Reports also include local harness adapter evidence for Claude Code, OpenCode, Codex, Gemini, dmux, terminal-agent wrappers, and project-local templates when matching markers are present.
 
 ## What It Catches
 
@@ -173,7 +173,7 @@ AgentShield scans both active MCP config and repository-shipped MCP templates.
 - Findings from `mcp.json`, `.claude/mcp.json`, `.claude.json`, and active `settings.json` should be treated as the highest-confidence runtime exposure.
 - Findings from `settings.local.json` are emitted as `runtimeConfidence: project-local-optional`.
 - Findings from locations such as `mcp-configs/`, `config/mcp/`, or `configs/mcp/` indicate risky MCP definitions present in repository templates, not guaranteed active runtime enablement.
-- JSON, markdown, terminal, and HTML outputs now expose source context via `runtimeConfidence: active-runtime | project-local-optional | template-example | docs-example | plugin-manifest | hook-code`.
+- JSON, markdown, terminal, and HTML outputs now expose source context via `runtimeConfidence: active-runtime | project-local-optional | template-example | docs-example | plugin-cache | plugin-manifest | hook-code`.
 - Non-secret `template-example` MCP findings are score-weighted at `0.25x`, and one template file is capped at `10` deduction points per score category so a single MCP catalog cannot score like dozens of enabled servers.
 - In template files, findings such as risky server type, remote URL transport, `npx -y`, unpinned packages, and environment inheritance are still valuable, but they should be interpreted as "this repo ships a risky MCP template" rather than "this MCP is definitely enabled right now."
 - Aggregate findings like large MCP server counts are especially likely to overstate runtime exposure when the source file is a template catalog.
@@ -309,9 +309,9 @@ When to open a false-positive issue instead of just triaging the report:
 - the finding would still be misleading even after reading `runtimeConfidence`
 
 Recommended operating model:
-- Start with `runtimeConfidence` before changing any rule. Separate `active-runtime` from `template-example`, `docs-example`, `plugin-manifest`, and `project-local-optional`.
+- Start with `runtimeConfidence` before changing any rule. Separate `active-runtime` from `template-example`, `docs-example`, `plugin-cache`, `plugin-manifest`, and `project-local-optional`.
 - Reclassify before suppressing. If the finding is real but lower confidence, keep it visible and adjust wording or score weight instead of hiding it.
-- Keep secrets on a stricter standard. Real credentials should stay critical even in docs, examples, or manifests.
+- Keep secrets on a stricter standard. Real credentials should stay critical even in docs, examples, plugin caches, or manifests.
 - Use cross-file context whenever possible. Settings, manifests, and referenced hook implementations usually need to be read together.
 - For `hook-code`, add only narrow language-aware rules for explicit risky behavior. Avoid broad wrapper heuristics.
 - For agent rules, anchor on role metadata and lead instructions before matching arbitrary later prose.
@@ -467,16 +467,17 @@ agentshield evidence-pack verify ./agentshield-evidence --json
 ```
 
 Notes:
-- `runtimeConfidence` is emitted for active runtime config, `settings.local.json`, docs/examples, plugin manifests, and manifest-resolved non-shell hook code.
+- `runtimeConfidence` is emitted for active runtime config, `settings.local.json`, docs/examples, installed Claude plugin caches, plugin manifests, and manifest-resolved non-shell hook code.
 - `harnessAdapters` is local marker evidence only. It does not call external services or imply a hosted/team entitlement.
 - Adapter `confidence` is `strong` when a primary harness marker exists, and `partial` when only supporting directories or secondary markers are present.
 - `active-runtime` means active config such as `mcp.json`, `.claude/mcp.json`, `.claude.json`, or active `settings.json`.
 - `project-local-optional` means project-local settings such as `settings.local.json`.
 - `template-example` means template/catalog files such as `mcp-configs/` or `config/mcp/`.
 - `docs-example` means docs/tutorial/example content such as `docs/guide/settings.json` or `commands/*.md`.
+- `plugin-cache` means installed Claude plugin cache content such as `.claude/plugins/cache/...`.
 - `plugin-manifest` means declarative hook manifests such as `hooks/hooks.json`.
 - `hook-code` means a manifest-resolved non-shell implementation such as `scripts/hooks/session-start.js`.
-- Score weighting discounts non-secret `template-example` and `docs-example` findings to `0.25x`, non-secret `project-local-optional` findings to `0.75x`, and non-secret `plugin-manifest` findings to `0.5x`; committed secrets still count at full weight. Non-secret `template-example` findings are also capped at `10` deduction points per file and score category. See [`false-positive-audit.md`](./false-positive-audit.md).
+- Score weighting discounts non-secret `template-example` and `docs-example` findings to `0.25x`, non-secret `project-local-optional` findings to `0.75x`, and non-secret `plugin-cache` / `plugin-manifest` findings to `0.5x`; committed secrets still count at full weight. Non-secret `template-example` findings are also capped at `10` deduction points per file and score category. See [`false-positive-audit.md`](./false-positive-audit.md).
 
 ## API Reference
 

--- a/dist/action.js
+++ b/dist/action.js
@@ -1829,6 +1829,9 @@ var EXAMPLE_LIKE_PATH_PATTERN = new RegExp(
 function isExampleLikePath(path) {
   return EXAMPLE_LIKE_PATH_PATTERN.test(path.replace(/\\/g, "/"));
 }
+function isPluginCachePath(path) {
+  return /(^|\/)(?:\.claude\/)?plugins\/cache(\/|$)/i.test(path.replace(/\\/g, "/"));
+}
 
 // src/scanner/discovery.ts
 var IGNORED_DIRS = /* @__PURE__ */ new Set([
@@ -10097,6 +10100,9 @@ function classifyRuntimeConfidence(file) {
   if (file.type === "hook-code") {
     return "hook-code";
   }
+  if (isPluginCachePath(normalizedPath)) {
+    return "plugin-cache";
+  }
   if (file.type === "settings-json" && /(?:^|\/)(?:\.claude\/)?hooks\/hooks\.json$/i.test(normalizedPath)) {
     return "plugin-manifest";
   }
@@ -10117,6 +10123,8 @@ function adjustFindingForSourceContext(finding) {
   switch (finding.runtimeConfidence) {
     case "docs-example":
       return adjustDocsExampleFinding(finding);
+    case "plugin-cache":
+      return adjustPluginCacheFinding(finding);
     case "plugin-manifest":
       return adjustPluginManifestFinding(finding);
     default:
@@ -10140,6 +10148,25 @@ function adjustDocsExampleFinding(finding) {
       title: prefixTitle(finding.title, "Example config")
     },
     "This finding comes from docs or sample configuration in the repository. It indicates risky guidance or example defaults, not confirmed active runtime exposure."
+  );
+}
+function adjustPluginCacheFinding(finding) {
+  if (finding.category === "secrets") {
+    return withPrefixedDescription(
+      {
+        ...finding,
+        title: prefixTitle(finding.title, "Plugin cache")
+      },
+      "This finding comes from an installed Claude plugin cache. It indicates packaged plugin content present on disk, not confirmed top-level runtime configuration."
+    );
+  }
+  return withPrefixedDescription(
+    {
+      ...finding,
+      severity: downgradeStructuralSeverity(finding.severity),
+      title: prefixTitle(finding.title, "Plugin cache")
+    },
+    "This finding comes from an installed Claude plugin cache. It indicates packaged plugin content present on disk, not confirmed top-level runtime configuration."
   );
 }
 function adjustPluginManifestFinding(finding) {
@@ -10260,6 +10287,9 @@ function confidenceWeight(finding) {
   if (finding.runtimeConfidence === "plugin-manifest" && finding.category !== "secrets") {
     return 0.5;
   }
+  if (finding.runtimeConfidence === "plugin-cache" && finding.category !== "secrets") {
+    return 0.5;
+  }
   return 1;
 }
 function roundedCategoryScore(maxCategoryScore, deduction) {
@@ -10301,6 +10331,8 @@ function formatRuntimeConfidence(value) {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":
@@ -10639,7 +10671,7 @@ function severityToSecurityScore(severity) {
 }
 function precisionForFinding(finding) {
   if (finding.runtimeConfidence === "active-runtime") return "very-high";
-  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example") {
+  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example" || finding.runtimeConfidence === "plugin-cache") {
     return "medium";
   }
   return "high";
@@ -11146,6 +11178,8 @@ function formatRuntimeConfidence2(value) {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":

--- a/dist/action.js
+++ b/dist/action.js
@@ -1826,11 +1826,28 @@ var EXAMPLE_LIKE_PATH_PATTERN = new RegExp(
   `(^|/)(${EXAMPLE_LIKE_SEGMENTS.join("|")})(/|$)`,
   "i"
 );
+var CLAUDE_PLUGIN_CACHE_PATH_PATTERN = /(^|\/)\.claude\/plugins\/cache(\/|$)/i;
+var CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN = /^plugins\/cache(\/|$)/i;
+function findAllMatches(content, pattern) {
+  const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
+  return [...content.matchAll(new RegExp(pattern.source, flags))];
+}
 function isExampleLikePath(path) {
   return EXAMPLE_LIKE_PATH_PATTERN.test(path.replace(/\\/g, "/"));
 }
-function isPluginCachePath(path) {
-  return /(^|\/)(?:\.claude\/)?plugins\/cache(\/|$)/i.test(path.replace(/\\/g, "/"));
+function isPluginCachePath(path, scanRoot) {
+  const normalizedPath = path.replace(/\\/g, "/");
+  if (findAllMatches(normalizedPath, CLAUDE_PLUGIN_CACHE_PATH_PATTERN).length > 0) {
+    return true;
+  }
+  if (!scanRoot || !isClaudeScanRoot(scanRoot)) {
+    return false;
+  }
+  return findAllMatches(normalizedPath, CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN).length > 0;
+}
+function isClaudeScanRoot(scanRoot) {
+  const normalizedRoot = scanRoot.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  return normalizedRoot === ".claude" || normalizedRoot.endsWith("/.claude");
 }
 
 // src/scanner/discovery.ts
@@ -2255,7 +2272,7 @@ var SECRET_PATTERNS = [
 function findLineNumber(content, matchIndex) {
   return content.substring(0, matchIndex).split("\n").length;
 }
-function findAllMatches(content, pattern) {
+function findAllMatches2(content, pattern) {
   const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
   return [...content.matchAll(new RegExp(pattern.source, flags))];
 }
@@ -2344,7 +2361,7 @@ var secretRules = [
     check(file) {
       const findings = [];
       for (const secretPattern of SECRET_PATTERNS) {
-        const matches = findAllMatches(file.content, secretPattern.pattern);
+        const matches = findAllMatches2(file.content, secretPattern.pattern);
         for (const match of matches) {
           const idx = match.index ?? 0;
           const context = file.content.substring(
@@ -2392,7 +2409,7 @@ var secretRules = [
     check(file) {
       const findings = [];
       const echoEnvPattern = /echo\s+.*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|PASS|CRED)\w*\}?/gi;
-      const matches = findAllMatches(file.content, echoEnvPattern);
+      const matches = findAllMatches2(file.content, echoEnvPattern);
       for (const match of matches) {
         findings.push({
           id: `secrets-echo-env-${match.index}`,
@@ -2424,7 +2441,7 @@ var secretRules = [
       if (file.type !== "claude-md") return [];
       const findings = [];
       const envAssignmentPattern = /(?:export\s+)?\b(\w*(?:API_KEY|SECRET_KEY|AUTH_TOKEN|ACCESS_TOKEN|PRIVATE_KEY|PASSWORD|CREDENTIAL|API_SECRET)\w*)\s*[=:]\s*["']?([^\s"']{4,})["']?/gi;
-      const matches = findAllMatches(file.content, envAssignmentPattern);
+      const matches = findAllMatches2(file.content, envAssignmentPattern);
       for (const match of matches) {
         const varName = match[1];
         const idx = match.index ?? 0;
@@ -2502,7 +2519,7 @@ var secretRules = [
       if (file.type !== "agent-md" && file.type !== "claude-md") return [];
       const findings = [];
       const urlCredPattern = /https?:\/\/[^:\s]+:[^@\s]+@[^\s"']+/g;
-      const matches = findAllMatches(file.content, urlCredPattern);
+      const matches = findAllMatches2(file.content, urlCredPattern);
       for (const match of matches) {
         const idx = match.index ?? 0;
         const context = file.content.substring(Math.max(0, idx - 20), idx);
@@ -2568,7 +2585,7 @@ var secretRules = [
         }
       ];
       for (const { pattern, description } of credentialFiles) {
-        const matches = findAllMatches(file.content, pattern);
+        const matches = findAllMatches2(file.content, pattern);
         for (const match of matches) {
           const idx = match.index ?? 0;
           findings.push({
@@ -2605,7 +2622,7 @@ var secretRules = [
         }
       ];
       for (const { pattern, description } of keyPatterns) {
-        const matches = findAllMatches(file.content, pattern);
+        const matches = findAllMatches2(file.content, pattern);
         for (const match of matches) {
           const idx = match.index ?? 0;
           findings.push({
@@ -2652,7 +2669,7 @@ var secretRules = [
         }
       ];
       for (const { pattern, description } of webhookPatterns) {
-        const matches = findAllMatches(file.content, pattern);
+        const matches = findAllMatches2(file.content, pattern);
         for (const match of matches) {
           const idx = match.index ?? 0;
           findings.push({
@@ -2686,7 +2703,7 @@ var secretRules = [
       if (file.type !== "agent-md" && file.type !== "claude-md") return [];
       const findings = [];
       const base64Pattern = /(?<![a-zA-Z0-9/])([A-Za-z0-9+/]{60,}={0,2})(?![a-zA-Z0-9])/g;
-      const matches = findAllMatches(file.content, base64Pattern);
+      const matches = findAllMatches2(file.content, base64Pattern);
       for (const match of matches) {
         const idx = match.index ?? 0;
         const context = file.content.substring(Math.max(0, idx - 30), idx);
@@ -2729,7 +2746,7 @@ var secretRules = [
         }
       ];
       for (const { pattern, description } of ipPatterns) {
-        const matches = findAllMatches(file.content, pattern);
+        const matches = findAllMatches2(file.content, pattern);
         for (const match of matches) {
           const idx = match.index ?? 0;
           findings.push({
@@ -3620,7 +3637,7 @@ var EXFILTRATION_PATTERNS = [
 function findLineNumber3(content, matchIndex) {
   return content.substring(0, matchIndex).split("\n").length;
 }
-function findAllMatches2(content, pattern) {
+function findAllMatches3(content, pattern) {
   return [...content.matchAll(new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g"))];
 }
 function isPluginHookManifest(file) {
@@ -3857,7 +3874,7 @@ function isBlockingGuardCommand(content) {
 function findAllHookMatches(file, pattern) {
   const matches = [];
   for (const target of getHookSearchTargets(file)) {
-    for (const match of findAllMatches2(target.content, pattern)) {
+    for (const match of findAllMatches3(target.content, pattern)) {
       if (file.type === "hook-script" && isCommentOnlyShellMatch(target.content, match.index ?? 0)) {
         continue;
       }
@@ -4016,7 +4033,7 @@ var hookRules = [
       ];
       for (const ioc of AI_TOOL_PERSISTENCE_IOCS) {
         for (const target of searchTargets) {
-          for (const match of findAllMatches2(target.content, ioc.pattern)) {
+          for (const match of findAllMatches3(target.content, ioc.pattern)) {
             const index = match.index ?? 0;
             if (target.source === "content" && isCommentOnlyAutomationMatch(file, target.content, index)) {
               continue;
@@ -7450,7 +7467,7 @@ var toolPoisoningRules = rawToolPoisoningRules;
 function findLineNumber4(content, matchIndex) {
   return content.substring(0, matchIndex).split("\n").length;
 }
-function findAllMatches3(content, pattern) {
+function findAllMatches4(content, pattern) {
   const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
   return [...content.matchAll(new RegExp(pattern.source, flags))];
 }
@@ -7702,7 +7719,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc, severity } of urlExecPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-claude-md-url-exec-${match.index}`,
@@ -7751,7 +7768,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of injectionPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-injection-pattern-${match.index}`,
@@ -7806,7 +7823,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, name, description } of unicodeTricks) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         if (matches.length > 0) {
           findings.push({
             id: `agents-hidden-unicode-${name.replace(/\s/g, "-")}`,
@@ -7931,7 +7948,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of autoRunPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-claude-md-autorun-${match.index}`,
@@ -8037,7 +8054,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of commentPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-comment-injection-${match.index}`,
@@ -8104,7 +8121,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of delegationPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-unrestricted-delegation-${match.index}`,
@@ -8149,7 +8166,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of exfilPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-exfil-instruction-${match.index}`,
@@ -8194,7 +8211,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of urlLoadPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-external-url-${match.index}`,
@@ -8235,7 +8252,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of suppressionPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-security-suppression-${match.index}`,
@@ -8276,7 +8293,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of impersonationPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-identity-impersonation-${match.index}`,
@@ -8317,7 +8334,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of destructionPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-fs-destruction-${match.index}`,
@@ -8358,7 +8375,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of miningPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-crypto-mining-${match.index}`,
@@ -8403,7 +8420,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of timeBombPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-time-bomb-${match.index}`,
@@ -8444,7 +8461,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of harvestingPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-data-harvesting-${match.index}`,
@@ -8485,7 +8502,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of obfuscationPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-obfuscated-code-${match.index}`,
@@ -8526,7 +8543,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of sePatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-social-engineering-${match.index}`,
@@ -8571,7 +8588,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of reflectionPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-reflection-${match.index}`,
@@ -8612,7 +8629,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of outputManipPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-output-manip-${match.index}`,
@@ -8661,7 +8678,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of endSequencePatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-end-sequence-${match.index}`,
@@ -8702,7 +8719,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of linkExfilPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           const url = match[0].toLowerCase();
           if (url.includes("github.com") || url.includes("shields.io") || url.includes("githubusercontent.com")) continue;
@@ -8745,7 +8762,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of russianDollPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-russian-doll-${match.index}`,
@@ -8790,7 +8807,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of encodedPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-encoded-payload-${match.index}`,
@@ -8835,7 +8852,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of toolPoisoningPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-tool-poisoning-${match.index}`,
@@ -8876,7 +8893,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of probingPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-env-probing-${match.index}`,
@@ -8925,7 +8942,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of persistencePatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-persistence-${match.index}`,
@@ -8974,7 +8991,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of privescPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-privesc-${match.index}`,
@@ -9019,7 +9036,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of allowlistPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-allowlist-bypass-${match.index}`,
@@ -9064,7 +9081,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of skillTamperPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-skill-tamper-${match.index}`,
@@ -9105,7 +9122,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of leakagePatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-config-secret-leak-${match.index}`,
@@ -9146,7 +9163,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of outputSecretPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-secrets-in-output-${match.index}`,
@@ -9188,7 +9205,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of extractionPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-prompt-extraction-${match.index}`,
@@ -9237,7 +9254,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of framingPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-jailbreak-framing-${match.index}`,
@@ -9282,7 +9299,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of rolePatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-role-hijacking-${match.index}`,
@@ -9327,7 +9344,7 @@ var agentRules = [
         }
       ];
       for (const { pattern, desc } of destructiveToolPatterns) {
-        const matches = findAllMatches3(file.content, pattern);
+        const matches = findAllMatches4(file.content, pattern);
         for (const match of matches) {
           findings.push({
             id: `agents-destructive-tool-${match.index}`,
@@ -10069,12 +10086,12 @@ function markerExists(rootPath, marker) {
 function scan(targetPath) {
   const target = discoverConfigFiles(targetPath);
   const rules = getBuiltinRules();
-  const findings = runRules(target.files, rules);
+  const findings = runRules(target.files, rules, target.path);
   const skillHealth = analyzeSkillHealth(target.files);
   const harnessAdapters = detectHarnessAdapters(targetPath);
   return { target, findings, skillHealth, harnessAdapters };
 }
-function runRules(files, rules) {
+function runRules(files, rules, scanRoot) {
   const findings = [];
   for (const file of files) {
     for (const rule of rules) {
@@ -10084,7 +10101,7 @@ function runRules(files, rules) {
   }
   const filesByPath = new Map(files.map((file) => [file.path, file]));
   const annotatedFindings = findings.map((finding) => {
-    const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath);
+    const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot);
     return adjustFindingForSourceContext(annotatedFinding);
   });
   return [...annotatedFindings].sort((a, b) => {
@@ -10092,16 +10109,16 @@ function runRules(files, rules) {
     return order[a.severity] - order[b.severity];
   });
 }
-function classifyRuntimeConfidence(file) {
+function classifyRuntimeConfidence(file, scanRoot) {
   const normalizedPath = file.path.replace(/\\/g, "/").toLowerCase();
   if (normalizedPath === "settings.local.json" || normalizedPath.endsWith("/settings.local.json")) {
     return "project-local-optional";
   }
+  if (isPluginCachePath(file.path, scanRoot)) {
+    return "plugin-cache";
+  }
   if (file.type === "hook-code") {
     return "hook-code";
-  }
-  if (isPluginCachePath(normalizedPath)) {
-    return "plugin-cache";
   }
   if (file.type === "settings-json" && /(?:^|\/)(?:\.claude\/)?hooks\/hooks\.json$/i.test(normalizedPath)) {
     return "plugin-manifest";
@@ -10111,12 +10128,12 @@ function classifyRuntimeConfidence(file) {
   }
   return void 0;
 }
-function annotateFindingRuntimeConfidence(finding, filesByPath) {
+function annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot) {
   if (finding.runtimeConfidence) {
     return finding;
   }
   const file = filesByPath.get(finding.file);
-  const runtimeConfidence = file ? classifyRuntimeConfidence(file) : void 0;
+  const runtimeConfidence = file ? classifyRuntimeConfidence(file, scanRoot) : void 0;
   return runtimeConfidence ? { ...finding, runtimeConfidence } : finding;
 }
 function adjustFindingForSourceContext(finding) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -10,13 +10,28 @@ var __export = (target, all) => {
 };
 
 // src/source-context.ts
+function findAllMatches(content, pattern) {
+  const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
+  return [...content.matchAll(new RegExp(pattern.source, flags))];
+}
 function isExampleLikePath(path) {
   return EXAMPLE_LIKE_PATH_PATTERN.test(path.replace(/\\/g, "/"));
 }
-function isPluginCachePath(path) {
-  return /(^|\/)(?:\.claude\/)?plugins\/cache(\/|$)/i.test(path.replace(/\\/g, "/"));
+function isPluginCachePath(path, scanRoot) {
+  const normalizedPath = path.replace(/\\/g, "/");
+  if (findAllMatches(normalizedPath, CLAUDE_PLUGIN_CACHE_PATH_PATTERN).length > 0) {
+    return true;
+  }
+  if (!scanRoot || !isClaudeScanRoot(scanRoot)) {
+    return false;
+  }
+  return findAllMatches(normalizedPath, CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN).length > 0;
 }
-var EXAMPLE_LIKE_SEGMENTS, EXAMPLE_LIKE_PATH_PATTERN;
+function isClaudeScanRoot(scanRoot) {
+  const normalizedRoot = scanRoot.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  return normalizedRoot === ".claude" || normalizedRoot.endsWith("/.claude");
+}
+var EXAMPLE_LIKE_SEGMENTS, EXAMPLE_LIKE_PATH_PATTERN, CLAUDE_PLUGIN_CACHE_PATH_PATTERN, CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN;
 var init_source_context = __esm({
   "src/source-context.ts"() {
     "use strict";
@@ -42,6 +57,8 @@ var init_source_context = __esm({
       `(^|/)(${EXAMPLE_LIKE_SEGMENTS.join("|")})(/|$)`,
       "i"
     );
+    CLAUDE_PLUGIN_CACHE_PATH_PATTERN = /(^|\/)\.claude\/plugins\/cache(\/|$)/i;
+    CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN = /^plugins\/cache(\/|$)/i;
   }
 });
 
@@ -359,7 +376,7 @@ var init_discovery = __esm({
 function findLineNumber(content, matchIndex) {
   return content.substring(0, matchIndex).split("\n").length;
 }
-function findAllMatches(content, pattern) {
+function findAllMatches2(content, pattern) {
   const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
   return [...content.matchAll(new RegExp(pattern.source, flags))];
 }
@@ -570,7 +587,7 @@ var init_secrets = __esm({
         check(file) {
           const findings = [];
           for (const secretPattern of SECRET_PATTERNS) {
-            const matches = findAllMatches(file.content, secretPattern.pattern);
+            const matches = findAllMatches2(file.content, secretPattern.pattern);
             for (const match of matches) {
               const idx = match.index ?? 0;
               const context = file.content.substring(
@@ -618,7 +635,7 @@ var init_secrets = __esm({
         check(file) {
           const findings = [];
           const echoEnvPattern = /echo\s+.*\$\{?\w*(KEY|TOKEN|SECRET|PASSWORD|PASS|CRED)\w*\}?/gi;
-          const matches = findAllMatches(file.content, echoEnvPattern);
+          const matches = findAllMatches2(file.content, echoEnvPattern);
           for (const match of matches) {
             findings.push({
               id: `secrets-echo-env-${match.index}`,
@@ -650,7 +667,7 @@ var init_secrets = __esm({
           if (file.type !== "claude-md") return [];
           const findings = [];
           const envAssignmentPattern = /(?:export\s+)?\b(\w*(?:API_KEY|SECRET_KEY|AUTH_TOKEN|ACCESS_TOKEN|PRIVATE_KEY|PASSWORD|CREDENTIAL|API_SECRET)\w*)\s*[=:]\s*["']?([^\s"']{4,})["']?/gi;
-          const matches = findAllMatches(file.content, envAssignmentPattern);
+          const matches = findAllMatches2(file.content, envAssignmentPattern);
           for (const match of matches) {
             const varName = match[1];
             const idx = match.index ?? 0;
@@ -728,7 +745,7 @@ var init_secrets = __esm({
           if (file.type !== "agent-md" && file.type !== "claude-md") return [];
           const findings = [];
           const urlCredPattern = /https?:\/\/[^:\s]+:[^@\s]+@[^\s"']+/g;
-          const matches = findAllMatches(file.content, urlCredPattern);
+          const matches = findAllMatches2(file.content, urlCredPattern);
           for (const match of matches) {
             const idx = match.index ?? 0;
             const context = file.content.substring(Math.max(0, idx - 20), idx);
@@ -794,7 +811,7 @@ var init_secrets = __esm({
             }
           ];
           for (const { pattern, description } of credentialFiles) {
-            const matches = findAllMatches(file.content, pattern);
+            const matches = findAllMatches2(file.content, pattern);
             for (const match of matches) {
               const idx = match.index ?? 0;
               findings.push({
@@ -831,7 +848,7 @@ var init_secrets = __esm({
             }
           ];
           for (const { pattern, description } of keyPatterns) {
-            const matches = findAllMatches(file.content, pattern);
+            const matches = findAllMatches2(file.content, pattern);
             for (const match of matches) {
               const idx = match.index ?? 0;
               findings.push({
@@ -878,7 +895,7 @@ var init_secrets = __esm({
             }
           ];
           for (const { pattern, description } of webhookPatterns) {
-            const matches = findAllMatches(file.content, pattern);
+            const matches = findAllMatches2(file.content, pattern);
             for (const match of matches) {
               const idx = match.index ?? 0;
               findings.push({
@@ -912,7 +929,7 @@ var init_secrets = __esm({
           if (file.type !== "agent-md" && file.type !== "claude-md") return [];
           const findings = [];
           const base64Pattern = /(?<![a-zA-Z0-9/])([A-Za-z0-9+/]{60,}={0,2})(?![a-zA-Z0-9])/g;
-          const matches = findAllMatches(file.content, base64Pattern);
+          const matches = findAllMatches2(file.content, base64Pattern);
           for (const match of matches) {
             const idx = match.index ?? 0;
             const context = file.content.substring(Math.max(0, idx - 30), idx);
@@ -955,7 +972,7 @@ var init_secrets = __esm({
             }
           ];
           for (const { pattern, description } of ipPatterns) {
-            const matches = findAllMatches(file.content, pattern);
+            const matches = findAllMatches2(file.content, pattern);
             for (const match of matches) {
               const idx = match.index ?? 0;
               findings.push({
@@ -1806,7 +1823,7 @@ var init_permissions = __esm({
 function findLineNumber3(content, matchIndex) {
   return content.substring(0, matchIndex).split("\n").length;
 }
-function findAllMatches2(content, pattern) {
+function findAllMatches3(content, pattern) {
   return [...content.matchAll(new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g"))];
 }
 function isPluginHookManifest(file) {
@@ -2043,7 +2060,7 @@ function isBlockingGuardCommand(content) {
 function findAllHookMatches(file, pattern) {
   const matches = [];
   for (const target of getHookSearchTargets(file)) {
-    for (const match of findAllMatches2(target.content, pattern)) {
+    for (const match of findAllMatches3(target.content, pattern)) {
       if (file.type === "hook-script" && isCommentOnlyShellMatch(target.content, match.index ?? 0)) {
         continue;
       }
@@ -2254,7 +2271,7 @@ var init_hooks = __esm({
           ];
           for (const ioc of AI_TOOL_PERSISTENCE_IOCS) {
             for (const target of searchTargets) {
-              for (const match of findAllMatches2(target.content, ioc.pattern)) {
+              for (const match of findAllMatches3(target.content, ioc.pattern)) {
                 const index = match.index ?? 0;
                 if (target.source === "content" && isCommentOnlyAutomationMatch(file, target.content, index)) {
                   continue;
@@ -6024,7 +6041,7 @@ var init_mcp_tool_poisoning = __esm({
 function findLineNumber4(content, matchIndex) {
   return content.substring(0, matchIndex).split("\n").length;
 }
-function findAllMatches3(content, pattern) {
+function findAllMatches4(content, pattern) {
   const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
   return [...content.matchAll(new RegExp(pattern.source, flags))];
 }
@@ -6280,7 +6297,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc, severity } of urlExecPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-claude-md-url-exec-${match.index}`,
@@ -6329,7 +6346,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of injectionPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-injection-pattern-${match.index}`,
@@ -6384,7 +6401,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, name, description } of unicodeTricks) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             if (matches.length > 0) {
               findings.push({
                 id: `agents-hidden-unicode-${name.replace(/\s/g, "-")}`,
@@ -6509,7 +6526,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of autoRunPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-claude-md-autorun-${match.index}`,
@@ -6615,7 +6632,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of commentPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-comment-injection-${match.index}`,
@@ -6682,7 +6699,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of delegationPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-unrestricted-delegation-${match.index}`,
@@ -6727,7 +6744,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of exfilPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-exfil-instruction-${match.index}`,
@@ -6772,7 +6789,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of urlLoadPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-external-url-${match.index}`,
@@ -6813,7 +6830,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of suppressionPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-security-suppression-${match.index}`,
@@ -6854,7 +6871,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of impersonationPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-identity-impersonation-${match.index}`,
@@ -6895,7 +6912,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of destructionPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-fs-destruction-${match.index}`,
@@ -6936,7 +6953,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of miningPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-crypto-mining-${match.index}`,
@@ -6981,7 +6998,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of timeBombPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-time-bomb-${match.index}`,
@@ -7022,7 +7039,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of harvestingPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-data-harvesting-${match.index}`,
@@ -7063,7 +7080,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of obfuscationPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-obfuscated-code-${match.index}`,
@@ -7104,7 +7121,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of sePatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-social-engineering-${match.index}`,
@@ -7149,7 +7166,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of reflectionPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-reflection-${match.index}`,
@@ -7190,7 +7207,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of outputManipPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-output-manip-${match.index}`,
@@ -7239,7 +7256,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of endSequencePatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-end-sequence-${match.index}`,
@@ -7280,7 +7297,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of linkExfilPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               const url = match[0].toLowerCase();
               if (url.includes("github.com") || url.includes("shields.io") || url.includes("githubusercontent.com")) continue;
@@ -7323,7 +7340,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of russianDollPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-russian-doll-${match.index}`,
@@ -7368,7 +7385,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of encodedPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-encoded-payload-${match.index}`,
@@ -7413,7 +7430,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of toolPoisoningPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-tool-poisoning-${match.index}`,
@@ -7454,7 +7471,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of probingPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-env-probing-${match.index}`,
@@ -7503,7 +7520,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of persistencePatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-persistence-${match.index}`,
@@ -7552,7 +7569,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of privescPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-privesc-${match.index}`,
@@ -7597,7 +7614,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of allowlistPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-allowlist-bypass-${match.index}`,
@@ -7642,7 +7659,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of skillTamperPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-skill-tamper-${match.index}`,
@@ -7683,7 +7700,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of leakagePatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-config-secret-leak-${match.index}`,
@@ -7724,7 +7741,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of outputSecretPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-secrets-in-output-${match.index}`,
@@ -7766,7 +7783,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of extractionPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-prompt-extraction-${match.index}`,
@@ -7815,7 +7832,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of framingPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-jailbreak-framing-${match.index}`,
@@ -7860,7 +7877,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of rolePatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-role-hijacking-${match.index}`,
@@ -7905,7 +7922,7 @@ var init_agents = __esm({
             }
           ];
           for (const { pattern, desc } of destructiveToolPatterns) {
-            const matches = findAllMatches3(file.content, pattern);
+            const matches = findAllMatches4(file.content, pattern);
             for (const match of matches) {
               findings.push({
                 id: `agents-destructive-tool-${match.index}`,
@@ -8697,12 +8714,12 @@ __export(scanner_exports, {
 function scan(targetPath) {
   const target = discoverConfigFiles(targetPath);
   const rules = getBuiltinRules();
-  const findings = runRules(target.files, rules);
+  const findings = runRules(target.files, rules, target.path);
   const skillHealth = analyzeSkillHealth(target.files);
   const harnessAdapters = detectHarnessAdapters(targetPath);
   return { target, findings, skillHealth, harnessAdapters };
 }
-function runRules(files, rules) {
+function runRules(files, rules, scanRoot) {
   const findings = [];
   for (const file of files) {
     for (const rule of rules) {
@@ -8712,7 +8729,7 @@ function runRules(files, rules) {
   }
   const filesByPath = new Map(files.map((file) => [file.path, file]));
   const annotatedFindings = findings.map((finding) => {
-    const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath);
+    const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot);
     return adjustFindingForSourceContext(annotatedFinding);
   });
   return [...annotatedFindings].sort((a, b) => {
@@ -8720,16 +8737,16 @@ function runRules(files, rules) {
     return order[a.severity] - order[b.severity];
   });
 }
-function classifyRuntimeConfidence(file) {
+function classifyRuntimeConfidence(file, scanRoot) {
   const normalizedPath = file.path.replace(/\\/g, "/").toLowerCase();
   if (normalizedPath === "settings.local.json" || normalizedPath.endsWith("/settings.local.json")) {
     return "project-local-optional";
   }
+  if (isPluginCachePath(file.path, scanRoot)) {
+    return "plugin-cache";
+  }
   if (file.type === "hook-code") {
     return "hook-code";
-  }
-  if (isPluginCachePath(normalizedPath)) {
-    return "plugin-cache";
   }
   if (file.type === "settings-json" && /(?:^|\/)(?:\.claude\/)?hooks\/hooks\.json$/i.test(normalizedPath)) {
     return "plugin-manifest";
@@ -8739,12 +8756,12 @@ function classifyRuntimeConfidence(file) {
   }
   return void 0;
 }
-function annotateFindingRuntimeConfidence(finding, filesByPath) {
+function annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot) {
   if (finding.runtimeConfidence) {
     return finding;
   }
   const file = filesByPath.get(finding.file);
-  const runtimeConfidence = file ? classifyRuntimeConfidence(file) : void 0;
+  const runtimeConfidence = file ? classifyRuntimeConfidence(file, scanRoot) : void 0;
   return runtimeConfidence ? { ...finding, runtimeConfidence } : finding;
 }
 function adjustFindingForSourceContext(finding) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13,6 +13,9 @@ var __export = (target, all) => {
 function isExampleLikePath(path) {
   return EXAMPLE_LIKE_PATH_PATTERN.test(path.replace(/\\/g, "/"));
 }
+function isPluginCachePath(path) {
+  return /(^|\/)(?:\.claude\/)?plugins\/cache(\/|$)/i.test(path.replace(/\\/g, "/"));
+}
 var EXAMPLE_LIKE_SEGMENTS, EXAMPLE_LIKE_PATH_PATTERN;
 var init_source_context = __esm({
   "src/source-context.ts"() {
@@ -8725,6 +8728,9 @@ function classifyRuntimeConfidence(file) {
   if (file.type === "hook-code") {
     return "hook-code";
   }
+  if (isPluginCachePath(normalizedPath)) {
+    return "plugin-cache";
+  }
   if (file.type === "settings-json" && /(?:^|\/)(?:\.claude\/)?hooks\/hooks\.json$/i.test(normalizedPath)) {
     return "plugin-manifest";
   }
@@ -8745,6 +8751,8 @@ function adjustFindingForSourceContext(finding) {
   switch (finding.runtimeConfidence) {
     case "docs-example":
       return adjustDocsExampleFinding(finding);
+    case "plugin-cache":
+      return adjustPluginCacheFinding(finding);
     case "plugin-manifest":
       return adjustPluginManifestFinding(finding);
     default:
@@ -8768,6 +8776,25 @@ function adjustDocsExampleFinding(finding) {
       title: prefixTitle(finding.title, "Example config")
     },
     "This finding comes from docs or sample configuration in the repository. It indicates risky guidance or example defaults, not confirmed active runtime exposure."
+  );
+}
+function adjustPluginCacheFinding(finding) {
+  if (finding.category === "secrets") {
+    return withPrefixedDescription(
+      {
+        ...finding,
+        title: prefixTitle(finding.title, "Plugin cache")
+      },
+      "This finding comes from an installed Claude plugin cache. It indicates packaged plugin content present on disk, not confirmed top-level runtime configuration."
+    );
+  }
+  return withPrefixedDescription(
+    {
+      ...finding,
+      severity: downgradeStructuralSeverity(finding.severity),
+      title: prefixTitle(finding.title, "Plugin cache")
+    },
+    "This finding comes from an installed Claude plugin cache. It indicates packaged plugin content present on disk, not confirmed top-level runtime configuration."
   );
 }
 function adjustPluginManifestFinding(finding) {
@@ -9244,6 +9271,8 @@ function formatRuntimeConfidence(value) {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":
@@ -13618,6 +13647,9 @@ function confidenceWeight(finding) {
   if (finding.runtimeConfidence === "plugin-manifest" && finding.category !== "secrets") {
     return 0.5;
   }
+  if (finding.runtimeConfidence === "plugin-cache" && finding.category !== "secrets") {
+    return 0.5;
+  }
   return 1;
 }
 function roundedCategoryScore(maxCategoryScore, deduction) {
@@ -13662,6 +13694,8 @@ function formatRuntimeConfidence2(value) {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":
@@ -14159,6 +14193,8 @@ function formatRuntimeConfidence3(value) {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":
@@ -14959,7 +14995,7 @@ function severityToSecurityScore(severity) {
 }
 function precisionForFinding(finding) {
   if (finding.runtimeConfidence === "active-runtime") return "very-high";
-  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example") {
+  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example" || finding.runtimeConfidence === "plugin-cache") {
     return "medium";
   }
   return "high";

--- a/src/reporter/html.ts
+++ b/src/reporter/html.ts
@@ -523,6 +523,8 @@ function formatRuntimeConfidence(value: RuntimeConfidence): string {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":

--- a/src/reporter/json.ts
+++ b/src/reporter/json.ts
@@ -10,6 +10,8 @@ function formatRuntimeConfidence(value: string): string {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":

--- a/src/reporter/sarif.ts
+++ b/src/reporter/sarif.ts
@@ -282,7 +282,11 @@ function severityToSecurityScore(severity: Severity): string {
 
 function precisionForFinding(finding: Finding): "very-high" | "high" | "medium" {
   if (finding.runtimeConfidence === "active-runtime") return "very-high";
-  if (finding.runtimeConfidence === "template-example" || finding.runtimeConfidence === "docs-example") {
+  if (
+    finding.runtimeConfidence === "template-example" ||
+    finding.runtimeConfidence === "docs-example" ||
+    finding.runtimeConfidence === "plugin-cache"
+  ) {
     return "medium";
   }
   return "high";

--- a/src/reporter/score.ts
+++ b/src/reporter/score.ts
@@ -124,6 +124,10 @@ function confidenceWeight(finding: Finding): number {
     return 0.5;
   }
 
+  if (finding.runtimeConfidence === "plugin-cache" && finding.category !== "secrets") {
+    return 0.5;
+  }
+
   return 1;
 }
 

--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -610,6 +610,8 @@ function formatRuntimeConfidence(value: RuntimeConfidence): string {
       return "template/example";
     case "docs-example":
       return "docs/example";
+    case "plugin-cache":
+      return "plugin cache";
     case "plugin-manifest":
       return "plugin manifest";
     case "hook-code":

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "../types.js";
 import { discoverConfigFiles } from "./discovery.js";
 import { getBuiltinRules } from "../rules/index.js";
-import { isExampleLikePath } from "../source-context.js";
+import { isExampleLikePath, isPluginCachePath } from "../source-context.js";
 import { analyzeSkillHealth } from "../skills/health.js";
 import { detectHarnessAdapters } from "../harness-adapters/index.js";
 
@@ -73,6 +73,10 @@ function classifyRuntimeConfidence(file: ConfigFile): RuntimeConfidence | undefi
     return "hook-code";
   }
 
+  if (isPluginCachePath(normalizedPath)) {
+    return "plugin-cache";
+  }
+
   if (
     file.type === "settings-json" &&
     /(?:^|\/)(?:\.claude\/)?hooks\/hooks\.json$/i.test(normalizedPath)
@@ -104,6 +108,8 @@ function adjustFindingForSourceContext(finding: Finding): Finding {
   switch (finding.runtimeConfidence) {
     case "docs-example":
       return adjustDocsExampleFinding(finding);
+    case "plugin-cache":
+      return adjustPluginCacheFinding(finding);
     case "plugin-manifest":
       return adjustPluginManifestFinding(finding);
     default:
@@ -129,6 +135,27 @@ function adjustDocsExampleFinding(finding: Finding): Finding {
       title: prefixTitle(finding.title, "Example config"),
     },
     "This finding comes from docs or sample configuration in the repository. It indicates risky guidance or example defaults, not confirmed active runtime exposure."
+  );
+}
+
+function adjustPluginCacheFinding(finding: Finding): Finding {
+  if (finding.category === "secrets") {
+    return withPrefixedDescription(
+      {
+        ...finding,
+        title: prefixTitle(finding.title, "Plugin cache"),
+      },
+      "This finding comes from an installed Claude plugin cache. It indicates packaged plugin content present on disk, not confirmed top-level runtime configuration."
+    );
+  }
+
+  return withPrefixedDescription(
+    {
+      ...finding,
+      severity: downgradeStructuralSeverity(finding.severity),
+      title: prefixTitle(finding.title, "Plugin cache"),
+    },
+    "This finding comes from an installed Claude plugin cache. It indicates packaged plugin content present on disk, not confirmed top-level runtime configuration."
   );
 }
 

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -27,7 +27,7 @@ export interface ScanResult {
 export function scan(targetPath: string): ScanResult {
   const target = discoverConfigFiles(targetPath);
   const rules = getBuiltinRules();
-  const findings = runRules(target.files, rules);
+  const findings = runRules(target.files, rules, target.path);
   const skillHealth = analyzeSkillHealth(target.files);
   const harnessAdapters = detectHarnessAdapters(targetPath);
 
@@ -39,7 +39,8 @@ export function scan(targetPath: string): ScanResult {
  */
 function runRules(
   files: ReadonlyArray<ConfigFile>,
-  rules: ReadonlyArray<Rule>
+  rules: ReadonlyArray<Rule>,
+  scanRoot: string
 ): ReadonlyArray<Finding> {
   const findings: Finding[] = [];
 
@@ -52,7 +53,7 @@ function runRules(
 
   const filesByPath = new Map(files.map((file) => [file.path, file]));
   const annotatedFindings = findings.map((finding) => {
-    const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath);
+    const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot);
     return adjustFindingForSourceContext(annotatedFinding);
   });
 
@@ -63,18 +64,18 @@ function runRules(
   });
 }
 
-function classifyRuntimeConfidence(file: ConfigFile): RuntimeConfidence | undefined {
+function classifyRuntimeConfidence(file: ConfigFile, scanRoot: string): RuntimeConfidence | undefined {
   const normalizedPath = file.path.replace(/\\/g, "/").toLowerCase();
   if (normalizedPath === "settings.local.json" || normalizedPath.endsWith("/settings.local.json")) {
     return "project-local-optional";
   }
 
-  if (file.type === "hook-code") {
-    return "hook-code";
+  if (isPluginCachePath(file.path, scanRoot)) {
+    return "plugin-cache";
   }
 
-  if (isPluginCachePath(normalizedPath)) {
-    return "plugin-cache";
+  if (file.type === "hook-code") {
+    return "hook-code";
   }
 
   if (
@@ -93,14 +94,15 @@ function classifyRuntimeConfidence(file: ConfigFile): RuntimeConfidence | undefi
 
 function annotateFindingRuntimeConfidence(
   finding: Finding,
-  filesByPath: ReadonlyMap<string, ConfigFile>
+  filesByPath: ReadonlyMap<string, ConfigFile>,
+  scanRoot: string
 ): Finding {
   if (finding.runtimeConfidence) {
     return finding;
   }
 
   const file = filesByPath.get(finding.file);
-  const runtimeConfidence = file ? classifyRuntimeConfidence(file) : undefined;
+  const runtimeConfidence = file ? classifyRuntimeConfidence(file, scanRoot) : undefined;
   return runtimeConfidence ? { ...finding, runtimeConfidence } : finding;
 }
 

--- a/src/source-context.ts
+++ b/src/source-context.ts
@@ -26,4 +26,8 @@ export function isExampleLikePath(path: string): boolean {
   return EXAMPLE_LIKE_PATH_PATTERN.test(path.replace(/\\/g, "/"));
 }
 
+export function isPluginCachePath(path: string): boolean {
+  return /(^|\/)(?:\.claude\/)?plugins\/cache(\/|$)/i.test(path.replace(/\\/g, "/"));
+}
+
 export { EXAMPLE_LIKE_SEGMENTS };

--- a/src/source-context.ts
+++ b/src/source-context.ts
@@ -22,12 +22,34 @@ const EXAMPLE_LIKE_PATH_PATTERN = new RegExp(
   "i"
 );
 
+const CLAUDE_PLUGIN_CACHE_PATH_PATTERN = /(^|\/)\.claude\/plugins\/cache(\/|$)/i;
+const CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN = /^plugins\/cache(\/|$)/i;
+
+function findAllMatches(content: string, pattern: RegExp): Array<RegExpMatchArray> {
+  const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
+  return [...content.matchAll(new RegExp(pattern.source, flags))];
+}
+
 export function isExampleLikePath(path: string): boolean {
   return EXAMPLE_LIKE_PATH_PATTERN.test(path.replace(/\\/g, "/"));
 }
 
-export function isPluginCachePath(path: string): boolean {
-  return /(^|\/)(?:\.claude\/)?plugins\/cache(\/|$)/i.test(path.replace(/\\/g, "/"));
+export function isPluginCachePath(path: string, scanRoot?: string): boolean {
+  const normalizedPath = path.replace(/\\/g, "/");
+  if (findAllMatches(normalizedPath, CLAUDE_PLUGIN_CACHE_PATH_PATTERN).length > 0) {
+    return true;
+  }
+
+  if (!scanRoot || !isClaudeScanRoot(scanRoot)) {
+    return false;
+  }
+
+  return findAllMatches(normalizedPath, CLAUDE_SCAN_ROOT_PLUGIN_CACHE_PATH_PATTERN).length > 0;
+}
+
+function isClaudeScanRoot(scanRoot: string): boolean {
+  const normalizedRoot = scanRoot.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+  return normalizedRoot === ".claude" || normalizedRoot.endsWith("/.claude");
 }
 
 export { EXAMPLE_LIKE_SEGMENTS };

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type RuntimeConfidence =
   | "project-local-optional"
   | "template-example"
   | "docs-example"
+  | "plugin-cache"
   | "plugin-manifest"
   | "hook-code";
 

--- a/tests/reporter/json.test.ts
+++ b/tests/reporter/json.test.ts
@@ -285,6 +285,15 @@ describe("renderMarkdownReport", () => {
         },
         {
           id: "RC-4",
+          severity: "low",
+          category: "agents",
+          title: "Plugin cache source",
+          description: "A test",
+          file: ".claude/plugins/cache/demo/agent.md",
+          runtimeConfidence: "plugin-cache",
+        },
+        {
+          id: "RC-5",
           severity: "info",
           category: "agents",
           title: "Unknown confidence source",
@@ -294,13 +303,13 @@ describe("renderMarkdownReport", () => {
         },
       ],
       summary: {
-        totalFindings: 4,
+        totalFindings: 5,
         critical: 0,
         high: 1,
         medium: 1,
-        low: 1,
+        low: 2,
         info: 1,
-        filesScanned: 4,
+        filesScanned: 5,
         autoFixable: 0,
       },
     }));
@@ -308,6 +317,7 @@ describe("renderMarkdownReport", () => {
     expect(output).toContain("project-local optional");
     expect(output).toContain("docs/example");
     expect(output).toContain("plugin manifest");
+    expect(output).toContain("plugin cache");
     expect(output).toContain("custom-confidence");
   });
 

--- a/tests/reporter/score.test.ts
+++ b/tests/reporter/score.test.ts
@@ -294,6 +294,21 @@ describe("calculateScore", () => {
     expect(report.score.numericScore).toBe(100);
   });
 
+  it("discounts plugin-cache findings in score weighting", () => {
+    const result = makeScanResult([
+      makeFinding({
+        id: "plugin-cache",
+        severity: "high",
+        category: "agents",
+        runtimeConfidence: "plugin-cache",
+      }),
+    ]);
+
+    const report = calculateScore(result);
+    expect(report.score.breakdown.agents).toBe(93);
+    expect(report.score.numericScore).toBe(99);
+  });
+
   it("grades correctly at boundaries", () => {
     // A: >= 90 — 2 medium in one category
     expect(calculateScore(makeScanResult([

--- a/tests/scanner/scanner.test.ts
+++ b/tests/scanner/scanner.test.ts
@@ -333,6 +333,50 @@ describe("scanner", () => {
       expect(finding?.description).toContain("installed Claude plugin cache");
     });
 
+    it("does not treat repository-local non-Claude plugin caches as installed Claude plugin cache", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "agentshield-scan-"));
+      mkdirSync(join(tempDir, "plugins", "cache", "acme", "pluginpkg", "agents"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(tempDir, "plugins", "cache", "acme", "pluginpkg", "CLAUDE.md"),
+        "# Plugin instructions",
+      );
+      writeFileSync(
+        join(tempDir, "plugins", "cache", "acme", "pluginpkg", "agents", "reviewer.md"),
+        "tools: Bash\n",
+      );
+
+      const result = scan(tempDir);
+      const finding = result.findings.find((f) =>
+        f.file.endsWith("plugins/cache/acme/pluginpkg/agents/reviewer.md")
+      );
+
+      expect(finding?.runtimeConfidence).not.toBe("plugin-cache");
+    });
+
+    it("marks hook-code inside installed Claude plugin caches as plugin-cache", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "agentshield-scan-"));
+      mkdirSync(join(tempDir, ".claude", "plugins", "cache", "acme", "pluginpkg", "1.0.0", "hooks"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(tempDir, ".claude", "plugins", "cache", "acme", "pluginpkg", "1.0.0", "CLAUDE.md"),
+        "# Plugin instructions",
+      );
+      writeFileSync(
+        join(tempDir, ".claude", "plugins", "cache", "acme", "pluginpkg", "1.0.0", "hooks", "session-start.js"),
+        "const { output } = require('../lib/utils');\noutput('hello');\n",
+      );
+
+      const result = scan(join(tempDir, ".claude"));
+      const finding = result.findings.find((f) =>
+        f.file.endsWith("plugins/cache/acme/pluginpkg/1.0.0/hooks/session-start.js")
+      );
+
+      expect(finding?.runtimeConfidence).toBe("plugin-cache");
+    });
+
     it("marks manifest-resolved hook-code findings as hook-code", () => {
       const tempDir = mkdtempSync(join(tmpdir(), "agentshield-scan-"));
       mkdirSync(join(tempDir, "hooks"));

--- a/tests/scanner/scanner.test.ts
+++ b/tests/scanner/scanner.test.ts
@@ -309,6 +309,30 @@ describe("scanner", () => {
       expect(finding?.description).toContain("declarative hook manifest");
     });
 
+    it("marks installed Claude plugin cache findings separately from active runtime config", () => {
+      const tempDir = mkdtempSync(join(tmpdir(), "agentshield-scan-"));
+      mkdirSync(join(tempDir, ".claude", "plugins", "cache", "acme", "pluginpkg", "1.0.0", "agents"), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(tempDir, ".claude", "plugins", "cache", "acme", "pluginpkg", "1.0.0", "CLAUDE.md"),
+        "# Plugin instructions",
+      );
+      writeFileSync(
+        join(tempDir, ".claude", "plugins", "cache", "acme", "pluginpkg", "1.0.0", "agents", "reviewer.md"),
+        "tools: Bash\n",
+      );
+
+      const result = scan(join(tempDir, ".claude"));
+      const finding = result.findings.find((f) =>
+        f.file.endsWith("plugins/cache/acme/pluginpkg/1.0.0/agents/reviewer.md")
+      );
+
+      expect(finding?.runtimeConfidence).toBe("plugin-cache");
+      expect(finding?.title).toMatch(/^Plugin cache: /);
+      expect(finding?.description).toContain("installed Claude plugin cache");
+    });
+
     it("marks manifest-resolved hook-code findings as hook-code", () => {
       const tempDir = mkdtempSync(join(tmpdir(), "agentshield-scan-"));
       mkdirSync(join(tempDir, "hooks"));


### PR DESCRIPTION
## Summary
- add a plugin-cache runtime confidence tier for installed Claude plugin cache findings
- discount non-secret plugin-cache findings in score weighting and expose the label in JSON/Markdown/HTML/terminal/SARIF reports
- document audit interpretation so cached plugin content is not confused with top-level active runtime config

## Verification
- npm run typecheck
- npx vitest run tests/scanner/scanner.test.ts tests/reporter/score.test.ts tests/reporter/json.test.ts tests/reporter/html.test.ts tests/reporter/terminal.test.ts tests/reporter/sarif.test.ts
- npm run test:batch:core
- npm test
- npm run build

## Evidence
A live scan of /Users/affoon/.claude now classifies 952 findings as plugin-cache, reducing uncategorized/active-like findings from 860 to 168 without suppressing real findings or downgrading secrets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `plugin-cache` runtime confidence to classify findings from installed Claude plugin caches and reduce active-like noise. Detection is tightened to only classify caches under `.claude`, while secrets keep full weight.

- New Features
  - Detect `/.claude/plugins/cache/` paths and, when scanning a `.claude` root, `plugins/cache/**`; classify hook files inside caches and avoid repo-local false positives outside `.claude`.
  - Apply 0.5x score weight to non-secret plugin-cache findings; keep secrets at full weight. Downgrade structural severity and prefix titles with "Plugin cache".
  - Show "plugin cache" in JSON, Markdown, HTML, terminal, and SARIF; set SARIF precision to medium.
  - Update README with audit guidance and jq filters; add tests for tightened classification (including non-Claude false positives and hook-code in caches), score weighting, and report rendering.

<sup>Written for commit 6ac3a540e877770d7e7a0d16abdcd2b0b529dd74. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/87?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and classify findings originating from installed Claude plugin caches.
  * Display plugin-cache findings as "plugin cache" across HTML, JSON, terminal, and SARIF outputs.
  * Apply reduced confidence weighting (0.5x) for non-secret plugin-cache findings in scoring.

* **Documentation**
  * Updated README triage guidance, JSON report notes, and audit-order recommendations to include plugin-cache semantics.

* **Tests**
  * Added tests covering plugin-cache detection, scoring, and report rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->