### PR TITLE
Add checksum-backed policy pack export

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ agentshield baseline write         Write a scan baseline JSON file
 agentshield evidence-pack fleet    Summarize multiple evidence packs for routing
 agentshield evidence-pack inspect  Verify and summarize an evidence bundle
 agentshield evidence-pack verify   Verify artifact and bundle digests
+agentshield policy export          Export policy packs plus checksum manifest
 agentshield policy init            Generate an organization policy preset
 ```
 
@@ -631,6 +632,8 @@ Organization policy files support enterprise metadata and temporary exceptions:
 ```bash
 agentshield policy init --pack enterprise --owner security-platform@acme.example
 agentshield policy init --pack regulated --name "Acme Regulated Policy"
+agentshield policy export --output-dir .github/agentshield-policies --owner security-platform@acme.example
+agentshield policy export --pack ci-enforcement --name-prefix "Acme" --json
 ```
 
 Policy pack presets are starter baselines, not hidden SaaS policy. `oss` keeps
@@ -639,6 +642,11 @@ public repos permissive while requiring destructive-command deny entries;
 tool allowlists; `regulated` disallows critical/high findings and bans broader
 MCP/tool surfaces; `high-risk-hooks-mcp` focuses on hook/MCP-heavy repos; and
 `ci-enforcement` is tuned for branch-protection evidence.
+
+Policy export writes one JSON policy file per selected pack plus a
+`manifest.json` containing SHA-256 digests. This gives platform teams a stable
+artifact bundle for branch-protection review, audit attachment, or downstream
+policy promotion without relying on generated console output.
 
 ```json
 {

--- a/dist/action.js
+++ b/dist/action.js
@@ -942,13 +942,70 @@ var init_evaluate = __esm({
   }
 });
 
+// src/policy/export.ts
+import { createHash as createHash3 } from "crypto";
+import { mkdirSync as mkdirSync3, writeFileSync as writeFileSync3 } from "fs";
+import { join as join5 } from "path";
+function exportPolicyPacks(options) {
+  mkdirSync3(options.outputDir, { recursive: true });
+  const summaries = listPolicyPacks();
+  const selectedPacks = options.packs && options.packs.length > 0 ? options.packs : summaries.map((summary) => summary.id);
+  const entries = [];
+  for (const packId of selectedPacks) {
+    const summary = summaries.find((item) => item.id === packId);
+    if (!summary) {
+      throw new Error(`Unknown policy pack: ${packId}`);
+    }
+    const policy = generatePolicyPack(packId, {
+      owners: options.owners,
+      name: options.namePrefix ? `${options.namePrefix} ${titleCase(summary.label)} Policy` : void 0
+    });
+    const policyJson = stableJson(policy);
+    const file = `${packId}-policy.json`;
+    writeFileSync3(join5(options.outputDir, file), policyJson);
+    entries.push({
+      id: summary.id,
+      label: summary.label,
+      description: summary.description,
+      file,
+      sha256: digest(policyJson)
+    });
+  }
+  const manifest = {
+    schema_version: POLICY_EXPORT_SCHEMA_VERSION,
+    packs: entries
+  };
+  writeFileSync3(join5(options.outputDir, "manifest.json"), stableJson(manifest));
+  return manifest;
+}
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}
+`;
+}
+function digest(value) {
+  return `sha256:${createHash3("sha256").update(value).digest("hex")}`;
+}
+function titleCase(label) {
+  return label.split(" ").map((word) => word.toUpperCase() === word ? word : `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`).join(" ");
+}
+var POLICY_EXPORT_SCHEMA_VERSION;
+var init_export = __esm({
+  "src/policy/export.ts"() {
+    "use strict";
+    init_presets();
+    POLICY_EXPORT_SCHEMA_VERSION = "agentshield.policy-export.v1";
+  }
+});
+
 // src/policy/index.ts
 var policy_exports = {};
 __export(policy_exports, {
   OrgPolicySchema: () => OrgPolicySchema,
+  POLICY_EXPORT_SCHEMA_VERSION: () => POLICY_EXPORT_SCHEMA_VERSION,
   PolicyExceptionSchema: () => PolicyExceptionSchema,
   PolicyPackSchema: () => PolicyPackSchema,
   evaluatePolicy: () => evaluatePolicy,
+  exportPolicyPacks: () => exportPolicyPacks,
   generateExamplePolicy: () => generateExamplePolicy,
   generatePolicyPack: () => generatePolicyPack,
   listPolicyPacks: () => listPolicyPacks,
@@ -960,6 +1017,7 @@ var init_policy = __esm({
     "use strict";
     init_evaluate();
     init_presets();
+    init_export();
     init_types();
   }
 });
@@ -1603,9 +1661,9 @@ var init_types3 = __esm({
 });
 
 // src/baseline/compare.ts
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync3, existsSync as existsSync5 } from "fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync4, existsSync as existsSync5 } from "fs";
 import { dirname as dirname3 } from "path";
-import { mkdirSync as mkdirSync3 } from "fs";
+import { mkdirSync as mkdirSync4 } from "fs";
 function saveBaseline(findings, score, outputPath) {
   const serialized = {
     version: 1,
@@ -1622,9 +1680,9 @@ function saveBaseline(findings, score, outputPath) {
   };
   const dir = dirname3(outputPath);
   if (!existsSync5(dir)) {
-    mkdirSync3(dir, { recursive: true });
+    mkdirSync4(dir, { recursive: true });
   }
-  writeFileSync3(outputPath, JSON.stringify(serialized, null, 2));
+  writeFileSync4(outputPath, JSON.stringify(serialized, null, 2));
 }
 function loadBaseline(baselinePath) {
   if (!existsSync5(baselinePath)) return null;
@@ -1797,7 +1855,7 @@ var init_baseline = __esm({
 import { resolve as resolve4 } from "path";
 import { dirname as dirname4 } from "path";
 import { existsSync as existsSync6 } from "fs";
-import { appendFileSync, mkdirSync as mkdirSync4, writeFileSync as writeFileSync4 } from "fs";
+import { appendFileSync, mkdirSync as mkdirSync5, writeFileSync as writeFileSync5 } from "fs";
 
 // src/scanner/discovery.ts
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
@@ -12497,8 +12555,8 @@ async function run() {
   }
   if (format === "sarif") {
     const sarifPath = resolve4(workspace, sarifOutput);
-    mkdirSync4(dirname4(sarifPath), { recursive: true });
-    writeFileSync4(
+    mkdirSync5(dirname4(sarifPath), { recursive: true });
+    writeFileSync5(
       sarifPath,
       renderSarifReport(report, {
         policyEvaluation: policyEvaluation ?? void 0,

--- a/dist/index.js
+++ b/dist/index.js
@@ -12716,13 +12716,70 @@ var init_evaluate = __esm({
   }
 });
 
+// src/policy/export.ts
+import { createHash as createHash3 } from "crypto";
+import { mkdirSync as mkdirSync6, writeFileSync as writeFileSync6 } from "fs";
+import { join as join10 } from "path";
+function exportPolicyPacks(options) {
+  mkdirSync6(options.outputDir, { recursive: true });
+  const summaries = listPolicyPacks();
+  const selectedPacks = options.packs && options.packs.length > 0 ? options.packs : summaries.map((summary) => summary.id);
+  const entries = [];
+  for (const packId of selectedPacks) {
+    const summary = summaries.find((item) => item.id === packId);
+    if (!summary) {
+      throw new Error(`Unknown policy pack: ${packId}`);
+    }
+    const policy = generatePolicyPack(packId, {
+      owners: options.owners,
+      name: options.namePrefix ? `${options.namePrefix} ${titleCase(summary.label)} Policy` : void 0
+    });
+    const policyJson = stableJson(policy);
+    const file = `${packId}-policy.json`;
+    writeFileSync6(join10(options.outputDir, file), policyJson);
+    entries.push({
+      id: summary.id,
+      label: summary.label,
+      description: summary.description,
+      file,
+      sha256: digest(policyJson)
+    });
+  }
+  const manifest = {
+    schema_version: POLICY_EXPORT_SCHEMA_VERSION,
+    packs: entries
+  };
+  writeFileSync6(join10(options.outputDir, "manifest.json"), stableJson(manifest));
+  return manifest;
+}
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}
+`;
+}
+function digest(value) {
+  return `sha256:${createHash3("sha256").update(value).digest("hex")}`;
+}
+function titleCase(label) {
+  return label.split(" ").map((word) => word.toUpperCase() === word ? word : `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`).join(" ");
+}
+var POLICY_EXPORT_SCHEMA_VERSION;
+var init_export = __esm({
+  "src/policy/export.ts"() {
+    "use strict";
+    init_presets();
+    POLICY_EXPORT_SCHEMA_VERSION = "agentshield.policy-export.v1";
+  }
+});
+
 // src/policy/index.ts
 var policy_exports = {};
 __export(policy_exports, {
   OrgPolicySchema: () => OrgPolicySchema,
+  POLICY_EXPORT_SCHEMA_VERSION: () => POLICY_EXPORT_SCHEMA_VERSION,
   PolicyExceptionSchema: () => PolicyExceptionSchema,
   PolicyPackSchema: () => PolicyPackSchema,
   evaluatePolicy: () => evaluatePolicy,
+  exportPolicyPacks: () => exportPolicyPacks,
   generateExamplePolicy: () => generateExamplePolicy,
   generatePolicyPack: () => generatePolicyPack,
   listPolicyPacks: () => listPolicyPacks,
@@ -12734,6 +12791,7 @@ var init_policy = __esm({
     "use strict";
     init_evaluate();
     init_presets();
+    init_export();
     init_types();
   }
 });
@@ -12753,9 +12811,9 @@ var init_types2 = __esm({
 });
 
 // src/baseline/compare.ts
-import { readFileSync as readFileSync8, writeFileSync as writeFileSync6, existsSync as existsSync11 } from "fs";
+import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, existsSync as existsSync11 } from "fs";
 import { dirname as dirname5 } from "path";
-import { mkdirSync as mkdirSync6 } from "fs";
+import { mkdirSync as mkdirSync7 } from "fs";
 function saveBaseline(findings, score, outputPath) {
   const serialized = {
     version: 1,
@@ -12772,9 +12830,9 @@ function saveBaseline(findings, score, outputPath) {
   };
   const dir = dirname5(outputPath);
   if (!existsSync11(dir)) {
-    mkdirSync6(dir, { recursive: true });
+    mkdirSync7(dir, { recursive: true });
   }
-  writeFileSync6(outputPath, JSON.stringify(serialized, null, 2));
+  writeFileSync7(outputPath, JSON.stringify(serialized, null, 2));
 }
 function loadBaseline(baselinePath) {
   if (!existsSync11(baselinePath)) return null;
@@ -13571,8 +13629,8 @@ var init_supply_chain = __esm({
 init_scanner();
 import { Command } from "commander";
 import { resolve as resolve10 } from "path";
-import { dirname as dirname6 } from "path";
-import { existsSync as existsSync12, writeFileSync as writeFileSync7, appendFileSync as appendFileSync2, mkdirSync as mkdirSync7 } from "fs";
+import { dirname as dirname6, join as join11 } from "path";
+import { existsSync as existsSync12, writeFileSync as writeFileSync8, appendFileSync as appendFileSync2, mkdirSync as mkdirSync8 } from "fs";
 
 // src/reporter/score.ts
 var SCORE_DEDUCTIONS = {
@@ -18193,7 +18251,7 @@ function createScanLogger(logPath, logFormat) {
     },
     flush() {
       if (logPath && logFormat === "json") {
-        writeFileSync7(logPath, JSON.stringify(entries, null, 2));
+        writeFileSync8(logPath, JSON.stringify(entries, null, 2));
       }
     }
   };
@@ -18207,8 +18265,8 @@ function emitReportOutput(output, outputPath) {
     return;
   }
   const resolvedOutput = resolve10(outputPath);
-  mkdirSync7(dirname6(resolvedOutput), { recursive: true });
-  writeFileSync7(resolvedOutput, output);
+  mkdirSync8(dirname6(resolvedOutput), { recursive: true });
+  writeFileSync8(resolvedOutput, output);
   console.log(`Report written to: ${resolvedOutput}`);
 }
 function collectOption(value, previous) {
@@ -18911,9 +18969,9 @@ policyCmd.command("init").description("Generate an example organization policy f
   }
   const dir = resolve10(outputPath, "..");
   if (!existsSync12(dir)) {
-    mkdirSync7(dir, { recursive: true });
+    mkdirSync8(dir, { recursive: true });
   }
-  writeFileSync7(outputPath, generateExamplePolicy2(packResult.data, {
+  writeFileSync8(outputPath, generateExamplePolicy2(packResult.data, {
     name: options.name,
     owners: options.owner
   }));
@@ -18923,6 +18981,49 @@ policyCmd.command("init").description("Generate an example organization policy f
   console.log(`  Edit the file to match your organization's requirements.`);
   console.log(`  Then run: agentshield scan --policy ${options.output}
 `);
+});
+policyCmd.command("export").description("Export policy pack JSON files with a checksum manifest").option("-o, --output-dir <path>", "Output directory", ".agentshield/policies").option("--pack <pack>", "Policy pack to export; repeat for multiple packs", collectOption, []).option("--owner <owner>", "Policy owner identifier; repeat for multiple owners", collectOption, []).option("--name-prefix <prefix>", "Prefix generated policy names").option("--json", "Emit the export manifest as JSON", false).action(async (options) => {
+  const {
+    exportPolicyPacks: exportPolicyPacks2,
+    listPolicyPacks: listPolicyPacks2,
+    PolicyPackSchema: PolicyPackSchema2
+  } = await Promise.resolve().then(() => (init_policy(), policy_exports));
+  const requestedPacks = options.pack;
+  const validPackIds = listPolicyPacks2().map((pack) => pack.id);
+  const packs = requestedPacks.length > 0 ? requestedPacks.map((pack) => {
+    const result = PolicyPackSchema2.safeParse(pack);
+    if (!result.success) {
+      console.error(`
+  Error: Unknown policy pack "${pack}". Valid packs: ${validPackIds.join(", ")}
+`);
+      process.exit(1);
+    }
+    return result.data;
+  }) : void 0;
+  const outputDir = resolve10(options.outputDir);
+  const manifest = exportPolicyPacks2({
+    outputDir,
+    packs,
+    owners: options.owner,
+    namePrefix: options.namePrefix
+  });
+  if (options.json) {
+    writeStdout(JSON.stringify(manifest, null, 2));
+    return;
+  }
+  console.log(`
+  Policy bundle written to: ${outputDir}`);
+  console.log(`  Manifest:       ${join11(outputDir, "manifest.json")}`);
+  console.log(`  Policies:       ${manifest.packs.length}`);
+  for (const pack of manifest.packs) {
+    console.log(`  - ${pack.id}: ${pack.file} (${pack.sha256})`);
+  }
+  if (manifest.packs[0]) {
+    console.log(`  Then run: agentshield scan --policy ${join11(options.outputDir, manifest.packs[0].file)}
+`);
+  } else {
+    console.log("");
+  }
 });
 var miniclaw = program.command("miniclaw").description("MiniClaw \u2014 minimal secure sandboxed AI agent runtime");
 miniclaw.command("start").description("Start the MiniClaw server").option("-p, --port <port>", "Port to listen on", "3847").option("-H, --hostname <hostname>", "Hostname to bind to", "localhost").option("--network <policy>", "Network policy: none, localhost, allowlist", "none").option("--rate-limit <limit>", "Max requests per minute per IP", "10").option("--sandbox-root <path>", "Root path for sandbox directories", "/tmp/miniclaw-sandboxes").option("--max-duration <ms>", "Max session duration in milliseconds", "300000").action((options) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { Command } from "commander";
 import { resolve } from "node:path";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { existsSync, writeFileSync, appendFileSync, mkdirSync } from "node:fs";
 import { scan } from "./scanner/index.js";
 import { calculateScore } from "./reporter/score.js";
@@ -1119,6 +1119,58 @@ policyCmd
     console.log(`  Policy pack: ${packResult.data}`);
     console.log(`  Edit the file to match your organization's requirements.`);
     console.log(`  Then run: agentshield scan --policy ${options.output}\n`);
+  });
+
+policyCmd
+  .command("export")
+  .description("Export policy pack JSON files with a checksum manifest")
+  .option("-o, --output-dir <path>", "Output directory", ".agentshield/policies")
+  .option("--pack <pack>", "Policy pack to export; repeat for multiple packs", collectOption, [])
+  .option("--owner <owner>", "Policy owner identifier; repeat for multiple owners", collectOption, [])
+  .option("--name-prefix <prefix>", "Prefix generated policy names")
+  .option("--json", "Emit the export manifest as JSON", false)
+  .action(async (options) => {
+    const {
+      exportPolicyPacks,
+      listPolicyPacks,
+      PolicyPackSchema,
+    } = await import("./policy/index.js");
+    const requestedPacks = options.pack as string[];
+    const validPackIds = listPolicyPacks().map((pack) => pack.id);
+    const packs = requestedPacks.length > 0
+      ? requestedPacks.map((pack) => {
+        const result = PolicyPackSchema.safeParse(pack);
+        if (!result.success) {
+          console.error(`\n  Error: Unknown policy pack "${pack}". Valid packs: ${validPackIds.join(", ")}\n`);
+          process.exit(1);
+        }
+        return result.data;
+      })
+      : undefined;
+    const outputDir = resolve(options.outputDir);
+    const manifest = exportPolicyPacks({
+      outputDir,
+      packs,
+      owners: options.owner,
+      namePrefix: options.namePrefix,
+    });
+
+    if (options.json) {
+      writeStdout(JSON.stringify(manifest, null, 2));
+      return;
+    }
+
+    console.log(`\n  Policy bundle written to: ${outputDir}`);
+    console.log(`  Manifest:       ${join(outputDir, "manifest.json")}`);
+    console.log(`  Policies:       ${manifest.packs.length}`);
+    for (const pack of manifest.packs) {
+      console.log(`  - ${pack.id}: ${pack.file} (${pack.sha256})`);
+    }
+    if (manifest.packs[0]) {
+      console.log(`  Then run: agentshield scan --policy ${join(options.outputDir, manifest.packs[0].file)}\n`);
+    } else {
+      console.log("");
+    }
   });
 
 // ─── MiniClaw Commands ───────────────────────────────────

--- a/src/policy/export.ts
+++ b/src/policy/export.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { generatePolicyPack, listPolicyPacks } from "./presets.js";
+import type { PolicyPack } from "./types.js";
+
+export const POLICY_EXPORT_SCHEMA_VERSION = "agentshield.policy-export.v1";
+
+export interface ExportPolicyPacksOptions {
+  readonly outputDir: string;
+  readonly packs?: ReadonlyArray<PolicyPack>;
+  readonly owners?: ReadonlyArray<string>;
+  readonly namePrefix?: string;
+}
+
+export interface PolicyPackExportEntry {
+  readonly id: PolicyPack;
+  readonly label: string;
+  readonly description: string;
+  readonly file: string;
+  readonly sha256: string;
+}
+
+export interface PolicyPackExportManifest {
+  readonly schema_version: typeof POLICY_EXPORT_SCHEMA_VERSION;
+  readonly packs: ReadonlyArray<PolicyPackExportEntry>;
+}
+
+export function exportPolicyPacks(options: ExportPolicyPacksOptions): PolicyPackExportManifest {
+  mkdirSync(options.outputDir, { recursive: true });
+
+  const summaries = listPolicyPacks();
+  const selectedPacks = options.packs && options.packs.length > 0
+    ? options.packs
+    : summaries.map((summary) => summary.id);
+  const entries: PolicyPackExportEntry[] = [];
+
+  for (const packId of selectedPacks) {
+    const summary = summaries.find((item) => item.id === packId);
+    if (!summary) {
+      throw new Error(`Unknown policy pack: ${packId}`);
+    }
+
+    const policy = generatePolicyPack(packId, {
+      owners: options.owners,
+      name: options.namePrefix ? `${options.namePrefix} ${titleCase(summary.label)} Policy` : undefined,
+    });
+    const policyJson = stableJson(policy);
+    const file = `${packId}-policy.json`;
+
+    writeFileSync(join(options.outputDir, file), policyJson);
+    entries.push({
+      id: summary.id,
+      label: summary.label,
+      description: summary.description,
+      file,
+      sha256: digest(policyJson),
+    });
+  }
+
+  const manifest: PolicyPackExportManifest = {
+    schema_version: POLICY_EXPORT_SCHEMA_VERSION,
+    packs: entries,
+  };
+  writeFileSync(join(options.outputDir, "manifest.json"), stableJson(manifest));
+  return manifest;
+}
+
+function stableJson(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function titleCase(label: string): string {
+  return label
+    .split(" ")
+    .map((word) => word.toUpperCase() === word
+      ? word
+      : `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+}

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -8,11 +8,20 @@ export {
   generatePolicyPack,
   listPolicyPacks,
 } from "./presets.js";
+export {
+  POLICY_EXPORT_SCHEMA_VERSION,
+  exportPolicyPacks,
+} from "./export.js";
 export type { EvaluatePolicyOptions, LoadPolicyResult } from "./evaluate.js";
 export type {
   GeneratePolicyPackOptions,
   PolicyPackSummary,
 } from "./presets.js";
+export type {
+  ExportPolicyPacksOptions,
+  PolicyPackExportEntry,
+  PolicyPackExportManifest,
+} from "./export.js";
 export {
   OrgPolicySchema,
   PolicyExceptionSchema,

--- a/tests/policy/export.test.ts
+++ b/tests/policy/export.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  exportPolicyPacks,
+  type PolicyPackExportManifest,
+} from "../../src/policy/index.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../dist/index.js");
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+describe("policy pack export", () => {
+  it("writes every policy pack with a manifest and stable digests", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-export-"));
+    const manifest = exportPolicyPacks({
+      outputDir,
+      owners: ["security@example.com"],
+    });
+
+    expect(manifest.schema_version).toBe("agentshield.policy-export.v1");
+    expect(manifest.packs.length).toBe(6);
+
+    for (const entry of manifest.packs) {
+      const policyPath = join(outputDir, entry.file);
+      expect(existsSync(policyPath)).toBe(true);
+      expect(entry.sha256).toMatch(/^sha256:[a-f0-9]{64}$/);
+
+      const policy = readJson<Record<string, unknown>>(policyPath);
+      expect(policy.policy_pack).toBe(entry.id);
+      expect(policy.owners).toEqual(["security@example.com"]);
+    }
+
+    const writtenManifest = readJson<PolicyPackExportManifest>(
+      join(outputDir, "manifest.json")
+    );
+    expect(writtenManifest).toEqual(manifest);
+  });
+
+  it("can export one selected policy pack for a branch-protection workflow", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-export-one-"));
+    const manifest = exportPolicyPacks({
+      outputDir,
+      packs: ["ci-enforcement"],
+      namePrefix: "Acme",
+    });
+
+    expect(manifest.packs).toEqual([
+      expect.objectContaining({
+        id: "ci-enforcement",
+        file: "ci-enforcement-policy.json",
+      }),
+    ]);
+
+    const policy = readJson<Record<string, unknown>>(
+      join(outputDir, "ci-enforcement-policy.json")
+    );
+    expect(policy.name).toBe("Acme CI Enforcement Policy");
+    expect(policy.policy_pack).toBe("ci-enforcement");
+  });
+
+  it("exposes policy pack export through the CLI", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-export-cli-"));
+    const result = spawnSync(process.execPath, [
+      CLI_PATH,
+      "policy",
+      "export",
+      "--pack",
+      "ci-enforcement",
+      "--owner",
+      "security@example.com",
+      "--name-prefix",
+      "Acme",
+      "--output-dir",
+      outputDir,
+      "--json",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+
+    const manifest = JSON.parse(result.stdout) as PolicyPackExportManifest;
+    expect(manifest.packs).toHaveLength(1);
+    expect(manifest.packs[0]).toMatchObject({
+      id: "ci-enforcement",
+      file: "ci-enforcement-policy.json",
+    });
+    expect(existsSync(join(outputDir, "manifest.json"))).toBe(true);
+    expect(existsSync(join(outputDir, "ci-enforcement-policy.json"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `exportPolicyPacks` to write policy pack JSON files plus a checksum manifest
- expose `agentshield policy export` with pack, owner, name-prefix, and JSON output options
- document the export workflow and add unit/CLI coverage

## Validation
- npm run build
- npx vitest run tests/policy/export.test.ts tests/policy/presets.test.ts
- npm run typecheck
- npm run lint
- npm test
- node dist/index.js policy export --pack ci-enforcement --owner security@example.com --name-prefix Acme --output-dir <tmpdir>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds checksum-backed policy pack export that writes one JSON policy per pack plus a manifest, exposed via `agentshield policy export`. This creates stable, verifiable policy bundles for branch-protection reviews, audits, and downstream promotion.

- **New Features**
  - Added `exportPolicyPacks(options)` to write per-pack policy JSONs and a `manifest.json` with SHA-256 digests (`agentshield.policy-export.v1`).
  - New CLI: `agentshield policy export` with `--output-dir`, repeatable `--pack` and `--owner`, `--name-prefix`, and `--json` for manifest to stdout.
  - Manifest entries include: `id`, `label`, `description`, `file`, `sha256`.
  - Updated README with examples, e.g. `agentshield policy export --pack ci-enforcement --owner security@example.com --name-prefix Acme --output-dir .github/agentshield-policies`.
  - Added unit and CLI tests for export flow and digest stability.

<sup>Written for commit 5fecebdbcf65f3db343ea3e13d251753f970e61d. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/91?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `agentshield policy export` command to export policy packs to a specified output directory.
  * Generates manifest with SHA-256 digests for stable artifact bundles for policy promotion.
  * Supports `--output-dir`, `--pack`, `--owner`, `--name-prefix`, and `--json` options.

* **Documentation**
  * Updated CLI reference and policy documentation for the new export command with examples.

* **Tests**
  * Added comprehensive test suite for policy export functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->