### PR TITLE
feat: inspect evidence pack summaries

### DIFF
--- a/API.md
+++ b/API.md
@@ -198,11 +198,24 @@ agentshield scan --evidence-pack ./agentshield-evidence
 The evidence-pack directory is deterministic and contains `manifest.json`,
 `README.md`, `agentshield-report.json`, `agentshield-report.html`,
 `agentshield-results.sarif`, `policy-evaluation.json`,
-`baseline-comparison.json`, `supply-chain.json`, and `remediation-plan.json`.
+`baseline-comparison.json`, `supply-chain.json`, `ci-context.json`, and
+`remediation-plan.json`.
 In the GitHub Action, evidence packs use the same supply-chain verification
 result that powers the package-risk outputs instead of an empty placeholder.
 Local path, username, email, and token-shaped string redaction is enabled by
 default.
+
+Consumers can verify and read back a saved pack:
+
+```bash
+agentshield evidence-pack verify ./agentshield-evidence --json
+agentshield evidence-pack inspect ./agentshield-evidence --json
+```
+
+`inspect` verifies the bundle first, then emits score, finding counts,
+runtime-confidence counts, policy status, baseline drift status, supply-chain
+counts, CI provenance, and remediation workflow counts for GitHub App, Linear,
+or customer-review ingestion.
 
 Top-level shape:
 

--- a/README.md
+++ b/README.md
@@ -423,6 +423,14 @@ agentshield evidence-pack verify ./agentshield-evidence
 agentshield evidence-pack verify ./agentshield-evidence --json
 ```
 
+Inspect a verified evidence pack when a downstream GitHub App, Linear sync, or
+security-review workflow needs a compact readback without opening every artifact:
+
+```bash
+agentshield evidence-pack inspect ./agentshield-evidence
+agentshield evidence-pack inspect ./agentshield-evidence --json
+```
+
 ### JSON Report Shape
 
 `agentshield scan --format json` is the supported machine-readable scanner interface today.
@@ -574,6 +582,7 @@ agentshield scan [options]         Scan configuration directory
 
 agentshield init                   Generate secure baseline config
 agentshield baseline write         Write a scan baseline JSON file
+agentshield evidence-pack inspect  Verify and summarize an evidence bundle
 agentshield evidence-pack verify   Verify artifact and bundle digests
 agentshield policy init            Generate an organization policy preset
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -15220,6 +15220,59 @@ function verifyEvidencePack(outputDir) {
     errors
   };
 }
+function inspectEvidencePack(outputDir) {
+  const resolvedOutputDir = resolve3(outputDir);
+  const verification = verifyEvidencePack(resolvedOutputDir);
+  const errors = [...verification.errors];
+  const manifest = readJsonFile(resolvedOutputDir, "manifest.json", errors);
+  const report = readJsonFile(resolvedOutputDir, "agentshield-report.json", errors);
+  const policy = readJsonFile(resolvedOutputDir, "policy-evaluation.json", errors);
+  const baseline2 = readJsonFile(resolvedOutputDir, "baseline-comparison.json", errors);
+  const supplyChain = readJsonFile(resolvedOutputDir, "supply-chain.json", errors);
+  const ciContext = readJsonFile(resolvedOutputDir, "ci-context.json", errors);
+  const remediation = readJsonFile(resolvedOutputDir, "remediation-plan.json", errors);
+  const reportSummary = summarizeArtifact(
+    "agentshield-report.json",
+    errors,
+    () => report ? summarizeReport(report) : null
+  );
+  const policySummary = summarizeArtifact("policy-evaluation.json", errors, () => summarizePolicy(policy));
+  const baselineSummary = summarizeArtifact("baseline-comparison.json", errors, () => summarizeBaseline(baseline2));
+  const supplyChainSummary = summarizeArtifact(
+    "supply-chain.json",
+    errors,
+    () => supplyChain ? summarizeSupplyChain(supplyChain) : null
+  );
+  const ciContextSummary = summarizeArtifact(
+    "ci-context.json",
+    errors,
+    () => ciContext ? summarizeCiContext(ciContext) : null
+  );
+  const remediationSummary = summarizeArtifact(
+    "remediation-plan.json",
+    errors,
+    () => remediation ? summarizeRemediation(remediation) : null
+  );
+  return {
+    ok: verification.ok && errors.length === 0,
+    outputDir: resolvedOutputDir,
+    generatedAt: typeof manifest?.generatedAt === "string" ? manifest.generatedAt : null,
+    targetPath: typeof manifest?.targetPath === "string" ? manifest.targetPath : null,
+    redacted: typeof manifest?.redacted === "boolean" ? manifest.redacted : null,
+    bundleDigest: verification.bundleDigest,
+    expectedBundleDigest: verification.expectedBundleDigest,
+    artifactCount: manifest?.artifacts.length ?? verification.artifacts.length,
+    verifiedArtifactCount: verification.artifacts.filter((artifact) => artifact.ok).length,
+    report: reportSummary,
+    policy: policySummary ?? { status: "unknown" },
+    baseline: baselineSummary ?? { status: "unknown" },
+    supplyChain: supplyChainSummary,
+    ciContext: ciContextSummary,
+    remediation: remediationSummary,
+    verification,
+    errors
+  };
+}
 function buildCiContext(environment, generatedAt) {
   const github = compact({
     repository: environment.GITHUB_REPOSITORY,
@@ -15290,6 +15343,113 @@ function buildBundleDigest(artifactContents) {
     };
   });
   return `sha256:${createHash2("sha256").update(JSON.stringify(bundleEntries)).digest("hex")}`;
+}
+function readJsonFile(outputDir, fileName, errors) {
+  const filePath = resolve3(outputDir, fileName);
+  if (!existsSync3(filePath)) {
+    errors.push(`${fileName} is missing`);
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync2(filePath, "utf-8"));
+  } catch (error) {
+    errors.push(`${fileName} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+function summarizeArtifact(fileName, errors, summarize) {
+  try {
+    return summarize();
+  } catch (error) {
+    errors.push(`${fileName} summary failed: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+function summarizeReport(report) {
+  return {
+    score: {
+      grade: report.score.grade,
+      numericScore: report.score.numericScore
+    },
+    findings: {
+      total: report.summary.totalFindings,
+      critical: report.summary.critical,
+      high: report.summary.high,
+      medium: report.summary.medium,
+      low: report.summary.low,
+      info: report.summary.info
+    },
+    runtimeConfidence: countRuntimeConfidence(report)
+  };
+}
+function countRuntimeConfidence(report) {
+  const counts = report.findings.reduce((accumulator, finding) => {
+    const key = finding.runtimeConfidence ?? "active-runtime";
+    return {
+      ...accumulator,
+      [key]: (accumulator[key] ?? 0) + 1
+    };
+  }, {});
+  return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+}
+function summarizePolicy(policy) {
+  if (!policy) return { status: "unknown" };
+  if (policy.status === "not-run") return { status: "not-run" };
+  const violations = Array.isArray(policy.violations) ? policy.violations.length : void 0;
+  return {
+    status: policy.passed === true ? "passed" : policy.passed === false ? "failed" : "unknown",
+    policyName: typeof policy.policyName === "string" ? policy.policyName : void 0,
+    policyPack: typeof policy.policyPack === "string" ? policy.policyPack : void 0,
+    violations
+  };
+}
+function summarizeBaseline(baseline2) {
+  if (!baseline2) return { status: "unknown" };
+  if (baseline2.status === "not-run") return { status: "not-run" };
+  return {
+    status: baseline2.isRegression === true ? "regressed" : baseline2.isRegression === false ? "passed" : "unknown",
+    newFindings: Array.isArray(baseline2.newFindings) ? baseline2.newFindings.length : void 0,
+    resolvedFindings: Array.isArray(baseline2.resolvedFindings) ? baseline2.resolvedFindings.length : void 0,
+    unchangedCount: typeof baseline2.unchangedCount === "number" ? baseline2.unchangedCount : void 0,
+    scoreDelta: typeof baseline2.scoreDelta === "number" ? baseline2.scoreDelta : void 0
+  };
+}
+function summarizeSupplyChain(report) {
+  return {
+    totalPackages: report.totalPackages,
+    riskyPackages: report.riskyPackages,
+    criticalCount: report.criticalCount,
+    highCount: report.highCount
+  };
+}
+function summarizeCiContext(context) {
+  return {
+    provider: context.provider,
+    repository: context.github?.repository,
+    workflow: context.github?.workflow,
+    runId: context.github?.runId,
+    sha: context.github?.sha
+  };
+}
+function summarizeRemediation(remediation) {
+  const summary = remediation.summary;
+  const workflow = remediation.workflow;
+  if (!summary || typeof summary !== "object") return null;
+  const summaryRecord = summary;
+  const phases = workflow && typeof workflow === "object" && Array.isArray(workflow.phases) ? workflow.phases : [];
+  return {
+    totalFindings: numberOrZero(summaryRecord.totalFindings),
+    autoFixable: numberOrZero(summaryRecord.autoFixable),
+    manualReview: numberOrZero(summaryRecord.manualReview),
+    phases: phases.map((phase) => ({
+      id: typeof phase.id === "string" ? phase.id : "unknown",
+      findingCount: numberOrZero(phase.findingCount),
+      blocking: phase.blocking === true
+    }))
+  };
+}
+function numberOrZero(value) {
+  return typeof value === "number" ? value : 0;
 }
 function hashContent(content) {
   return {
@@ -17755,6 +17915,10 @@ function resolveSettingsPath(targetPath) {
 }
 
 // src/index.ts
+function writeStdout(line = "") {
+  process.stdout.write(`${line}
+`);
+}
 async function runInjectionTests2(targetPath) {
   try {
     const { runInjectionSuite: runInjectionSuite2 } = await Promise.resolve().then(() => (init_injection(), injection_exports));
@@ -18256,6 +18420,57 @@ program.command("init").description("Generate a secure baseline Claude Code conf
   console.log(renderInitSummary(initResult));
 });
 var evidencePack = program.command("evidence-pack").description("Inspect and verify AgentShield evidence-pack bundles");
+evidencePack.command("inspect").description("Inspect verified evidence-pack contents for downstream consumers").argument("<dir>", "Evidence-pack directory").option("--json", "Emit machine-readable inspection results", false).action((dir, options) => {
+  const result = inspectEvidencePack(dir);
+  if (options.json) {
+    writeStdout(JSON.stringify(result, null, 2));
+  } else {
+    writeStdout();
+    writeStdout("AgentShield Evidence Pack Inspection");
+    writeStdout(`Directory:   ${result.outputDir}`);
+    writeStdout(`Status:      ${result.ok ? "passed" : "failed"}`);
+    writeStdout(`Digest:      ${result.bundleDigest ?? "not available"}`);
+    writeStdout(`Generated:   ${result.generatedAt ?? "unknown"}`);
+    writeStdout(`Target:      ${result.targetPath ?? "unknown"}`);
+    writeStdout(`Artifacts:   ${result.verifiedArtifactCount}/${result.artifactCount} verified`);
+    if (result.report) {
+      writeStdout(
+        `Score:       ${result.report.score.numericScore}/100 (${result.report.score.grade}); ${result.report.findings.total} findings`
+      );
+      writeStdout(
+        `Findings:    critical ${result.report.findings.critical}, high ${result.report.findings.high}, medium ${result.report.findings.medium}, low ${result.report.findings.low}, info ${result.report.findings.info}`
+      );
+    }
+    writeStdout(`Policy:      ${result.policy.status}`);
+    writeStdout(`Baseline:    ${result.baseline.status}`);
+    if (result.supplyChain) {
+      writeStdout(
+        `Supply:      ${result.supplyChain.riskyPackages}/${result.supplyChain.totalPackages} risky packages`
+      );
+    }
+    if (result.ciContext) {
+      writeStdout(
+        `CI:          ${result.ciContext.provider}${result.ciContext.repository ? ` ${result.ciContext.repository}` : ""}`
+      );
+    }
+    if (result.remediation) {
+      writeStdout(
+        `Remediate:   ${result.remediation.autoFixable} auto-fixable, ${result.remediation.manualReview} manual-review`
+      );
+    }
+    if (result.errors.length > 0) {
+      writeStdout();
+      writeStdout("Errors:");
+      for (const error of result.errors) {
+        writeStdout(`- ${error}`);
+      }
+    }
+    writeStdout();
+  }
+  if (!result.ok) {
+    process.exit(6);
+  }
+});
 evidencePack.command("verify").description("Verify evidence-pack artifact digests and bundle digest").argument("<dir>", "Evidence-pack directory").option("--json", "Emit machine-readable verification results", false).action((dir, options) => {
   const result = verifyEvidencePack(dir);
   if (options.json) {

--- a/src/evidence-pack/index.ts
+++ b/src/evidence-pack/index.ts
@@ -48,6 +48,83 @@ export interface EvidencePackVerificationResult {
   readonly errors: ReadonlyArray<string>;
 }
 
+export interface EvidencePackInspectionResult {
+  readonly ok: boolean;
+  readonly outputDir: string;
+  readonly generatedAt: string | null;
+  readonly targetPath: string | null;
+  readonly redacted: boolean | null;
+  readonly bundleDigest: string | null;
+  readonly expectedBundleDigest: string | null;
+  readonly artifactCount: number;
+  readonly verifiedArtifactCount: number;
+  readonly report: EvidencePackReportSummary | null;
+  readonly policy: EvidencePackPolicySummary;
+  readonly baseline: EvidencePackBaselineSummary;
+  readonly supplyChain: EvidencePackSupplyChainSummary | null;
+  readonly ciContext: EvidencePackCiSummary | null;
+  readonly remediation: EvidencePackRemediationSummary | null;
+  readonly verification: EvidencePackVerificationResult;
+  readonly errors: ReadonlyArray<string>;
+}
+
+export interface EvidencePackReportSummary {
+  readonly score: {
+    readonly grade: string;
+    readonly numericScore: number;
+  };
+  readonly findings: {
+    readonly total: number;
+    readonly critical: number;
+    readonly high: number;
+    readonly medium: number;
+    readonly low: number;
+    readonly info: number;
+  };
+  readonly runtimeConfidence: Readonly<Record<string, number>>;
+}
+
+export interface EvidencePackPolicySummary {
+  readonly status: "passed" | "failed" | "not-run" | "unknown";
+  readonly policyName?: string;
+  readonly policyPack?: string;
+  readonly violations?: number;
+}
+
+export interface EvidencePackBaselineSummary {
+  readonly status: "passed" | "regressed" | "not-run" | "unknown";
+  readonly newFindings?: number;
+  readonly resolvedFindings?: number;
+  readonly unchangedCount?: number;
+  readonly scoreDelta?: number;
+}
+
+export interface EvidencePackSupplyChainSummary {
+  readonly totalPackages: number;
+  readonly riskyPackages: number;
+  readonly criticalCount: number;
+  readonly highCount: number;
+}
+
+export interface EvidencePackCiSummary {
+  readonly provider: "github-actions" | "local" | "unknown";
+  readonly repository?: string;
+  readonly workflow?: string;
+  readonly runId?: string;
+  readonly sha?: string;
+}
+
+export interface EvidencePackRemediationSummary {
+  readonly totalFindings: number;
+  readonly autoFixable: number;
+  readonly manualReview: number;
+  readonly phases: ReadonlyArray<{
+    readonly id: string;
+    readonly findingCount: number;
+    readonly blocking: boolean;
+  }>;
+}
+
 export interface EvidencePackCiContext {
   readonly schemaVersion: 1;
   readonly generatedAt: string;
@@ -319,6 +396,53 @@ export function verifyEvidencePack(outputDir: string): EvidencePackVerificationR
   };
 }
 
+export function inspectEvidencePack(outputDir: string): EvidencePackInspectionResult {
+  const resolvedOutputDir = resolve(outputDir);
+  const verification = verifyEvidencePack(resolvedOutputDir);
+  const errors = [...verification.errors];
+  const manifest = readJsonFile<EvidencePackManifest>(resolvedOutputDir, "manifest.json", errors);
+  const report = readJsonFile<SecurityReport>(resolvedOutputDir, "agentshield-report.json", errors);
+  const policy = readJsonFile<Record<string, unknown>>(resolvedOutputDir, "policy-evaluation.json", errors);
+  const baseline = readJsonFile<Record<string, unknown>>(resolvedOutputDir, "baseline-comparison.json", errors);
+  const supplyChain = readJsonFile<SupplyChainReport>(resolvedOutputDir, "supply-chain.json", errors);
+  const ciContext = readJsonFile<EvidencePackCiContext>(resolvedOutputDir, "ci-context.json", errors);
+  const remediation = readJsonFile<Record<string, unknown>>(resolvedOutputDir, "remediation-plan.json", errors);
+  const reportSummary = summarizeArtifact("agentshield-report.json", errors, () =>
+    report ? summarizeReport(report) : null
+  );
+  const policySummary = summarizeArtifact("policy-evaluation.json", errors, () => summarizePolicy(policy));
+  const baselineSummary = summarizeArtifact("baseline-comparison.json", errors, () => summarizeBaseline(baseline));
+  const supplyChainSummary = summarizeArtifact("supply-chain.json", errors, () =>
+    supplyChain ? summarizeSupplyChain(supplyChain) : null
+  );
+  const ciContextSummary = summarizeArtifact("ci-context.json", errors, () =>
+    ciContext ? summarizeCiContext(ciContext) : null
+  );
+  const remediationSummary = summarizeArtifact("remediation-plan.json", errors, () =>
+    remediation ? summarizeRemediation(remediation) : null
+  );
+
+  return {
+    ok: verification.ok && errors.length === 0,
+    outputDir: resolvedOutputDir,
+    generatedAt: typeof manifest?.generatedAt === "string" ? manifest.generatedAt : null,
+    targetPath: typeof manifest?.targetPath === "string" ? manifest.targetPath : null,
+    redacted: typeof manifest?.redacted === "boolean" ? manifest.redacted : null,
+    bundleDigest: verification.bundleDigest,
+    expectedBundleDigest: verification.expectedBundleDigest,
+    artifactCount: manifest?.artifacts.length ?? verification.artifacts.length,
+    verifiedArtifactCount: verification.artifacts.filter((artifact) => artifact.ok).length,
+    report: reportSummary,
+    policy: policySummary ?? { status: "unknown" },
+    baseline: baselineSummary ?? { status: "unknown" },
+    supplyChain: supplyChainSummary,
+    ciContext: ciContextSummary,
+    remediation: remediationSummary,
+    verification,
+    errors,
+  };
+}
+
 function buildCiContext(
   environment: EvidencePackEnvironment,
   generatedAt: string
@@ -408,6 +532,138 @@ function buildBundleDigest(artifactContents: ReadonlyMap<string, string>): strin
       };
     });
   return `sha256:${createHash("sha256").update(JSON.stringify(bundleEntries)).digest("hex")}`;
+}
+
+function readJsonFile<T>(
+  outputDir: string,
+  fileName: string,
+  errors: string[]
+): T | null {
+  const filePath = resolve(outputDir, fileName);
+  if (!existsSync(filePath)) {
+    errors.push(`${fileName} is missing`);
+    return null;
+  }
+
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8")) as T;
+  } catch (error) {
+    errors.push(`${fileName} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+function summarizeArtifact<T>(
+  fileName: string,
+  errors: string[],
+  summarize: () => T
+): T | null {
+  try {
+    return summarize();
+  } catch (error) {
+    errors.push(`${fileName} summary failed: ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+function summarizeReport(report: SecurityReport): EvidencePackReportSummary {
+  return {
+    score: {
+      grade: report.score.grade,
+      numericScore: report.score.numericScore,
+    },
+    findings: {
+      total: report.summary.totalFindings,
+      critical: report.summary.critical,
+      high: report.summary.high,
+      medium: report.summary.medium,
+      low: report.summary.low,
+      info: report.summary.info,
+    },
+    runtimeConfidence: countRuntimeConfidence(report),
+  };
+}
+
+function countRuntimeConfidence(report: SecurityReport): Readonly<Record<string, number>> {
+  const counts = report.findings.reduce<Record<string, number>>((accumulator, finding) => {
+    const key = finding.runtimeConfidence ?? "active-runtime";
+    return {
+      ...accumulator,
+      [key]: (accumulator[key] ?? 0) + 1,
+    };
+  }, {});
+  return Object.fromEntries(Object.entries(counts).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function summarizePolicy(policy: Record<string, unknown> | null): EvidencePackPolicySummary {
+  if (!policy) return { status: "unknown" };
+  if (policy.status === "not-run") return { status: "not-run" };
+
+  const violations = Array.isArray(policy.violations) ? policy.violations.length : undefined;
+  return {
+    status: policy.passed === true ? "passed" : policy.passed === false ? "failed" : "unknown",
+    policyName: typeof policy.policyName === "string" ? policy.policyName : undefined,
+    policyPack: typeof policy.policyPack === "string" ? policy.policyPack : undefined,
+    violations,
+  };
+}
+
+function summarizeBaseline(baseline: Record<string, unknown> | null): EvidencePackBaselineSummary {
+  if (!baseline) return { status: "unknown" };
+  if (baseline.status === "not-run") return { status: "not-run" };
+
+  return {
+    status: baseline.isRegression === true ? "regressed" : baseline.isRegression === false ? "passed" : "unknown",
+    newFindings: Array.isArray(baseline.newFindings) ? baseline.newFindings.length : undefined,
+    resolvedFindings: Array.isArray(baseline.resolvedFindings) ? baseline.resolvedFindings.length : undefined,
+    unchangedCount: typeof baseline.unchangedCount === "number" ? baseline.unchangedCount : undefined,
+    scoreDelta: typeof baseline.scoreDelta === "number" ? baseline.scoreDelta : undefined,
+  };
+}
+
+function summarizeSupplyChain(report: SupplyChainReport): EvidencePackSupplyChainSummary {
+  return {
+    totalPackages: report.totalPackages,
+    riskyPackages: report.riskyPackages,
+    criticalCount: report.criticalCount,
+    highCount: report.highCount,
+  };
+}
+
+function summarizeCiContext(context: EvidencePackCiContext): EvidencePackCiSummary {
+  return {
+    provider: context.provider,
+    repository: context.github?.repository,
+    workflow: context.github?.workflow,
+    runId: context.github?.runId,
+    sha: context.github?.sha,
+  };
+}
+
+function summarizeRemediation(remediation: Record<string, unknown>): EvidencePackRemediationSummary | null {
+  const summary = remediation.summary;
+  const workflow = remediation.workflow;
+  if (!summary || typeof summary !== "object") return null;
+
+  const summaryRecord = summary as Record<string, unknown>;
+  const phases = workflow && typeof workflow === "object" && Array.isArray((workflow as Record<string, unknown>).phases)
+    ? ((workflow as { phases: ReadonlyArray<Record<string, unknown>> }).phases)
+    : [];
+
+  return {
+    totalFindings: numberOrZero(summaryRecord.totalFindings),
+    autoFixable: numberOrZero(summaryRecord.autoFixable),
+    manualReview: numberOrZero(summaryRecord.manualReview),
+    phases: phases.map((phase) => ({
+      id: typeof phase.id === "string" ? phase.id : "unknown",
+      findingCount: numberOrZero(phase.findingCount),
+      blocking: phase.blocking === true,
+    })),
+  };
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" ? value : 0;
 }
 
 function hashContent(content: string): { readonly sha256: string; readonly bytes: number } {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { renderTerminalReport } from "./reporter/terminal.js";
 import { renderJsonReport, renderMarkdownReport } from "./reporter/json.js";
 import { renderHtmlReport } from "./reporter/html.js";
 import { renderSarifReport } from "./reporter/sarif.js";
-import { verifyEvidencePack, writeEvidencePack } from "./evidence-pack/index.js";
+import { inspectEvidencePack, verifyEvidencePack, writeEvidencePack } from "./evidence-pack/index.js";
 import { runOpusPipeline, renderOpusAnalysis } from "./opus/index.js";
 import { applyFixes, renderFixSummary } from "./fixer/index.js";
 import { runInit, renderInitSummary } from "./init/index.js";
@@ -31,6 +31,10 @@ import type {
   DeepScanResult,
 } from "./types.js";
 import type { PolicyEvaluation } from "./policy/index.js";
+
+function writeStdout(line = ""): void {
+  process.stdout.write(`${line}\n`);
+}
 
 // ─── Dynamic Module Loaders ───────────────────────────────────
 // These modules are being built in parallel by other agents.
@@ -671,6 +675,64 @@ program
 const evidencePack = program
   .command("evidence-pack")
   .description("Inspect and verify AgentShield evidence-pack bundles");
+
+evidencePack
+  .command("inspect")
+  .description("Inspect verified evidence-pack contents for downstream consumers")
+  .argument("<dir>", "Evidence-pack directory")
+  .option("--json", "Emit machine-readable inspection results", false)
+  .action((dir, options) => {
+    const result = inspectEvidencePack(dir);
+    if (options.json) {
+      writeStdout(JSON.stringify(result, null, 2));
+    } else {
+      writeStdout();
+      writeStdout("AgentShield Evidence Pack Inspection");
+      writeStdout(`Directory:   ${result.outputDir}`);
+      writeStdout(`Status:      ${result.ok ? "passed" : "failed"}`);
+      writeStdout(`Digest:      ${result.bundleDigest ?? "not available"}`);
+      writeStdout(`Generated:   ${result.generatedAt ?? "unknown"}`);
+      writeStdout(`Target:      ${result.targetPath ?? "unknown"}`);
+      writeStdout(`Artifacts:   ${result.verifiedArtifactCount}/${result.artifactCount} verified`);
+      if (result.report) {
+        writeStdout(
+          `Score:       ${result.report.score.numericScore}/100 (${result.report.score.grade}); ${result.report.findings.total} findings`
+        );
+        writeStdout(
+          `Findings:    critical ${result.report.findings.critical}, high ${result.report.findings.high}, medium ${result.report.findings.medium}, low ${result.report.findings.low}, info ${result.report.findings.info}`
+        );
+      }
+      writeStdout(`Policy:      ${result.policy.status}`);
+      writeStdout(`Baseline:    ${result.baseline.status}`);
+      if (result.supplyChain) {
+        writeStdout(
+          `Supply:      ${result.supplyChain.riskyPackages}/${result.supplyChain.totalPackages} risky packages`
+        );
+      }
+      if (result.ciContext) {
+        writeStdout(
+          `CI:          ${result.ciContext.provider}${result.ciContext.repository ? ` ${result.ciContext.repository}` : ""}`
+        );
+      }
+      if (result.remediation) {
+        writeStdout(
+          `Remediate:   ${result.remediation.autoFixable} auto-fixable, ${result.remediation.manualReview} manual-review`
+        );
+      }
+      if (result.errors.length > 0) {
+        writeStdout();
+        writeStdout("Errors:");
+        for (const error of result.errors) {
+          writeStdout(`- ${error}`);
+        }
+      }
+      writeStdout();
+    }
+
+    if (!result.ok) {
+      process.exit(6);
+    }
+  });
 
 evidencePack
   .command("verify")

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { verifyEvidencePack, writeEvidencePack } from "../../src/evidence-pack/index.js";
+import { inspectEvidencePack, verifyEvidencePack, writeEvidencePack } from "../../src/evidence-pack/index.js";
 import type { BaselineComparison } from "../../src/baseline/index.js";
 import type { PolicyEvaluation } from "../../src/policy/index.js";
 import type { SupplyChainReport } from "../../src/supply-chain/index.js";
@@ -386,6 +386,83 @@ describe("writeEvidencePack", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("inspects evidence packs as a downstream consumer summary", () => {
+    const targetPath = mkdtempSync(join(tmpdir(), "agentshield-inspect-target-"));
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-evidence-pack-"));
+
+    writeEvidencePack({
+      outputDir,
+      report: makeReport(targetPath),
+      policyEvaluation: makePolicyEvaluation(),
+      baselineComparison: makeBaselineComparison(targetPath),
+      supplyChainReport: makeSupplyChainReport(),
+      generatedAt: "2026-05-13T05:02:30.000Z",
+      environment: makeGitHubEnvironment(targetPath),
+    });
+
+    const result = inspectEvidencePack(outputDir);
+
+    expect(result.ok).toBe(true);
+    expect(result.generatedAt).toBe("2026-05-13T05:02:30.000Z");
+    expect(result.targetPath).toBe("<target-path>");
+    expect(result.artifactCount).toBe(10);
+    expect(result.verifiedArtifactCount).toBe(10);
+    expect(result.report).toMatchObject({
+      score: { grade: "C", numericScore: 72 },
+      findings: { total: 1, critical: 1 },
+      runtimeConfidence: { "active-runtime": 1 },
+    });
+    expect(result.policy).toMatchObject({
+      status: "failed",
+      policyName: "Enterprise Policy",
+      violations: 1,
+    });
+    expect(result.baseline).toMatchObject({
+      status: "regressed",
+      newFindings: 1,
+      resolvedFindings: 0,
+      scoreDelta: -8,
+    });
+    expect(result.supplyChain).toMatchObject({
+      totalPackages: 0,
+      riskyPackages: 0,
+    });
+    expect(result.ciContext).toMatchObject({
+      provider: "github-actions",
+      repository: "affaan-m/agentshield",
+      runId: "987654321",
+    });
+    expect(result.remediation).toMatchObject({
+      totalFindings: 1,
+      autoFixable: 0,
+      manualReview: 1,
+    });
+  });
+
+  it("reports malformed artifact shapes as inspection errors instead of throwing", () => {
+    const targetPath = mkdtempSync(join(tmpdir(), "agentshield-malformed-inspect-target-"));
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-evidence-pack-"));
+
+    writeEvidencePack({
+      outputDir,
+      report: makeReport(targetPath),
+      supplyChainReport: makeSupplyChainReport(),
+      generatedAt: "2026-05-13T05:02:45.000Z",
+    });
+    writeFileSync(join(outputDir, "agentshield-report.json"), "{}\n");
+
+    const result = inspectEvidencePack(outputDir);
+
+    expect(result.ok).toBe(false);
+    expect(result.report).toBeNull();
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("agentshield-report.json digest mismatch"),
+        expect.stringContaining("agentshield-report.json summary failed"),
+      ])
+    );
+  });
+
   it("detects tampered evidence-pack artifacts", () => {
     const targetPath = mkdtempSync(join(tmpdir(), "agentshield-tamper-target-"));
     const outputDir = mkdtempSync(join(tmpdir(), "agentshield-evidence-pack-"));
@@ -458,6 +535,86 @@ describe("writeEvidencePack", () => {
 
     expect(invalid.status).toBe(6);
     expect(JSON.parse(invalid.stdout)).toMatchObject({
+      ok: false,
+      errors: expect.arrayContaining([expect.stringContaining("agentshield-report.json")]),
+    });
+  });
+
+  it("exposes evidence-pack inspection through the CLI", () => {
+    const targetPath = mkdtempSync(join(tmpdir(), "agentshield-cli-inspect-target-"));
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-evidence-pack-"));
+
+    writeEvidencePack({
+      outputDir,
+      report: makeReport(targetPath),
+      policyEvaluation: makePolicyEvaluation(),
+      baselineComparison: makeBaselineComparison(targetPath),
+      supplyChainReport: makeSupplyChainReport(),
+      generatedAt: "2026-05-13T05:05:00.000Z",
+      environment: makeGitHubEnvironment(targetPath),
+    });
+
+    const text = spawnSync(process.execPath, [
+      CLI_PATH,
+      "evidence-pack",
+      "inspect",
+      outputDir,
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(text.status).toBe(0);
+    expect(text.stdout).toContain("AgentShield Evidence Pack Inspection");
+    expect(text.stdout).toContain("Score:       72/100 (C); 1 findings");
+    expect(text.stdout).toContain("Policy:      failed");
+    expect(text.stdout).toContain("Baseline:    regressed");
+
+    const json = spawnSync(process.execPath, [
+      CLI_PATH,
+      "evidence-pack",
+      "inspect",
+      outputDir,
+      "--json",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(json.status).toBe(0);
+    expect(JSON.parse(json.stdout)).toMatchObject({
+      ok: true,
+      report: {
+        score: { grade: "C", numericScore: 72 },
+      },
+      policy: { status: "failed" },
+      baseline: { status: "regressed" },
+      ciContext: { provider: "github-actions" },
+    });
+
+    writeFileSync(join(outputDir, "agentshield-report.json"), "{}\n");
+    const invalidJson = spawnSync(process.execPath, [
+      CLI_PATH,
+      "evidence-pack",
+      "inspect",
+      outputDir,
+      "--json",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(invalidJson.status).toBe(6);
+    expect(JSON.parse(invalidJson.stdout)).toMatchObject({
       ok: false,
       errors: expect.arrayContaining([expect.stringContaining("agentshield-report.json")]),
     });


### PR DESCRIPTION
## Summary
- add `inspectEvidencePack()` to verify and summarize saved evidence packs for downstream consumers
- expose `agentshield evidence-pack inspect [--json]` with score, finding, runtime-confidence, policy, baseline, supply-chain, CI, and remediation readback
- document the consumer/readback flow and cover it in direct + CLI evidence-pack tests

## Verification
- `npm run typecheck`
- `npm run build`
- `npx vitest run tests/evidence-pack/evidence-pack.test.ts tests/action.test.ts`
- `npm test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds evidence-pack inspection that verifies a saved bundle and returns a compact summary for downstream consumers via API and CLI. Supports human-readable and JSON output, and collects verification/shape errors instead of throwing.

- **New Features**
  - New API `inspectEvidencePack()` verifies the bundle, reads `manifest.json`, `agentshield-report.json`, `policy-evaluation.json`, `baseline-comparison.json`, `supply-chain.json`, `ci-context.json`, and `remediation-plan.json`, then returns a summary with metadata (generatedAt, targetPath, redacted, artifact/verified counts, digests) and an error list.
  - New CLI: `agentshield evidence-pack inspect <dir> [--json]` prints a readable summary (score, finding counts, runtime-confidence, policy/baseline status, supply-chain, CI provenance, remediation) or emits structured JSON; exits non-zero if inspection fails.
  - Docs updated in `README.md` and `API.md` with inspect usage and command help.
  - Tests added for API summaries, malformed artifact handling (errors collected, no throw), CLI text/JSON output, and non-zero exit on failure.

<sup>Written for commit 1378ff796d90c29d3189ba9e3ceed7acd03f8330. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/88?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an evidence-pack "inspect" command (human-readable or --json output) that reports status, counts, scores, policy/baseline/supply-chain summaries, CI provenance, remediation totals, and exits non‑zero (exit code 6) when inspection fails.

* **Documentation**
  * Expanded API/CLI docs and README with inspect usage, examples, and updated evidence-pack artifact/spec (including baseline-comparison, CI context, and remediation-plan details).

* **Tests**
  * Added unit and CLI tests for successful inspection and malformed-pack error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->