### PR TITLE
feat: add policy promotion gate

### DIFF
--- a/API.md
+++ b/API.md
@@ -103,10 +103,20 @@ Policy preset generation:
 ```bash
 agentshield policy init --pack enterprise --owner security@example.com
 agentshield policy init --pack regulated --name "Regulated Agent Policy"
+agentshield policy export --pack ci-enforcement --output-dir .github/agentshield-policies
+agentshield policy promote --manifest .github/agentshield-policies/manifest.json --pack ci-enforcement --output .agentshield/policy.json
+agentshield policy promote --manifest .github/agentshield-policies/manifest.json --pack ci-enforcement --dry-run --json
 ```
 
 Supported packs: `oss`, `team`, `enterprise`, `regulated`,
 `high-risk-hooks-mcp`, and `ci-enforcement`.
+
+`policy promote` is checksum-first: it rejects missing manifests, unsupported
+manifest schemas, ambiguous multi-pack manifests without `--pack`, tampered
+policy files whose SHA-256 no longer matches the manifest, and policy files
+that fail the organization policy schema. This makes exported policy bundles
+usable as reviewable CI artifacts before they become the active
+`.agentshield/policy.json`.
 
 The GitHub Action exposes the same organization policy gate through the
 `policy` input. It reports `policy-status` and `policy-violations` outputs,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Added `agentshield policy promote` to verify exported policy-pack manifests,
+  reject tampered policy JSON by SHA-256 digest, and promote a selected pack
+  into the active policy path with dry-run and JSON review modes.
+
 ## [1.4.0] - 2026-03-20
 
 This release focuses on scan accuracy, source-aware scoring, and safer interpretation of example and manifest-heavy repositories.

--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ agentshield evidence-pack inspect  Verify and summarize an evidence bundle
 agentshield evidence-pack verify   Verify artifact and bundle digests
 agentshield policy export          Export policy packs plus checksum manifest
 agentshield policy init            Generate an organization policy preset
+agentshield policy promote         Verify and promote an exported policy
 ```
 
 Baseline write:
@@ -634,6 +635,8 @@ agentshield policy init --pack enterprise --owner security-platform@acme.example
 agentshield policy init --pack regulated --name "Acme Regulated Policy"
 agentshield policy export --output-dir .github/agentshield-policies --owner security-platform@acme.example
 agentshield policy export --pack ci-enforcement --name-prefix "Acme" --json
+agentshield policy promote --manifest .github/agentshield-policies/manifest.json --pack ci-enforcement --output .agentshield/policy.json
+agentshield policy promote --manifest .github/agentshield-policies/manifest.json --pack ci-enforcement --dry-run --json
 ```
 
 Policy pack presets are starter baselines, not hidden SaaS policy. `oss` keeps
@@ -647,6 +650,12 @@ Policy export writes one JSON policy file per selected pack plus a
 `manifest.json` containing SHA-256 digests. This gives platform teams a stable
 artifact bundle for branch-protection review, audit attachment, or downstream
 policy promotion without relying on generated console output.
+
+Policy promotion is the review gate for those exported bundles. It reads the
+export manifest, verifies the selected policy file digest, validates the policy
+schema, and only then writes the active policy path. Use `--dry-run --json` in
+review workflows to prove the exact pack, source file, output path, owner list,
+and digest before a protected branch or operator copies the policy into place.
 
 ```json
 {

--- a/dist/action.js
+++ b/dist/action.js
@@ -997,6 +997,120 @@ var init_export = __esm({
   }
 });
 
+// src/policy/promote.ts
+import { createHash as createHash4 } from "crypto";
+import {
+  existsSync as existsSync5,
+  mkdirSync as mkdirSync4,
+  readFileSync as readFileSync4,
+  writeFileSync as writeFileSync4
+} from "fs";
+import {
+  dirname as dirname3,
+  isAbsolute,
+  join as join6
+} from "path";
+function promotePolicyPack(options) {
+  const manifest = readExportManifest(options.manifestPath);
+  const entry = selectPolicyPack(manifest.packs, options.pack);
+  const sourceFile = isAbsolute(entry.file) ? entry.file : join6(dirname3(options.manifestPath), entry.file);
+  if (!existsSync5(sourceFile)) {
+    throw new Error(`Policy file not found: ${sourceFile}`);
+  }
+  const policyJson = readFileSync4(sourceFile, "utf-8");
+  const actualDigest = digest2(policyJson);
+  if (actualDigest !== entry.sha256) {
+    throw new Error(
+      `Policy digest mismatch for ${entry.id}: expected ${entry.sha256}, got ${actualDigest}`
+    );
+  }
+  const parsed = JSON.parse(policyJson);
+  const policy = OrgPolicySchema.parse(parsed);
+  if (policy.policy_pack !== entry.id) {
+    throw new Error(
+      `Policy pack mismatch: manifest entry is ${entry.id}, policy file declares ${policy.policy_pack}`
+    );
+  }
+  if (!options.dryRun) {
+    mkdirSync4(dirname3(options.outputPath), { recursive: true });
+    writeFileSync4(options.outputPath, policyJson);
+  }
+  return {
+    manifestPath: options.manifestPath,
+    sourceFile,
+    outputPath: options.outputPath,
+    pack: entry.id,
+    policyName: policy.name ?? "Organization Policy",
+    owners: policy.owners ?? [],
+    sha256: entry.sha256,
+    verified: true,
+    promoted: !options.dryRun,
+    dryRun: Boolean(options.dryRun)
+  };
+}
+function readExportManifest(manifestPath) {
+  if (!existsSync5(manifestPath)) {
+    throw new Error(`Policy export manifest not found: ${manifestPath}`);
+  }
+  const raw = JSON.parse(readFileSync4(manifestPath, "utf-8"));
+  if (raw.schema_version !== POLICY_EXPORT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported policy export manifest schema: ${String(raw.schema_version)}`
+    );
+  }
+  if (!Array.isArray(raw.packs)) {
+    throw new Error("Policy export manifest is missing a packs array");
+  }
+  return {
+    schema_version: POLICY_EXPORT_SCHEMA_VERSION,
+    packs: raw.packs.map(readManifestEntry)
+  };
+}
+function readManifestEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    throw new Error("Invalid policy export manifest entry");
+  }
+  const candidate = entry;
+  const packResult = PolicyPackSchema.safeParse(candidate.id);
+  if (!packResult.success) {
+    throw new Error(`Invalid policy pack id in manifest: ${String(candidate.id)}`);
+  }
+  if (typeof candidate.file !== "string" || candidate.file.length === 0) {
+    throw new Error(`Invalid policy file for manifest pack: ${packResult.data}`);
+  }
+  if (typeof candidate.sha256 !== "string" || !/^sha256:[a-f0-9]{64}$/.test(candidate.sha256)) {
+    throw new Error(`Invalid policy digest for manifest pack: ${packResult.data}`);
+  }
+  return {
+    id: packResult.data,
+    file: candidate.file,
+    sha256: candidate.sha256
+  };
+}
+function selectPolicyPack(entries, requestedPack) {
+  if (requestedPack) {
+    const entry = entries.find((item) => item.id === requestedPack);
+    if (!entry) {
+      throw new Error(`Policy pack ${requestedPack} not found in export manifest`);
+    }
+    return entry;
+  }
+  if (entries.length === 1) {
+    return entries[0];
+  }
+  throw new Error("Export manifest contains multiple policy packs; pass --pack to select one");
+}
+function digest2(value) {
+  return `sha256:${createHash4("sha256").update(value).digest("hex")}`;
+}
+var init_promote = __esm({
+  "src/policy/promote.ts"() {
+    "use strict";
+    init_export();
+    init_types();
+  }
+});
+
 // src/policy/index.ts
 var policy_exports = {};
 __export(policy_exports, {
@@ -1010,6 +1124,7 @@ __export(policy_exports, {
   generatePolicyPack: () => generatePolicyPack,
   listPolicyPacks: () => listPolicyPacks,
   loadPolicy: () => loadPolicy,
+  promotePolicyPack: () => promotePolicyPack,
   renderPolicyEvaluation: () => renderPolicyEvaluation
 });
 var init_policy = __esm({
@@ -1018,6 +1133,7 @@ var init_policy = __esm({
     init_evaluate();
     init_presets();
     init_export();
+    init_promote();
     init_types();
   }
 });
@@ -1661,9 +1777,9 @@ var init_types3 = __esm({
 });
 
 // src/baseline/compare.ts
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync4, existsSync as existsSync5 } from "fs";
-import { dirname as dirname3 } from "path";
-import { mkdirSync as mkdirSync4 } from "fs";
+import { readFileSync as readFileSync5, writeFileSync as writeFileSync5, existsSync as existsSync6 } from "fs";
+import { dirname as dirname4 } from "path";
+import { mkdirSync as mkdirSync5 } from "fs";
 function saveBaseline(findings, score, outputPath) {
   const serialized = {
     version: 1,
@@ -1678,16 +1794,16 @@ function saveBaseline(findings, score, outputPath) {
       fingerprint: fingerprintFinding(f)
     }))
   };
-  const dir = dirname3(outputPath);
-  if (!existsSync5(dir)) {
-    mkdirSync4(dir, { recursive: true });
+  const dir = dirname4(outputPath);
+  if (!existsSync6(dir)) {
+    mkdirSync5(dir, { recursive: true });
   }
-  writeFileSync4(outputPath, JSON.stringify(serialized, null, 2));
+  writeFileSync5(outputPath, JSON.stringify(serialized, null, 2));
 }
 function loadBaseline(baselinePath) {
-  if (!existsSync5(baselinePath)) return null;
+  if (!existsSync6(baselinePath)) return null;
   try {
-    const raw = readFileSync4(baselinePath, "utf-8");
+    const raw = readFileSync5(baselinePath, "utf-8");
     const parsed = JSON.parse(raw);
     if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
       return null;
@@ -1853,9 +1969,9 @@ var init_baseline = __esm({
 
 // src/action.ts
 import { resolve as resolve4 } from "path";
-import { dirname as dirname4 } from "path";
-import { existsSync as existsSync6 } from "fs";
-import { appendFileSync, mkdirSync as mkdirSync5, writeFileSync as writeFileSync5 } from "fs";
+import { dirname as dirname5 } from "path";
+import { existsSync as existsSync7 } from "fs";
+import { appendFileSync, mkdirSync as mkdirSync6, writeFileSync as writeFileSync6 } from "fs";
 
 // src/scanner/discovery.ts
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
@@ -12463,7 +12579,7 @@ async function run() {
   const verifyEvidencePackOutput = getInput("verify-evidence-pack", "true") === "true";
   const workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
   const targetPath = resolve4(workspace, inputPath);
-  if (!existsSync6(targetPath)) {
+  if (!existsSync7(targetPath)) {
     console.log(`::error::AgentShield: Path does not exist: ${targetPath}`);
     process.exitCode = 1;
     return;
@@ -12555,8 +12671,8 @@ async function run() {
   }
   if (format === "sarif") {
     const sarifPath = resolve4(workspace, sarifOutput);
-    mkdirSync5(dirname4(sarifPath), { recursive: true });
-    writeFileSync5(
+    mkdirSync6(dirname5(sarifPath), { recursive: true });
+    writeFileSync6(
       sarifPath,
       renderSarifReport(report, {
         policyEvaluation: policyEvaluation ?? void 0,

--- a/dist/index.js
+++ b/dist/index.js
@@ -12771,6 +12771,120 @@ var init_export = __esm({
   }
 });
 
+// src/policy/promote.ts
+import { createHash as createHash4 } from "crypto";
+import {
+  existsSync as existsSync11,
+  mkdirSync as mkdirSync7,
+  readFileSync as readFileSync8,
+  writeFileSync as writeFileSync7
+} from "fs";
+import {
+  dirname as dirname5,
+  isAbsolute,
+  join as join11
+} from "path";
+function promotePolicyPack(options) {
+  const manifest = readExportManifest(options.manifestPath);
+  const entry = selectPolicyPack(manifest.packs, options.pack);
+  const sourceFile = isAbsolute(entry.file) ? entry.file : join11(dirname5(options.manifestPath), entry.file);
+  if (!existsSync11(sourceFile)) {
+    throw new Error(`Policy file not found: ${sourceFile}`);
+  }
+  const policyJson = readFileSync8(sourceFile, "utf-8");
+  const actualDigest = digest2(policyJson);
+  if (actualDigest !== entry.sha256) {
+    throw new Error(
+      `Policy digest mismatch for ${entry.id}: expected ${entry.sha256}, got ${actualDigest}`
+    );
+  }
+  const parsed = JSON.parse(policyJson);
+  const policy = OrgPolicySchema.parse(parsed);
+  if (policy.policy_pack !== entry.id) {
+    throw new Error(
+      `Policy pack mismatch: manifest entry is ${entry.id}, policy file declares ${policy.policy_pack}`
+    );
+  }
+  if (!options.dryRun) {
+    mkdirSync7(dirname5(options.outputPath), { recursive: true });
+    writeFileSync7(options.outputPath, policyJson);
+  }
+  return {
+    manifestPath: options.manifestPath,
+    sourceFile,
+    outputPath: options.outputPath,
+    pack: entry.id,
+    policyName: policy.name ?? "Organization Policy",
+    owners: policy.owners ?? [],
+    sha256: entry.sha256,
+    verified: true,
+    promoted: !options.dryRun,
+    dryRun: Boolean(options.dryRun)
+  };
+}
+function readExportManifest(manifestPath) {
+  if (!existsSync11(manifestPath)) {
+    throw new Error(`Policy export manifest not found: ${manifestPath}`);
+  }
+  const raw = JSON.parse(readFileSync8(manifestPath, "utf-8"));
+  if (raw.schema_version !== POLICY_EXPORT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported policy export manifest schema: ${String(raw.schema_version)}`
+    );
+  }
+  if (!Array.isArray(raw.packs)) {
+    throw new Error("Policy export manifest is missing a packs array");
+  }
+  return {
+    schema_version: POLICY_EXPORT_SCHEMA_VERSION,
+    packs: raw.packs.map(readManifestEntry)
+  };
+}
+function readManifestEntry(entry) {
+  if (!entry || typeof entry !== "object") {
+    throw new Error("Invalid policy export manifest entry");
+  }
+  const candidate = entry;
+  const packResult = PolicyPackSchema.safeParse(candidate.id);
+  if (!packResult.success) {
+    throw new Error(`Invalid policy pack id in manifest: ${String(candidate.id)}`);
+  }
+  if (typeof candidate.file !== "string" || candidate.file.length === 0) {
+    throw new Error(`Invalid policy file for manifest pack: ${packResult.data}`);
+  }
+  if (typeof candidate.sha256 !== "string" || !/^sha256:[a-f0-9]{64}$/.test(candidate.sha256)) {
+    throw new Error(`Invalid policy digest for manifest pack: ${packResult.data}`);
+  }
+  return {
+    id: packResult.data,
+    file: candidate.file,
+    sha256: candidate.sha256
+  };
+}
+function selectPolicyPack(entries, requestedPack) {
+  if (requestedPack) {
+    const entry = entries.find((item) => item.id === requestedPack);
+    if (!entry) {
+      throw new Error(`Policy pack ${requestedPack} not found in export manifest`);
+    }
+    return entry;
+  }
+  if (entries.length === 1) {
+    return entries[0];
+  }
+  throw new Error("Export manifest contains multiple policy packs; pass --pack to select one");
+}
+function digest2(value) {
+  return `sha256:${createHash4("sha256").update(value).digest("hex")}`;
+}
+var init_promote = __esm({
+  "src/policy/promote.ts"() {
+    "use strict";
+    init_export();
+    init_types();
+  }
+});
+
 // src/policy/index.ts
 var policy_exports = {};
 __export(policy_exports, {
@@ -12784,6 +12898,7 @@ __export(policy_exports, {
   generatePolicyPack: () => generatePolicyPack,
   listPolicyPacks: () => listPolicyPacks,
   loadPolicy: () => loadPolicy2,
+  promotePolicyPack: () => promotePolicyPack,
   renderPolicyEvaluation: () => renderPolicyEvaluation
 });
 var init_policy = __esm({
@@ -12792,6 +12907,7 @@ var init_policy = __esm({
     init_evaluate();
     init_presets();
     init_export();
+    init_promote();
     init_types();
   }
 });
@@ -12811,9 +12927,9 @@ var init_types2 = __esm({
 });
 
 // src/baseline/compare.ts
-import { readFileSync as readFileSync8, writeFileSync as writeFileSync7, existsSync as existsSync11 } from "fs";
-import { dirname as dirname5 } from "path";
-import { mkdirSync as mkdirSync7 } from "fs";
+import { readFileSync as readFileSync9, writeFileSync as writeFileSync8, existsSync as existsSync12 } from "fs";
+import { dirname as dirname6 } from "path";
+import { mkdirSync as mkdirSync8 } from "fs";
 function saveBaseline(findings, score, outputPath) {
   const serialized = {
     version: 1,
@@ -12828,16 +12944,16 @@ function saveBaseline(findings, score, outputPath) {
       fingerprint: fingerprintFinding(f)
     }))
   };
-  const dir = dirname5(outputPath);
-  if (!existsSync11(dir)) {
-    mkdirSync7(dir, { recursive: true });
+  const dir = dirname6(outputPath);
+  if (!existsSync12(dir)) {
+    mkdirSync8(dir, { recursive: true });
   }
-  writeFileSync7(outputPath, JSON.stringify(serialized, null, 2));
+  writeFileSync8(outputPath, JSON.stringify(serialized, null, 2));
 }
 function loadBaseline(baselinePath) {
-  if (!existsSync11(baselinePath)) return null;
+  if (!existsSync12(baselinePath)) return null;
   try {
-    const raw = readFileSync8(baselinePath, "utf-8");
+    const raw = readFileSync9(baselinePath, "utf-8");
     const parsed = JSON.parse(raw);
     if (parsed.version !== 1 || !Array.isArray(parsed.findings)) {
       return null;
@@ -13629,8 +13745,8 @@ var init_supply_chain = __esm({
 init_scanner();
 import { Command } from "commander";
 import { resolve as resolve10 } from "path";
-import { dirname as dirname6, join as join11 } from "path";
-import { existsSync as existsSync12, writeFileSync as writeFileSync8, appendFileSync as appendFileSync2, mkdirSync as mkdirSync8 } from "fs";
+import { dirname as dirname7, join as join12 } from "path";
+import { existsSync as existsSync13, writeFileSync as writeFileSync9, appendFileSync as appendFileSync2, mkdirSync as mkdirSync9 } from "fs";
 
 // src/reporter/score.ts
 var SCORE_DEDUCTIONS = {
@@ -18251,7 +18367,7 @@ function createScanLogger(logPath, logFormat) {
     },
     flush() {
       if (logPath && logFormat === "json") {
-        writeFileSync8(logPath, JSON.stringify(entries, null, 2));
+        writeFileSync9(logPath, JSON.stringify(entries, null, 2));
       }
     }
   };
@@ -18265,8 +18381,8 @@ function emitReportOutput(output, outputPath) {
     return;
   }
   const resolvedOutput = resolve10(outputPath);
-  mkdirSync8(dirname6(resolvedOutput), { recursive: true });
-  writeFileSync8(resolvedOutput, output);
+  mkdirSync9(dirname7(resolvedOutput), { recursive: true });
+  writeFileSync9(resolvedOutput, output);
   console.log(`Report written to: ${resolvedOutput}`);
 }
 function collectOption(value, previous) {
@@ -18301,7 +18417,7 @@ function emptySupplyChainReport() {
 }
 program.command("scan").description("Scan a Claude Code configuration directory for security issues").option("-p, --path <path>", "Path to scan (default: ~/.claude or current dir)").option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal").option("-o, --output <path>", "Write the primary report output to a file").option("--fix", "Auto-apply safe fixes", false).option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false).option("--stream", "Stream Opus analysis in real-time", false).option("--injection", "Run active prompt injection testing against the config", false).option("--sandbox", "Execute hooks in sandbox and observe behavior", false).option("--taint", "Run taint analysis (data flow tracking)", false).option("--deep", "Run ALL analysis (injection + sandbox + taint + opus)", false).option("--log <path>", "Write structured scan log to file").option("--log-format <format>", "Log format: ndjson (default) or json", "ndjson").option("--corpus", "Run scanner validation against built-in attack corpus", false).option("--corpus-gate", "Run built-in attack corpus and fail if scanner accuracy regresses", false).option("--baseline <path>", "Compare against a baseline file and report regressions").option("--save-baseline <path>", "Save current scan results as a baseline file").option("--gate", "Fail if new critical/high findings or score drops (use with --baseline)", false).option("--supply-chain", "Verify MCP npm packages against known-bad list and typosquatting", false).option("--supply-chain-online", "Also query npm registry for metadata (requires network)", false).option("--policy <path>", "Validate against an organization policy file").option("--evidence-pack <dir>", "Write a portable evidence bundle for audits and security reviews").option("--remediation-plan <path>", "Write a stable-fingerprint JSON remediation plan").option("--no-evidence-redact", "Disable evidence-pack redaction of local paths, usernames, emails, and token-shaped strings").option("--min-severity <severity>", "Minimum severity to report: critical, high, medium, low, info", "info").option("-v, --verbose", "Show detailed output", false).action(async (options) => {
   const targetPath = resolveTargetPath(options.path);
-  if (!existsSync12(targetPath)) {
+  if (!existsSync13(targetPath)) {
     console.error(`Error: Path does not exist: ${targetPath}`);
     process.exit(1);
   }
@@ -18764,7 +18880,7 @@ baseline.command("write").description("Scan a target and write the current findi
     process.exit(1);
   }
   const targetPath = resolveTargetPath(options.path);
-  if (!existsSync12(targetPath)) {
+  if (!existsSync13(targetPath)) {
     console.error(`Error: Path does not exist: ${targetPath}`);
     process.exit(1);
   }
@@ -18799,7 +18915,7 @@ baseline.command("write").description("Scan a target and write the current findi
 });
 program.command("watch").description("Continuously monitor config directories for security regressions").option("-p, --path <path>", "Path to watch (default: ~/.claude or current dir)").option("--debounce <ms>", "Debounce interval in milliseconds", "500").option("--alert <mode>", "Alert mode: terminal, webhook, both", "terminal").option("--webhook <url>", "Webhook URL for alerts").option("--min-severity <severity>", "Minimum severity to track: critical, high, medium, low, info", "info").option("--block", "Exit non-zero if critical findings detected (for CI integration)", false).action((options) => {
   const targetPath = resolveTargetPath(options.path);
-  if (!existsSync12(targetPath)) {
+  if (!existsSync13(targetPath)) {
     console.error(`Error: Path does not exist: ${targetPath}`);
     process.exit(1);
   }
@@ -18839,7 +18955,7 @@ program.command("watch").description("Continuously monitor config directories fo
     ".claude"
   );
   const watchPaths = [targetPath];
-  if (existsSync12(homeClaude) && homeClaude !== targetPath) {
+  if (existsSync13(homeClaude) && homeClaude !== targetPath) {
     watchPaths.push(homeClaude);
     console.log(`  Also watching:  ${homeClaude}`);
   }
@@ -18954,7 +19070,7 @@ policyCmd.command("init").description("Generate an example organization policy f
   const { generateExamplePolicy: generateExamplePolicy2, listPolicyPacks: listPolicyPacks2, PolicyPackSchema: PolicyPackSchema2 } = await Promise.resolve().then(() => (init_policy(), policy_exports));
   const outputPath = resolve10(options.output);
   const packResult = PolicyPackSchema2.safeParse(options.pack);
-  if (existsSync12(outputPath)) {
+  if (existsSync13(outputPath)) {
     console.error(`
   Error: Policy file already exists at ${outputPath}
 `);
@@ -18968,10 +19084,10 @@ policyCmd.command("init").description("Generate an example organization policy f
     process.exit(1);
   }
   const dir = resolve10(outputPath, "..");
-  if (!existsSync12(dir)) {
-    mkdirSync8(dir, { recursive: true });
+  if (!existsSync13(dir)) {
+    mkdirSync9(dir, { recursive: true });
   }
-  writeFileSync8(outputPath, generateExamplePolicy2(packResult.data, {
+  writeFileSync9(outputPath, generateExamplePolicy2(packResult.data, {
     name: options.name,
     owners: options.owner
   }));
@@ -19013,16 +19129,57 @@ policyCmd.command("export").description("Export policy pack JSON files with a ch
   }
   console.log(`
   Policy bundle written to: ${outputDir}`);
-  console.log(`  Manifest:       ${join11(outputDir, "manifest.json")}`);
+  console.log(`  Manifest:       ${join12(outputDir, "manifest.json")}`);
   console.log(`  Policies:       ${manifest.packs.length}`);
   for (const pack of manifest.packs) {
     console.log(`  - ${pack.id}: ${pack.file} (${pack.sha256})`);
   }
   if (manifest.packs[0]) {
-    console.log(`  Then run: agentshield scan --policy ${join11(options.outputDir, manifest.packs[0].file)}
+    console.log(`  Then run: agentshield scan --policy ${join12(options.outputDir, manifest.packs[0].file)}
 `);
   } else {
     console.log("");
+  }
+});
+policyCmd.command("promote").description("Promote a checksum-verified exported policy into the active policy path").option("-m, --manifest <path>", "Policy export manifest path", ".agentshield/policies/manifest.json").option("-o, --output <path>", "Active policy output path", ".agentshield/policy.json").option("--pack <pack>", "Policy pack to promote when the manifest contains multiple packs").option("--dry-run", "Verify the manifest and policy without writing the active policy", false).option("--json", "Emit the promotion result as JSON", false).action(async (options) => {
+  const {
+    promotePolicyPack: promotePolicyPack2,
+    PolicyPackSchema: PolicyPackSchema2
+  } = await Promise.resolve().then(() => (init_policy(), policy_exports));
+  const pack = options.pack ? PolicyPackSchema2.safeParse(options.pack) : void 0;
+  if (pack && !pack.success) {
+    console.error(`
+  Error: Unknown policy pack "${options.pack}"
+`);
+    process.exit(1);
+  }
+  try {
+    const result = promotePolicyPack2({
+      manifestPath: resolve10(options.manifest),
+      outputPath: resolve10(options.output),
+      pack: pack?.data,
+      dryRun: options.dryRun
+    });
+    if (options.json) {
+      writeStdout(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(`
+  Policy promotion ${result.dryRun ? "verified" : "complete"}`);
+    console.log(`  Pack:        ${result.pack}`);
+    console.log(`  Policy:      ${result.policyName}`);
+    console.log(`  Manifest:    ${result.manifestPath}`);
+    console.log(`  Source:      ${result.sourceFile}`);
+    console.log(`  Output:      ${result.outputPath}`);
+    console.log(`  Digest:      ${result.sha256}`);
+    console.log(`  Written:     ${result.promoted ? "yes" : "no (dry run)"}
+`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`
+  Error: ${message}
+`);
+    process.exit(1);
   }
 });
 var miniclaw = program.command("miniclaw").description("MiniClaw \u2014 minimal secure sandboxed AI agent runtime");
@@ -19119,14 +19276,14 @@ function resolveTargetPath(pathArg) {
     return resolve10(pathArg);
   }
   const localClaude = resolve10(process.cwd(), ".claude");
-  if (existsSync12(localClaude)) {
+  if (existsSync13(localClaude)) {
     return localClaude;
   }
   const homeClaude = resolve10(
     process.env.HOME ?? process.env.USERPROFILE ?? ".",
     ".claude"
   );
-  if (existsSync12(homeClaude)) {
+  if (existsSync13(homeClaude)) {
     return homeClaude;
   }
   return process.cwd();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1173,6 +1173,55 @@ policyCmd
     }
   });
 
+policyCmd
+  .command("promote")
+  .description("Promote a checksum-verified exported policy into the active policy path")
+  .option("-m, --manifest <path>", "Policy export manifest path", ".agentshield/policies/manifest.json")
+  .option("-o, --output <path>", "Active policy output path", ".agentshield/policy.json")
+  .option("--pack <pack>", "Policy pack to promote when the manifest contains multiple packs")
+  .option("--dry-run", "Verify the manifest and policy without writing the active policy", false)
+  .option("--json", "Emit the promotion result as JSON", false)
+  .action(async (options) => {
+    const {
+      promotePolicyPack,
+      PolicyPackSchema,
+    } = await import("./policy/index.js");
+    const pack = options.pack
+      ? PolicyPackSchema.safeParse(options.pack)
+      : undefined;
+    if (pack && !pack.success) {
+      console.error(`\n  Error: Unknown policy pack "${options.pack}"\n`);
+      process.exit(1);
+    }
+
+    try {
+      const result = promotePolicyPack({
+        manifestPath: resolve(options.manifest),
+        outputPath: resolve(options.output),
+        pack: pack?.data,
+        dryRun: options.dryRun,
+      });
+
+      if (options.json) {
+        writeStdout(JSON.stringify(result, null, 2));
+        return;
+      }
+
+      console.log(`\n  Policy promotion ${result.dryRun ? "verified" : "complete"}`);
+      console.log(`  Pack:        ${result.pack}`);
+      console.log(`  Policy:      ${result.policyName}`);
+      console.log(`  Manifest:    ${result.manifestPath}`);
+      console.log(`  Source:      ${result.sourceFile}`);
+      console.log(`  Output:      ${result.outputPath}`);
+      console.log(`  Digest:      ${result.sha256}`);
+      console.log(`  Written:     ${result.promoted ? "yes" : "no (dry run)"}\n`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`\n  Error: ${message}\n`);
+      process.exit(1);
+    }
+  });
+
 // ─── MiniClaw Commands ───────────────────────────────────
 
 const miniclaw = program

--- a/src/policy/index.ts
+++ b/src/policy/index.ts
@@ -12,6 +12,9 @@ export {
   POLICY_EXPORT_SCHEMA_VERSION,
   exportPolicyPacks,
 } from "./export.js";
+export {
+  promotePolicyPack,
+} from "./promote.js";
 export type { EvaluatePolicyOptions, LoadPolicyResult } from "./evaluate.js";
 export type {
   GeneratePolicyPackOptions,
@@ -22,6 +25,10 @@ export type {
   PolicyPackExportEntry,
   PolicyPackExportManifest,
 } from "./export.js";
+export type {
+  PromotePolicyPackOptions,
+  PolicyPackPromotionResult,
+} from "./promote.js";
 export {
   OrgPolicySchema,
   PolicyExceptionSchema,

--- a/src/policy/promote.ts
+++ b/src/policy/promote.ts
@@ -1,0 +1,172 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  dirname,
+  isAbsolute,
+  join,
+} from "node:path";
+import { POLICY_EXPORT_SCHEMA_VERSION } from "./export.js";
+import {
+  OrgPolicySchema,
+  PolicyPackSchema,
+} from "./types.js";
+import type { PolicyPack } from "./types.js";
+
+export interface PromotePolicyPackOptions {
+  readonly manifestPath: string;
+  readonly outputPath: string;
+  readonly pack?: PolicyPack;
+  readonly dryRun?: boolean;
+}
+
+export interface PolicyPackPromotionResult {
+  readonly manifestPath: string;
+  readonly sourceFile: string;
+  readonly outputPath: string;
+  readonly pack: PolicyPack;
+  readonly policyName: string;
+  readonly owners: ReadonlyArray<string>;
+  readonly sha256: string;
+  readonly verified: true;
+  readonly promoted: boolean;
+  readonly dryRun: boolean;
+}
+
+interface ExportManifestEntry {
+  readonly id: PolicyPack;
+  readonly file: string;
+  readonly sha256: string;
+}
+
+interface ExportManifest {
+  readonly schema_version: typeof POLICY_EXPORT_SCHEMA_VERSION;
+  readonly packs: ReadonlyArray<ExportManifestEntry>;
+}
+
+export function promotePolicyPack(options: PromotePolicyPackOptions): PolicyPackPromotionResult {
+  const manifest = readExportManifest(options.manifestPath);
+  const entry = selectPolicyPack(manifest.packs, options.pack);
+  const sourceFile = isAbsolute(entry.file)
+    ? entry.file
+    : join(dirname(options.manifestPath), entry.file);
+
+  if (!existsSync(sourceFile)) {
+    throw new Error(`Policy file not found: ${sourceFile}`);
+  }
+
+  const policyJson = readFileSync(sourceFile, "utf-8");
+  const actualDigest = digest(policyJson);
+  if (actualDigest !== entry.sha256) {
+    throw new Error(
+      `Policy digest mismatch for ${entry.id}: expected ${entry.sha256}, got ${actualDigest}`
+    );
+  }
+
+  const parsed = JSON.parse(policyJson);
+  const policy = OrgPolicySchema.parse(parsed);
+  if (policy.policy_pack !== entry.id) {
+    throw new Error(
+      `Policy pack mismatch: manifest entry is ${entry.id}, policy file declares ${policy.policy_pack}`
+    );
+  }
+
+  if (!options.dryRun) {
+    mkdirSync(dirname(options.outputPath), { recursive: true });
+    writeFileSync(options.outputPath, policyJson);
+  }
+
+  return {
+    manifestPath: options.manifestPath,
+    sourceFile,
+    outputPath: options.outputPath,
+    pack: entry.id,
+    policyName: policy.name ?? "Organization Policy",
+    owners: policy.owners ?? [],
+    sha256: entry.sha256,
+    verified: true,
+    promoted: !options.dryRun,
+    dryRun: Boolean(options.dryRun),
+  };
+}
+
+function readExportManifest(manifestPath: string): ExportManifest {
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Policy export manifest not found: ${manifestPath}`);
+  }
+
+  const raw = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+    readonly schema_version?: unknown;
+    readonly packs?: unknown;
+  };
+
+  if (raw.schema_version !== POLICY_EXPORT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported policy export manifest schema: ${String(raw.schema_version)}`
+    );
+  }
+
+  if (!Array.isArray(raw.packs)) {
+    throw new Error("Policy export manifest is missing a packs array");
+  }
+
+  return {
+    schema_version: POLICY_EXPORT_SCHEMA_VERSION,
+    packs: raw.packs.map(readManifestEntry),
+  };
+}
+
+function readManifestEntry(entry: unknown): ExportManifestEntry {
+  if (!entry || typeof entry !== "object") {
+    throw new Error("Invalid policy export manifest entry");
+  }
+
+  const candidate = entry as {
+    readonly id?: unknown;
+    readonly file?: unknown;
+    readonly sha256?: unknown;
+  };
+  const packResult = PolicyPackSchema.safeParse(candidate.id);
+  if (!packResult.success) {
+    throw new Error(`Invalid policy pack id in manifest: ${String(candidate.id)}`);
+  }
+  if (typeof candidate.file !== "string" || candidate.file.length === 0) {
+    throw new Error(`Invalid policy file for manifest pack: ${packResult.data}`);
+  }
+  if (typeof candidate.sha256 !== "string" || !/^sha256:[a-f0-9]{64}$/.test(candidate.sha256)) {
+    throw new Error(`Invalid policy digest for manifest pack: ${packResult.data}`);
+  }
+
+  return {
+    id: packResult.data,
+    file: candidate.file,
+    sha256: candidate.sha256,
+  };
+}
+
+function selectPolicyPack(
+  entries: ReadonlyArray<ExportManifestEntry>,
+  requestedPack: PolicyPack | undefined
+): ExportManifestEntry {
+  if (requestedPack) {
+    const entry = entries.find((item) => item.id === requestedPack);
+    if (!entry) {
+      throw new Error(`Policy pack ${requestedPack} not found in export manifest`);
+    }
+    return entry;
+  }
+
+  if (entries.length === 1) {
+    return entries[0]!;
+  }
+
+  throw new Error("Export manifest contains multiple policy packs; pass --pack to select one");
+}
+
+function digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}

--- a/tests/policy/promote.test.ts
+++ b/tests/policy/promote.test.ts
@@ -1,0 +1,123 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  exportPolicyPacks,
+  promotePolicyPack,
+  type PolicyPackPromotionResult,
+} from "../../src/policy/index.js";
+
+const CLI_PATH = resolve(import.meta.dirname, "../../dist/index.js");
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+describe("policy pack promotion", () => {
+  it("promotes one exported policy after verifying its manifest digest", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-promote-"));
+    exportPolicyPacks({
+      outputDir,
+      packs: ["enterprise"],
+      owners: ["security@example.com"],
+      namePrefix: "Acme",
+    });
+
+    const activePolicyPath = join(outputDir, "active-policy.json");
+    const result = promotePolicyPack({
+      manifestPath: join(outputDir, "manifest.json"),
+      outputPath: activePolicyPath,
+    });
+
+    expect(result).toMatchObject<Partial<PolicyPackPromotionResult>>({
+      pack: "enterprise",
+      policyName: "Acme Enterprise Policy",
+      outputPath: activePolicyPath,
+      promoted: true,
+      verified: true,
+    });
+    expect(result.sha256).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(existsSync(activePolicyPath)).toBe(true);
+
+    const policy = readJson<Record<string, unknown>>(activePolicyPath);
+    expect(policy.policy_pack).toBe("enterprise");
+    expect(policy.owners).toEqual(["security@example.com"]);
+  });
+
+  it("dry-runs a promotion without writing the active policy file", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-promote-dry-"));
+    exportPolicyPacks({ outputDir, packs: ["ci-enforcement"] });
+
+    const activePolicyPath = join(outputDir, "active-policy.json");
+    const result = promotePolicyPack({
+      manifestPath: join(outputDir, "manifest.json"),
+      outputPath: activePolicyPath,
+      dryRun: true,
+    });
+
+    expect(result.pack).toBe("ci-enforcement");
+    expect(result.promoted).toBe(false);
+    expect(result.verified).toBe(true);
+    expect(existsSync(activePolicyPath)).toBe(false);
+  });
+
+  it("rejects a tampered policy file whose digest no longer matches the manifest", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-promote-tamper-"));
+    exportPolicyPacks({ outputDir, packs: ["team"] });
+
+    const policyPath = join(outputDir, "team-policy.json");
+    const policy = readJson<Record<string, unknown>>(policyPath);
+    writeFileSync(policyPath, `${JSON.stringify({ ...policy, min_score: 1 }, null, 2)}\n`);
+
+    expect(() => promotePolicyPack({
+      manifestPath: join(outputDir, "manifest.json"),
+      outputPath: join(outputDir, "active-policy.json"),
+    })).toThrow(/digest mismatch/i);
+  });
+
+  it("requires an explicit pack when the manifest contains multiple policies", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-promote-many-"));
+    exportPolicyPacks({ outputDir });
+
+    expect(() => promotePolicyPack({
+      manifestPath: join(outputDir, "manifest.json"),
+      outputPath: join(outputDir, "active-policy.json"),
+    })).toThrow(/multiple policy packs/i);
+  });
+
+  it("exposes promotion through the CLI", () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "agentshield-policy-promote-cli-"));
+    exportPolicyPacks({ outputDir, packs: ["ci-enforcement"] });
+    const activePolicyPath = join(outputDir, "active-policy.json");
+
+    const result = spawnSync(process.execPath, [
+      CLI_PATH,
+      "policy",
+      "promote",
+      "--manifest",
+      join(outputDir, "manifest.json"),
+      "--output",
+      activePolicyPath,
+      "--json",
+    ], {
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        NODE_NO_WARNINGS: "1",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+
+    const promotion = JSON.parse(result.stdout) as PolicyPackPromotionResult;
+    expect(promotion).toMatchObject({
+      pack: "ci-enforcement",
+      promoted: true,
+      verified: true,
+    });
+    expect(existsSync(activePolicyPath)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `promotePolicyPack` to verify exported policy manifests and SHA-256 digests before activating a policy
- add `agentshield policy promote` with `--manifest`, `--pack`, `--output`, `--dry-run`, and `--json` for review workflows
- document the export-to-promote workflow and update the changelog
- rebuild the bundled CLI/action dist artifacts

## Validation
- npx vitest run tests/policy/promote.test.ts tests/policy/export.test.ts tests/policy/presets.test.ts tests/policy/evaluate.test.ts
- npm run typecheck
- npm run lint
- npm run build
- node dist/index.js policy export --pack ci-enforcement --output-dir /tmp/agentshield-policy-promote-smoke --json
- node dist/index.js policy promote --manifest /tmp/agentshield-policy-promote-smoke/manifest.json --output /tmp/agentshield-policy-promote-smoke/active-policy.json --json
- npm test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a checksum-first policy promotion gate that verifies exported manifests and SHA-256 digests before writing the active `.agentshield/policy.json`. Introduces `agentshield policy promote` with dry-run and JSON modes for safe, reviewable workflows.

- New Features
  - Added `promotePolicyPack` to validate export manifest schema, pack selection, SHA-256 digest, and policy schema; writes the active policy unless `--dry-run`.
  - New CLI: `agentshield policy promote` with `--manifest`, `--output`, `--pack`, `--dry-run`, and `--json`.
  - Documented the export-to-promote workflow; updated `README.md`, `API.md`, and `CHANGELOG.md`.
  - Added tests for promotion behavior, tamper detection, multi-pack selection, and CLI JSON output.

<sup>Written for commit 3c6360180540ab9576895ccf58718ad53c6fe280. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/92?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `agentshield policy promote` command to validate and activate exported policy packs with SHA-256 checksum verification, supporting `--dry-run`, `--json`, and pack selection options.

* **Documentation**
  * Updated CLI documentation with policy promotion command examples and schema validation details.

* **Tests**
  * Added comprehensive test coverage for policy promotion workflow including checksum validation and dry-run modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->