### PR TITLE
feat: summarize evidence pack fleets

### DIFF
--- a/API.md
+++ b/API.md
@@ -210,12 +210,17 @@ Consumers can verify and read back a saved pack:
 ```bash
 agentshield evidence-pack verify ./agentshield-evidence --json
 agentshield evidence-pack inspect ./agentshield-evidence --json
+agentshield evidence-pack fleet ./repo-a-evidence ./repo-b-evidence --json
 ```
 
 `inspect` verifies the bundle first, then emits score, finding counts,
 runtime-confidence counts, policy status, baseline drift status, supply-chain
 counts, CI provenance, and remediation workflow counts for GitHub App, Linear,
 or customer-review ingestion.
+
+`fleet` runs the same inspection across multiple evidence-pack directories and
+emits totals plus route suggestions: `invalid`, `security-blocker`,
+`policy-review`, `baseline-regression`, `supply-chain-review`, or `ready`.
 
 Top-level shape:
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,14 @@ agentshield evidence-pack inspect ./agentshield-evidence
 agentshield evidence-pack inspect ./agentshield-evidence --json
 ```
 
+Aggregate multiple verified evidence packs when an operator needs fleet-level
+routing across repos, teams, or harnesses:
+
+```bash
+agentshield evidence-pack fleet ./repo-a-evidence ./repo-b-evidence
+agentshield evidence-pack fleet ./repo-a-evidence ./repo-b-evidence --json
+```
+
 ### JSON Report Shape
 
 `agentshield scan --format json` is the supported machine-readable scanner interface today.
@@ -582,6 +590,7 @@ agentshield scan [options]         Scan configuration directory
 
 agentshield init                   Generate secure baseline config
 agentshield baseline write         Write a scan baseline JSON file
+agentshield evidence-pack fleet    Summarize multiple evidence packs for routing
 agentshield evidence-pack inspect  Verify and summarize an evidence bundle
 agentshield evidence-pack verify   Verify artifact and bundle digests
 agentshield policy init            Generate an organization policy preset

--- a/dist/index.js
+++ b/dist/index.js
@@ -15273,6 +15273,118 @@ function inspectEvidencePack(outputDir) {
     errors
   };
 }
+function inspectEvidencePackFleet(outputDirs) {
+  const entries = outputDirs.map(
+    (outputDir) => summarizeFleetEntry(inspectEvidencePack(outputDir))
+  );
+  const summary = entries.reduce(
+    (accumulator, entry) => ({
+      totalPacks: accumulator.totalPacks + 1,
+      verifiedPacks: accumulator.verifiedPacks + (entry.ok ? 1 : 0),
+      invalidPacks: accumulator.invalidPacks + (entry.ok ? 0 : 1),
+      totalFindings: accumulator.totalFindings + entry.totalFindings,
+      critical: accumulator.critical + entry.critical,
+      high: accumulator.high + entry.high,
+      medium: accumulator.medium + entry.medium,
+      low: accumulator.low + entry.low,
+      info: accumulator.info + entry.info,
+      policyFailures: accumulator.policyFailures + (entry.policyStatus === "failed" ? 1 : 0),
+      baselineRegressions: accumulator.baselineRegressions + (entry.baselineStatus === "regressed" ? 1 : 0),
+      riskyPackages: accumulator.riskyPackages + entry.riskyPackages,
+      autoFixable: accumulator.autoFixable + entry.autoFixable,
+      manualReview: accumulator.manualReview + entry.manualReview
+    }),
+    {
+      totalPacks: 0,
+      verifiedPacks: 0,
+      invalidPacks: 0,
+      totalFindings: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+      policyFailures: 0,
+      baselineRegressions: 0,
+      riskyPackages: 0,
+      autoFixable: 0,
+      manualReview: 0
+    }
+  );
+  const routes = entries.map((entry) => ({
+    route: entry.route,
+    outputDir: entry.outputDir,
+    repository: entry.repository,
+    targetPath: entry.targetPath,
+    reason: entry.reason
+  }));
+  const errors = entries.flatMap(
+    (entry) => entry.errors.map((error) => `${entry.outputDir}: ${error}`)
+  );
+  return {
+    ok: summary.invalidPacks === 0,
+    requiresAttention: routes.some((route) => route.route !== "ready"),
+    summary,
+    entries,
+    routes,
+    errors
+  };
+}
+function summarizeFleetEntry(inspection) {
+  const findings = inspection.report?.findings;
+  const route = determineFleetRoute(inspection);
+  return {
+    outputDir: inspection.outputDir,
+    ok: inspection.ok,
+    route,
+    reason: describeFleetRoute(inspection, route),
+    generatedAt: inspection.generatedAt,
+    targetPath: inspection.targetPath,
+    repository: inspection.ciContext?.repository ?? null,
+    provider: inspection.ciContext?.provider ?? null,
+    score: inspection.report?.score.numericScore ?? null,
+    grade: inspection.report?.score.grade ?? null,
+    totalFindings: findings?.total ?? 0,
+    critical: findings?.critical ?? 0,
+    high: findings?.high ?? 0,
+    medium: findings?.medium ?? 0,
+    low: findings?.low ?? 0,
+    info: findings?.info ?? 0,
+    policyStatus: inspection.policy.status,
+    baselineStatus: inspection.baseline.status,
+    riskyPackages: inspection.supplyChain?.riskyPackages ?? 0,
+    autoFixable: inspection.remediation?.autoFixable ?? 0,
+    manualReview: inspection.remediation?.manualReview ?? 0,
+    errors: inspection.errors
+  };
+}
+function determineFleetRoute(inspection) {
+  if (!inspection.ok) return "invalid";
+  if ((inspection.report?.findings.critical ?? 0) > 0 || (inspection.report?.findings.high ?? 0) > 0) {
+    return "security-blocker";
+  }
+  if ((inspection.supplyChain?.criticalCount ?? 0) > 0 || (inspection.supplyChain?.highCount ?? 0) > 0) {
+    return "security-blocker";
+  }
+  if (inspection.policy.status === "failed") return "policy-review";
+  if (inspection.baseline.status === "regressed") return "baseline-regression";
+  if ((inspection.supplyChain?.riskyPackages ?? 0) > 0) return "supply-chain-review";
+  return "ready";
+}
+function describeFleetRoute(inspection, route) {
+  if (route === "invalid") return inspection.errors[0] ?? "evidence pack failed verification";
+  const findings = inspection.report?.findings;
+  if (route === "security-blocker") {
+    if ((findings?.critical ?? 0) > 0) return `${findings?.critical ?? 0} critical findings`;
+    if ((findings?.high ?? 0) > 0) return `${findings?.high ?? 0} high findings`;
+    if ((inspection.supplyChain?.criticalCount ?? 0) > 0) return `${inspection.supplyChain?.criticalCount ?? 0} critical supply-chain packages`;
+    return `${inspection.supplyChain?.highCount ?? 0} high supply-chain packages`;
+  }
+  if (route === "policy-review") return "policy failed";
+  if (route === "baseline-regression") return "baseline regressed";
+  if (route === "supply-chain-review") return `${inspection.supplyChain?.riskyPackages ?? 0} risky packages`;
+  return "no routing blockers";
+}
 function buildCiContext(environment, generatedAt) {
   const github = compact({
     repository: environment.GITHUB_REPOSITORY,
@@ -18464,6 +18576,40 @@ evidencePack.command("inspect").description("Inspect verified evidence-pack cont
       for (const error of result.errors) {
         writeStdout(`- ${error}`);
       }
+    }
+    writeStdout();
+  }
+  if (!result.ok) {
+    process.exit(6);
+  }
+});
+evidencePack.command("fleet").description("Inspect multiple evidence packs and summarize fleet routing").argument("<dirs...>", "Evidence-pack directories").option("--json", "Emit machine-readable fleet inspection results", false).action((dirs, options) => {
+  const result = inspectEvidencePackFleet(dirs);
+  if (options.json) {
+    writeStdout(JSON.stringify(result, null, 2));
+  } else {
+    writeStdout();
+    writeStdout("AgentShield Evidence Pack Fleet");
+    writeStdout(
+      `Packs:       ${result.summary.totalPacks} total, ${result.summary.verifiedPacks} verified, ${result.summary.invalidPacks} invalid`
+    );
+    writeStdout(`Status:      ${result.ok ? "verified" : "invalid evidence"}`);
+    writeStdout(`Attention:   ${result.requiresAttention ? "required" : "none"}`);
+    writeStdout(
+      `Findings:    critical ${result.summary.critical}, high ${result.summary.high}, medium ${result.summary.medium}, low ${result.summary.low}, info ${result.summary.info}`
+    );
+    writeStdout(
+      `Policy:      ${result.summary.policyFailures} failed; Baseline: ${result.summary.baselineRegressions} regressed; Supply: ${result.summary.riskyPackages} risky packages`
+    );
+    writeStdout(
+      `Remediate:   ${result.summary.autoFixable} auto-fixable, ${result.summary.manualReview} manual-review`
+    );
+    writeStdout();
+    writeStdout("Routes:");
+    for (const route of result.routes) {
+      writeStdout(
+        `- ${route.route} ${route.repository ?? route.targetPath ?? route.outputDir}: ${route.reason}`
+      );
     }
     writeStdout();
   }

--- a/src/evidence-pack/index.ts
+++ b/src/evidence-pack/index.ts
@@ -68,6 +68,73 @@ export interface EvidencePackInspectionResult {
   readonly errors: ReadonlyArray<string>;
 }
 
+export type EvidencePackFleetRoute =
+  | "invalid"
+  | "security-blocker"
+  | "policy-review"
+  | "baseline-regression"
+  | "supply-chain-review"
+  | "ready";
+
+export interface EvidencePackFleetInspectionResult {
+  readonly ok: boolean;
+  readonly requiresAttention: boolean;
+  readonly summary: EvidencePackFleetSummary;
+  readonly entries: ReadonlyArray<EvidencePackFleetEntry>;
+  readonly routes: ReadonlyArray<EvidencePackFleetRouteEntry>;
+  readonly errors: ReadonlyArray<string>;
+}
+
+export interface EvidencePackFleetSummary {
+  readonly totalPacks: number;
+  readonly verifiedPacks: number;
+  readonly invalidPacks: number;
+  readonly totalFindings: number;
+  readonly critical: number;
+  readonly high: number;
+  readonly medium: number;
+  readonly low: number;
+  readonly info: number;
+  readonly policyFailures: number;
+  readonly baselineRegressions: number;
+  readonly riskyPackages: number;
+  readonly autoFixable: number;
+  readonly manualReview: number;
+}
+
+export interface EvidencePackFleetEntry {
+  readonly outputDir: string;
+  readonly ok: boolean;
+  readonly route: EvidencePackFleetRoute;
+  readonly reason: string;
+  readonly generatedAt: string | null;
+  readonly targetPath: string | null;
+  readonly repository: string | null;
+  readonly provider: "github-actions" | "local" | "unknown" | null;
+  readonly score: number | null;
+  readonly grade: string | null;
+  readonly totalFindings: number;
+  readonly critical: number;
+  readonly high: number;
+  readonly medium: number;
+  readonly low: number;
+  readonly info: number;
+  readonly policyStatus: EvidencePackPolicySummary["status"];
+  readonly baselineStatus: EvidencePackBaselineSummary["status"];
+  readonly riskyPackages: number;
+  readonly autoFixable: number;
+  readonly manualReview: number;
+  readonly errors: ReadonlyArray<string>;
+}
+
+export interface EvidencePackFleetRouteEntry {
+  readonly route: EvidencePackFleetRoute;
+  readonly outputDir: string;
+  readonly repository: string | null;
+  readonly targetPath: string | null;
+  readonly reason: string;
+}
+
 export interface EvidencePackReportSummary {
   readonly score: {
     readonly grade: string;
@@ -441,6 +508,126 @@ export function inspectEvidencePack(outputDir: string): EvidencePackInspectionRe
     verification,
     errors,
   };
+}
+
+export function inspectEvidencePackFleet(outputDirs: ReadonlyArray<string>): EvidencePackFleetInspectionResult {
+  const entries: ReadonlyArray<EvidencePackFleetEntry> = outputDirs.map((outputDir) =>
+    summarizeFleetEntry(inspectEvidencePack(outputDir))
+  );
+  const summary = entries.reduce<EvidencePackFleetSummary>(
+    (accumulator, entry) => ({
+      totalPacks: accumulator.totalPacks + 1,
+      verifiedPacks: accumulator.verifiedPacks + (entry.ok ? 1 : 0),
+      invalidPacks: accumulator.invalidPacks + (entry.ok ? 0 : 1),
+      totalFindings: accumulator.totalFindings + entry.totalFindings,
+      critical: accumulator.critical + entry.critical,
+      high: accumulator.high + entry.high,
+      medium: accumulator.medium + entry.medium,
+      low: accumulator.low + entry.low,
+      info: accumulator.info + entry.info,
+      policyFailures: accumulator.policyFailures + (entry.policyStatus === "failed" ? 1 : 0),
+      baselineRegressions: accumulator.baselineRegressions + (entry.baselineStatus === "regressed" ? 1 : 0),
+      riskyPackages: accumulator.riskyPackages + entry.riskyPackages,
+      autoFixable: accumulator.autoFixable + entry.autoFixable,
+      manualReview: accumulator.manualReview + entry.manualReview,
+    }),
+    {
+      totalPacks: 0,
+      verifiedPacks: 0,
+      invalidPacks: 0,
+      totalFindings: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+      policyFailures: 0,
+      baselineRegressions: 0,
+      riskyPackages: 0,
+      autoFixable: 0,
+      manualReview: 0,
+    }
+  );
+  const routes: ReadonlyArray<EvidencePackFleetRouteEntry> = entries.map((entry) => ({
+    route: entry.route,
+    outputDir: entry.outputDir,
+    repository: entry.repository,
+    targetPath: entry.targetPath,
+    reason: entry.reason,
+  }));
+  const errors: ReadonlyArray<string> = entries.flatMap((entry) =>
+    entry.errors.map((error) => `${entry.outputDir}: ${error}`)
+  );
+
+  return {
+    ok: summary.invalidPacks === 0,
+    requiresAttention: routes.some((route) => route.route !== "ready"),
+    summary,
+    entries,
+    routes,
+    errors,
+  };
+}
+
+function summarizeFleetEntry(inspection: EvidencePackInspectionResult): EvidencePackFleetEntry {
+  const findings = inspection.report?.findings;
+  const route = determineFleetRoute(inspection);
+  return {
+    outputDir: inspection.outputDir,
+    ok: inspection.ok,
+    route,
+    reason: describeFleetRoute(inspection, route),
+    generatedAt: inspection.generatedAt,
+    targetPath: inspection.targetPath,
+    repository: inspection.ciContext?.repository ?? null,
+    provider: inspection.ciContext?.provider ?? null,
+    score: inspection.report?.score.numericScore ?? null,
+    grade: inspection.report?.score.grade ?? null,
+    totalFindings: findings?.total ?? 0,
+    critical: findings?.critical ?? 0,
+    high: findings?.high ?? 0,
+    medium: findings?.medium ?? 0,
+    low: findings?.low ?? 0,
+    info: findings?.info ?? 0,
+    policyStatus: inspection.policy.status,
+    baselineStatus: inspection.baseline.status,
+    riskyPackages: inspection.supplyChain?.riskyPackages ?? 0,
+    autoFixable: inspection.remediation?.autoFixable ?? 0,
+    manualReview: inspection.remediation?.manualReview ?? 0,
+    errors: inspection.errors,
+  };
+}
+
+function determineFleetRoute(inspection: EvidencePackInspectionResult): EvidencePackFleetRoute {
+  if (!inspection.ok) return "invalid";
+  if ((inspection.report?.findings.critical ?? 0) > 0 || (inspection.report?.findings.high ?? 0) > 0) {
+    return "security-blocker";
+  }
+  if ((inspection.supplyChain?.criticalCount ?? 0) > 0 || (inspection.supplyChain?.highCount ?? 0) > 0) {
+    return "security-blocker";
+  }
+  if (inspection.policy.status === "failed") return "policy-review";
+  if (inspection.baseline.status === "regressed") return "baseline-regression";
+  if ((inspection.supplyChain?.riskyPackages ?? 0) > 0) return "supply-chain-review";
+  return "ready";
+}
+
+function describeFleetRoute(
+  inspection: EvidencePackInspectionResult,
+  route: EvidencePackFleetRoute
+): string {
+  if (route === "invalid") return inspection.errors[0] ?? "evidence pack failed verification";
+  const findings = inspection.report?.findings;
+  if (route === "security-blocker") {
+    if ((findings?.critical ?? 0) > 0) return `${findings?.critical ?? 0} critical findings`;
+    if ((findings?.high ?? 0) > 0) return `${findings?.high ?? 0} high findings`;
+    if ((inspection.supplyChain?.criticalCount ?? 0) > 0) return `${inspection.supplyChain?.criticalCount ?? 0} critical supply-chain packages`;
+    return `${inspection.supplyChain?.highCount ?? 0} high supply-chain packages`;
+  }
+  if (route === "policy-review") return "policy failed";
+  if (route === "baseline-regression") return "baseline regressed";
+  if (route === "supply-chain-review") return `${inspection.supplyChain?.riskyPackages ?? 0} risky packages`;
+  return "no routing blockers";
 }
 
 function buildCiContext(

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,12 @@ import { renderTerminalReport } from "./reporter/terminal.js";
 import { renderJsonReport, renderMarkdownReport } from "./reporter/json.js";
 import { renderHtmlReport } from "./reporter/html.js";
 import { renderSarifReport } from "./reporter/sarif.js";
-import { inspectEvidencePack, verifyEvidencePack, writeEvidencePack } from "./evidence-pack/index.js";
+import {
+  inspectEvidencePack,
+  inspectEvidencePackFleet,
+  verifyEvidencePack,
+  writeEvidencePack,
+} from "./evidence-pack/index.js";
 import { runOpusPipeline, renderOpusAnalysis } from "./opus/index.js";
 import { applyFixes, renderFixSummary } from "./fixer/index.js";
 import { runInit, renderInitSummary } from "./init/index.js";
@@ -725,6 +730,47 @@ evidencePack
         for (const error of result.errors) {
           writeStdout(`- ${error}`);
         }
+      }
+      writeStdout();
+    }
+
+    if (!result.ok) {
+      process.exit(6);
+    }
+  });
+
+evidencePack
+  .command("fleet")
+  .description("Inspect multiple evidence packs and summarize fleet routing")
+  .argument("<dirs...>", "Evidence-pack directories")
+  .option("--json", "Emit machine-readable fleet inspection results", false)
+  .action((dirs: ReadonlyArray<string>, options) => {
+    const result = inspectEvidencePackFleet(dirs);
+    if (options.json) {
+      writeStdout(JSON.stringify(result, null, 2));
+    } else {
+      writeStdout();
+      writeStdout("AgentShield Evidence Pack Fleet");
+      writeStdout(
+        `Packs:       ${result.summary.totalPacks} total, ${result.summary.verifiedPacks} verified, ${result.summary.invalidPacks} invalid`
+      );
+      writeStdout(`Status:      ${result.ok ? "verified" : "invalid evidence"}`);
+      writeStdout(`Attention:   ${result.requiresAttention ? "required" : "none"}`);
+      writeStdout(
+        `Findings:    critical ${result.summary.critical}, high ${result.summary.high}, medium ${result.summary.medium}, low ${result.summary.low}, info ${result.summary.info}`
+      );
+      writeStdout(
+        `Policy:      ${result.summary.policyFailures} failed; Baseline: ${result.summary.baselineRegressions} regressed; Supply: ${result.summary.riskyPackages} risky packages`
+      );
+      writeStdout(
+        `Remediate:   ${result.summary.autoFixable} auto-fixable, ${result.summary.manualReview} manual-review`
+      );
+      writeStdout();
+      writeStdout("Routes:");
+      for (const route of result.routes) {
+        writeStdout(
+          `- ${route.route} ${route.repository ?? route.targetPath ?? route.outputDir}: ${route.reason}`
+        );
       }
       writeStdout();
     }

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -4,7 +4,12 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { inspectEvidencePack, verifyEvidencePack, writeEvidencePack } from "../../src/evidence-pack/index.js";
+import {
+  inspectEvidencePack,
+  inspectEvidencePackFleet,
+  verifyEvidencePack,
+  writeEvidencePack,
+} from "../../src/evidence-pack/index.js";
 import type { BaselineComparison } from "../../src/baseline/index.js";
 import type { PolicyEvaluation } from "../../src/policy/index.js";
 import type { SupplyChainReport } from "../../src/supply-chain/index.js";
@@ -131,6 +136,73 @@ function makeGitHubEnvironment(targetPath: string): Record<string, string> {
     RUNNER_TEMP: join(targetPath, "runner-temp"),
     RUNNER_TOOL_CACHE: join(targetPath, "tool-cache"),
   };
+}
+
+function makeCleanReport(targetPath: string): SecurityReport {
+  const report = makeReport(targetPath);
+  return {
+    ...report,
+    findings: [],
+    score: {
+      ...report.score,
+      grade: "A",
+      numericScore: 100,
+    },
+    summary: {
+      totalFindings: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+      filesScanned: 1,
+      autoFixable: 0,
+    },
+  };
+}
+
+function makePassingPolicyEvaluation(): PolicyEvaluation {
+  return {
+    ...makePolicyEvaluation(),
+    passed: true,
+    violations: [],
+    score: 100,
+  };
+}
+
+function makePassingBaselineComparison(targetPath: string): BaselineComparison {
+  return {
+    ...makeBaselineComparison(targetPath),
+    newFindings: [],
+    scoreDelta: 0,
+    currentScore: 100,
+    isRegression: false,
+    newCriticalCount: 0,
+  };
+}
+
+function writeFleetEvidencePack(options: {
+  readonly outputDir: string;
+  readonly targetPath: string;
+  readonly generatedAt: string;
+  readonly repository: string;
+  readonly report?: SecurityReport;
+  readonly policyEvaluation?: PolicyEvaluation;
+  readonly baselineComparison?: BaselineComparison;
+  readonly supplyChainReport?: SupplyChainReport;
+}): void {
+  writeEvidencePack({
+    outputDir: options.outputDir,
+    report: options.report ?? makeReport(options.targetPath),
+    policyEvaluation: options.policyEvaluation ?? makePolicyEvaluation(),
+    baselineComparison: options.baselineComparison ?? makeBaselineComparison(options.targetPath),
+    supplyChainReport: options.supplyChainReport ?? makeSupplyChainReport(),
+    generatedAt: options.generatedAt,
+    environment: {
+      ...makeGitHubEnvironment(options.targetPath),
+      GITHUB_REPOSITORY: options.repository,
+    },
+  });
 }
 
 describe("writeEvidencePack", () => {
@@ -617,6 +689,184 @@ describe("writeEvidencePack", () => {
     expect(JSON.parse(invalidJson.stdout)).toMatchObject({
       ok: false,
       errors: expect.arrayContaining([expect.stringContaining("agentshield-report.json")]),
+    });
+  });
+
+  it("aggregates multiple evidence packs into a fleet routing summary", () => {
+    const cleanTargetPath = mkdtempSync(join(tmpdir(), "agentshield-fleet-clean-target-"));
+    const riskyTargetPath = mkdtempSync(join(tmpdir(), "agentshield-fleet-risky-target-"));
+    const cleanOutputDir = mkdtempSync(join(tmpdir(), "agentshield-fleet-clean-pack-"));
+    const riskyOutputDir = mkdtempSync(join(tmpdir(), "agentshield-fleet-risky-pack-"));
+
+    writeFleetEvidencePack({
+      outputDir: cleanOutputDir,
+      targetPath: cleanTargetPath,
+      report: makeCleanReport(cleanTargetPath),
+      policyEvaluation: makePassingPolicyEvaluation(),
+      baselineComparison: makePassingBaselineComparison(cleanTargetPath),
+      generatedAt: "2026-05-13T05:10:00.000Z",
+      repository: "affaan-m/clean-repo",
+    });
+    writeFleetEvidencePack({
+      outputDir: riskyOutputDir,
+      targetPath: riskyTargetPath,
+      supplyChainReport: {
+        ...makeSupplyChainReport(),
+        totalPackages: 3,
+        riskyPackages: 1,
+        criticalCount: 1,
+      },
+      generatedAt: "2026-05-13T05:11:00.000Z",
+      repository: "affaan-m/risky-repo",
+    });
+
+    const fleet = inspectEvidencePackFleet([cleanOutputDir, riskyOutputDir]);
+
+    expect(fleet.ok).toBe(true);
+    expect(fleet.requiresAttention).toBe(true);
+    expect(fleet.summary).toMatchObject({
+      totalPacks: 2,
+      verifiedPacks: 2,
+      invalidPacks: 0,
+      totalFindings: 1,
+      critical: 1,
+      high: 0,
+      policyFailures: 1,
+      baselineRegressions: 1,
+      riskyPackages: 1,
+      autoFixable: 0,
+      manualReview: 1,
+    });
+    expect(fleet.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          outputDir: cleanOutputDir,
+          repository: "affaan-m/clean-repo",
+          ok: true,
+          route: "ready",
+        }),
+        expect.objectContaining({
+          outputDir: riskyOutputDir,
+          repository: "affaan-m/risky-repo",
+          ok: true,
+          route: "security-blocker",
+        }),
+      ])
+    );
+    expect(fleet.routes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          route: "security-blocker",
+          repository: "affaan-m/risky-repo",
+          reason: "1 critical findings",
+        }),
+        expect.objectContaining({
+          route: "ready",
+          repository: "affaan-m/clean-repo",
+        }),
+      ])
+    );
+  });
+
+  it("routes tampered fleet entries as invalid without hiding pack errors", () => {
+    const targetPath = mkdtempSync(join(tmpdir(), "agentshield-fleet-invalid-target-"));
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-fleet-invalid-pack-"));
+
+    writeFleetEvidencePack({
+      outputDir,
+      targetPath,
+      generatedAt: "2026-05-13T05:11:30.000Z",
+      repository: "affaan-m/agentshield",
+    });
+    writeFileSync(join(outputDir, "agentshield-report.json"), "{}\n");
+
+    const fleet = inspectEvidencePackFleet([outputDir]);
+
+    expect(fleet.ok).toBe(false);
+    expect(fleet.requiresAttention).toBe(true);
+    expect(fleet.summary).toMatchObject({
+      totalPacks: 1,
+      verifiedPacks: 0,
+      invalidPacks: 1,
+    });
+    expect(fleet.entries[0]).toMatchObject({
+      outputDir,
+      ok: false,
+      route: "invalid",
+    });
+    expect(fleet.errors).toEqual(expect.arrayContaining([expect.stringContaining("agentshield-report.json")]));
+  });
+
+  it("exposes evidence-pack fleet inspection through the CLI", () => {
+    const cleanTargetPath = mkdtempSync(join(tmpdir(), "agentshield-cli-fleet-clean-target-"));
+    const riskyTargetPath = mkdtempSync(join(tmpdir(), "agentshield-cli-fleet-risky-target-"));
+    const cleanOutputDir = mkdtempSync(join(tmpdir(), "agentshield-cli-fleet-clean-pack-"));
+    const riskyOutputDir = mkdtempSync(join(tmpdir(), "agentshield-cli-fleet-risky-pack-"));
+
+    writeFleetEvidencePack({
+      outputDir: cleanOutputDir,
+      targetPath: cleanTargetPath,
+      report: makeCleanReport(cleanTargetPath),
+      policyEvaluation: makePassingPolicyEvaluation(),
+      baselineComparison: makePassingBaselineComparison(cleanTargetPath),
+      generatedAt: "2026-05-13T05:12:00.000Z",
+      repository: "affaan-m/clean-repo",
+    });
+    writeFleetEvidencePack({
+      outputDir: riskyOutputDir,
+      targetPath: riskyTargetPath,
+      generatedAt: "2026-05-13T05:13:00.000Z",
+      repository: "affaan-m/risky-repo",
+    });
+
+    const text = spawnSync(process.execPath, [
+      CLI_PATH,
+      "evidence-pack",
+      "fleet",
+      cleanOutputDir,
+      riskyOutputDir,
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(text.status).toBe(0);
+    expect(text.stdout).toContain("AgentShield Evidence Pack Fleet");
+    expect(text.stdout).toContain("Packs:       2 total, 2 verified, 0 invalid");
+    expect(text.stdout).toContain("Findings:    critical 1, high 0, medium 0, low 0, info 0");
+    expect(text.stdout).toContain("security-blocker affaan-m/risky-repo");
+    expect(text.stdout).toContain("ready affaan-m/clean-repo");
+
+    const json = spawnSync(process.execPath, [
+      CLI_PATH,
+      "evidence-pack",
+      "fleet",
+      cleanOutputDir,
+      riskyOutputDir,
+      "--json",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(json.status).toBe(0);
+    expect(JSON.parse(json.stdout)).toMatchObject({
+      ok: true,
+      requiresAttention: true,
+      summary: {
+        totalPacks: 2,
+        verifiedPacks: 2,
+        invalidPacks: 0,
+        critical: 1,
+        policyFailures: 1,
+        baselineRegressions: 1,
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- add `inspectEvidencePackFleet()` to aggregate multiple verified evidence packs
- add `agentshield evidence-pack fleet <dirs...> [--json]` for fleet-level routing across repos/harnesses
- document fleet evidence-pack readback in README/API

## Validation
- `npm run typecheck`
- `npm run build`
- `npx vitest run tests/evidence-pack/evidence-pack.test.ts tests/action.test.ts` (34/34)
- `npm test` (1774/1774)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fleet-level evidence pack inspection and routing so operators can aggregate packs across repos or harnesses and get clear route suggestions. Provides an API and CLI to summarize fleet totals, risk, policy/baseline status, remediation counts, and a requires-attention flag.

- **New Features**
  - Added `inspectEvidencePackFleet(outputDirs)` returning `ok`, `requiresAttention`, summary counts (packs, severities, `policyFailures`, `baselineRegressions`, `riskyPackages`, `autoFixable`, `manualReview`), per‑pack entries, routes, and errors.
  - Added CLI: `agentshield evidence-pack fleet <dirs...> [--json]` to print a fleet summary and per‑pack routes; exits non‑zero if any pack is invalid.
  - Routing logic and reasons: `invalid`, `security-blocker`, `policy-review`, `baseline-regression`, `supply-chain-review`, `ready` with concise reasons (e.g., critical/high findings, risky packages).
  - Updated README and `API.md`; added tests covering aggregation, routing, CLI output and JSON shape, invalid handling, and error propagation.

<sup>Written for commit d7bba16374ea28f230f5c73dddc23d6605b0e640. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/89?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agentshield evidence-pack fleet` command to aggregate and inspect multiple evidence packs, emitting fleet-level summaries and per-pack routing statuses (ready, security-blocker, policy-review, baseline-regression, supply-chain-review, invalid). Supports machine-readable JSON output with `--json` and a readable fleet summary with per-route details.

* **Documentation**
  * Updated README and API docs with usage examples and CLI reference for the new fleet subcommand.

* **Tests**
  * Added fleet-focused tests validating aggregation, routing, tamper handling, and CLI output (text and JSON).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->