### PR TITLE
Add fleet approval IDs

### DIFF
--- a/API.md
+++ b/API.md
@@ -231,6 +231,10 @@ or customer-review ingestion.
 `fleet` runs the same inspection across multiple evidence-pack directories and
 emits totals plus route suggestions: `invalid`, `security-blocker`,
 `policy-review`, `baseline-regression`, `supply-chain-review`, or `ready`.
+Fleet output includes `operatorReadback.approvalIds`; each non-ready
+`reviewItems[]` entry repeats its `approvalId` and exposes
+`ticket.externalId` in the form `agentshield-fleet-review:<approvalId>` for
+idempotent GitHub App or Linear sync.
 
 Top-level shape:
 

--- a/README.md
+++ b/README.md
@@ -462,8 +462,11 @@ agentshield evidence-pack fleet ./repo-a-evidence ./repo-b-evidence --json
 
 `operatorReadback` is the stable field for downstream GitHub App, Linear, or
 ECC Tools routing. It reports `ready`, `status`, `digest`, owner counts,
-blocking review counts, approval routes, and the next operator action so fleet
-promotion can be gated without parsing terminal prose.
+blocking review counts, approval routes, deterministic `approvalIds`, and the
+next operator action so fleet promotion can be gated without parsing terminal
+prose. Each review item also carries the same `approvalId` plus a
+Linear-friendly ticket `externalId`, allowing sync jobs to dedupe owner approval
+threads across reruns.
 
 ### JSON Report Shape
 

--- a/dist/action.js
+++ b/dist/action.js
@@ -4372,9 +4372,9 @@ var AI_TOOL_PERSISTENCE_IOCS = [
     description: "Matches the fictitious @tanstack/setup dependency or malicious git ref from the May 2026 TanStack/Mini Shai-Hulud campaign."
   },
   {
-    name: "tanstack-payload-filename",
-    pattern: /\b(?:router_init\.js|tanstack_runner\.js)\b/gi,
-    description: "Matches payload filenames used by the May 2026 TanStack/Mini Shai-Hulud npm campaign."
+    name: "mini-shai-hulud-payload-filename",
+    pattern: /\b(?:router_init\.js|tanstack_runner\.js|opensearch_init\.js|vite_setup\.mjs|execution\.js|shai-hulud-workflow\.ya?ml)\b/gi,
+    description: "Matches payload and workflow filenames used by the May 2026 TanStack/Mini Shai-Hulud npm campaign and follow-on package waves."
   },
   {
     name: "tanstack-exfil-network",

--- a/dist/index.js
+++ b/dist/index.js
@@ -2299,9 +2299,9 @@ var init_hooks = __esm({
         description: "Matches the fictitious @tanstack/setup dependency or malicious git ref from the May 2026 TanStack/Mini Shai-Hulud campaign."
       },
       {
-        name: "tanstack-payload-filename",
-        pattern: /\b(?:router_init\.js|tanstack_runner\.js)\b/gi,
-        description: "Matches payload filenames used by the May 2026 TanStack/Mini Shai-Hulud npm campaign."
+        name: "mini-shai-hulud-payload-filename",
+        pattern: /\b(?:router_init\.js|tanstack_runner\.js|opensearch_init\.js|vite_setup\.mjs|execution\.js|shai-hulud-workflow\.ya?ml)\b/gi,
+        description: "Matches payload and workflow filenames used by the May 2026 TanStack/Mini Shai-Hulud npm campaign and follow-on package waves."
       },
       {
         name: "tanstack-exfil-network",
@@ -16210,6 +16210,7 @@ function buildFleetOperatorReadback(summary, routes, reviewItems) {
   const status = determineFleetOperatorStatus(summary, reviewItems);
   const owners = Array.from(new Set(reviewItems.map((item) => item.owner))).sort();
   const routesRequiringApproval = Array.from(new Set(reviewItems.map((item) => item.route))).sort();
+  const approvalIds = reviewItems.map((item) => item.approvalId).sort();
   return {
     status,
     ready: status === "ready",
@@ -16221,6 +16222,7 @@ function buildFleetOperatorReadback(summary, routes, reviewItems) {
     ownerCount: owners.length,
     owners,
     routesRequiringApproval,
+    approvalIds,
     nextAction: describeFleetOperatorNextAction(status)
   };
 }
@@ -16247,6 +16249,7 @@ function buildFleetOperatorDigest(summary, routes, reviewItems) {
       route: item.route,
       severity: item.severity,
       priority: item.priority,
+      approvalId: item.approvalId,
       outputDir: item.outputDir,
       owner: item.owner,
       repository: item.repository,
@@ -16275,12 +16278,26 @@ function buildFleetReviewItem(entry) {
   const reversibleAction = buildFleetReviewReversibleAction(entry.route);
   const actions = buildFleetReviewActions(entry.route);
   const recommendation = buildFleetReviewRecommendation(entry.route);
+  const owner = buildFleetReviewOwner(entry);
+  const approvalId = buildFleetReviewApprovalId({
+    entry,
+    severity,
+    priority,
+    owner,
+    evidencePaths,
+    beforeState,
+    afterState,
+    reversibleAction,
+    actions,
+    recommendation
+  });
   return {
     route: entry.route,
     severity,
     priority,
+    approvalId,
     outputDir: entry.outputDir,
-    owner: buildFleetReviewOwner(entry),
+    owner,
     repository: entry.repository,
     targetPath: entry.targetPath,
     reason: entry.reason,
@@ -16294,6 +16311,8 @@ function buildFleetReviewItem(entry) {
       entry,
       severity,
       priority,
+      owner,
+      approvalId,
       evidencePaths,
       beforeState,
       afterState,
@@ -16302,6 +16321,26 @@ function buildFleetReviewItem(entry) {
       recommendation
     })
   };
+}
+function buildFleetReviewApprovalId(options) {
+  const payload = {
+    route: options.entry.route,
+    severity: options.severity,
+    priority: options.priority,
+    outputDir: options.entry.outputDir,
+    repository: options.entry.repository,
+    targetPath: options.entry.targetPath,
+    reason: options.entry.reason,
+    owner: options.owner,
+    evidencePaths: [...options.evidencePaths].sort(),
+    beforeState: options.beforeState,
+    afterState: options.afterState,
+    reversibleAction: options.reversibleAction,
+    actions: [...options.actions],
+    recommendation: options.recommendation
+  };
+  const digest3 = createHash2("sha256").update(JSON.stringify(payload)).digest("hex");
+  return `agsr_${digest3.slice(0, 16)}`;
 }
 function determineFleetReviewSeverity(route) {
   if (route === "invalid" || route === "security-blocker") return "high";
@@ -16405,6 +16444,7 @@ function buildFleetReviewActions(route) {
 }
 function buildFleetReviewTicket(options) {
   const repository = options.entry.repository ?? "unknown repository";
+  const externalId = `agentshield-fleet-review:${options.approvalId}`;
   const labels = [
     "AgentShield",
     "Security",
@@ -16417,8 +16457,10 @@ function buildFleetReviewTicket(options) {
     `Route: \`${options.entry.route}\``,
     `Priority: \`${options.priority}\``,
     `Severity: \`${options.severity}\``,
+    `Approval ID: \`${options.approvalId}\``,
+    `External ID: \`${externalId}\``,
     `Repository: \`${repository}\``,
-    `Owner: \`${buildFleetReviewOwner(options.entry)}\``,
+    `Owner: \`${options.owner}\``,
     `Reason: ${options.entry.reason}`,
     "",
     "### State",
@@ -16435,6 +16477,7 @@ function buildFleetReviewTicket(options) {
     `Recommendation: ${options.recommendation}`
   ].join("\n");
   return {
+    externalId,
     title: `AgentShield ${options.entry.route}: ${repository} (${options.entry.reason})`,
     body,
     labels,
@@ -19737,6 +19780,7 @@ evidencePack.command("fleet").description("Inspect multiple evidence packs and s
         );
         writeStdout(`  owner: ${item.owner}`);
         writeStdout(`  priority: ${item.priority}`);
+        writeStdout(`  approval: ${item.approvalId}`);
         writeStdout(`  ticket: ${item.ticket.title}`);
         writeStdout(`  before: ${item.beforeState}`);
         writeStdout(`  after: ${item.afterState}`);

--- a/release-draft.md
+++ b/release-draft.md
@@ -14,7 +14,10 @@ Linear, and ECC Tools flows can consume directly.
   drop-ins, and OS startup artifacts.
 - Added evidence-pack fleet `operatorReadback` output with ready/blocked status,
   deterministic review digest, owner counts, approval routes, blocking counts,
-  and next-action guidance for promotion gates.
+  deterministic approval IDs, and next-action guidance for promotion gates.
+- Added review-item approval IDs and ticket external IDs so downstream GitHub
+  App, Linear, and ECC Tools sync jobs can dedupe owner-approval threads across
+  repeated fleet inspections.
 - Added `agentshield policy promote` to verify exported policy-pack manifests,
   reject tampered policy JSON by SHA-256 digest, and promote a selected pack
   into the active policy path with dry-run and JSON review modes.

--- a/src/evidence-pack/index.ts
+++ b/src/evidence-pack/index.ts
@@ -98,6 +98,7 @@ export interface EvidencePackFleetOperatorReadback {
   readonly ownerCount: number;
   readonly owners: ReadonlyArray<string>;
   readonly routesRequiringApproval: ReadonlyArray<EvidencePackFleetRoute>;
+  readonly approvalIds: ReadonlyArray<string>;
   readonly nextAction: string;
 }
 
@@ -155,6 +156,7 @@ export interface EvidencePackFleetReviewItem {
   readonly route: EvidencePackFleetRoute;
   readonly severity: "high" | "medium" | "low" | "info";
   readonly priority: "urgent" | "high" | "normal";
+  readonly approvalId: string;
   readonly outputDir: string;
   readonly owner: string;
   readonly repository: string | null;
@@ -170,6 +172,7 @@ export interface EvidencePackFleetReviewItem {
 }
 
 export interface EvidencePackFleetReviewTicket {
+  readonly externalId: string;
   readonly title: string;
   readonly body: string;
   readonly labels: ReadonlyArray<string>;
@@ -624,6 +627,7 @@ function buildFleetOperatorReadback(
   const status = determineFleetOperatorStatus(summary, reviewItems);
   const owners = Array.from(new Set(reviewItems.map((item) => item.owner))).sort();
   const routesRequiringApproval = Array.from(new Set(reviewItems.map((item) => item.route))).sort();
+  const approvalIds = reviewItems.map((item) => item.approvalId).sort();
   return {
     status,
     ready: status === "ready",
@@ -635,6 +639,7 @@ function buildFleetOperatorReadback(
     ownerCount: owners.length,
     owners,
     routesRequiringApproval,
+    approvalIds,
     nextAction: describeFleetOperatorNextAction(status),
   };
 }
@@ -674,6 +679,7 @@ function buildFleetOperatorDigest(
         route: item.route,
         severity: item.severity,
         priority: item.priority,
+        approvalId: item.approvalId,
         outputDir: item.outputDir,
         owner: item.owner,
         repository: item.repository,
@@ -705,12 +711,26 @@ function buildFleetReviewItem(entry: EvidencePackFleetEntry): EvidencePackFleetR
   const reversibleAction = buildFleetReviewReversibleAction(entry.route);
   const actions = buildFleetReviewActions(entry.route);
   const recommendation = buildFleetReviewRecommendation(entry.route);
+  const owner = buildFleetReviewOwner(entry);
+  const approvalId = buildFleetReviewApprovalId({
+    entry,
+    severity,
+    priority,
+    owner,
+    evidencePaths,
+    beforeState,
+    afterState,
+    reversibleAction,
+    actions,
+    recommendation,
+  });
   return {
     route: entry.route,
     severity,
     priority,
+    approvalId,
     outputDir: entry.outputDir,
-    owner: buildFleetReviewOwner(entry),
+    owner,
     repository: entry.repository,
     targetPath: entry.targetPath,
     reason: entry.reason,
@@ -724,6 +744,8 @@ function buildFleetReviewItem(entry: EvidencePackFleetEntry): EvidencePackFleetR
       entry,
       severity,
       priority,
+      owner,
+      approvalId,
       evidencePaths,
       beforeState,
       afterState,
@@ -732,6 +754,38 @@ function buildFleetReviewItem(entry: EvidencePackFleetEntry): EvidencePackFleetR
       recommendation,
     }),
   };
+}
+
+function buildFleetReviewApprovalId(options: {
+  readonly entry: EvidencePackFleetEntry;
+  readonly severity: EvidencePackFleetReviewItem["severity"];
+  readonly priority: EvidencePackFleetReviewItem["priority"];
+  readonly owner: string;
+  readonly evidencePaths: ReadonlyArray<string>;
+  readonly beforeState: string;
+  readonly afterState: string;
+  readonly reversibleAction: string;
+  readonly actions: ReadonlyArray<string>;
+  readonly recommendation: string;
+}): string {
+  const payload = {
+    route: options.entry.route,
+    severity: options.severity,
+    priority: options.priority,
+    outputDir: options.entry.outputDir,
+    repository: options.entry.repository,
+    targetPath: options.entry.targetPath,
+    reason: options.entry.reason,
+    owner: options.owner,
+    evidencePaths: [...options.evidencePaths].sort(),
+    beforeState: options.beforeState,
+    afterState: options.afterState,
+    reversibleAction: options.reversibleAction,
+    actions: [...options.actions],
+    recommendation: options.recommendation,
+  };
+  const digest = createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+  return `agsr_${digest.slice(0, 16)}`;
 }
 
 function determineFleetReviewSeverity(route: EvidencePackFleetRoute): EvidencePackFleetReviewItem["severity"] {
@@ -849,6 +903,8 @@ function buildFleetReviewTicket(options: {
   readonly entry: EvidencePackFleetEntry;
   readonly severity: EvidencePackFleetReviewItem["severity"];
   readonly priority: EvidencePackFleetReviewItem["priority"];
+  readonly owner: string;
+  readonly approvalId: string;
   readonly evidencePaths: ReadonlyArray<string>;
   readonly beforeState: string;
   readonly afterState: string;
@@ -857,6 +913,7 @@ function buildFleetReviewTicket(options: {
   readonly recommendation: string;
 }): EvidencePackFleetReviewTicket {
   const repository = options.entry.repository ?? "unknown repository";
+  const externalId = `agentshield-fleet-review:${options.approvalId}`;
   const labels = [
     "AgentShield",
     "Security",
@@ -869,8 +926,10 @@ function buildFleetReviewTicket(options: {
     `Route: \`${options.entry.route}\``,
     `Priority: \`${options.priority}\``,
     `Severity: \`${options.severity}\``,
+    `Approval ID: \`${options.approvalId}\``,
+    `External ID: \`${externalId}\``,
     `Repository: \`${repository}\``,
-    `Owner: \`${buildFleetReviewOwner(options.entry)}\``,
+    `Owner: \`${options.owner}\``,
     `Reason: ${options.entry.reason}`,
     "",
     "### State",
@@ -888,6 +947,7 @@ function buildFleetReviewTicket(options: {
   ].join("\n");
 
   return {
+    externalId,
     title: `AgentShield ${options.entry.route}: ${repository} (${options.entry.reason})`,
     body,
     labels,

--- a/src/index.ts
+++ b/src/index.ts
@@ -785,6 +785,7 @@ evidencePack
           );
           writeStdout(`  owner: ${item.owner}`);
           writeStdout(`  priority: ${item.priority}`);
+          writeStdout(`  approval: ${item.approvalId}`);
           writeStdout(`  ticket: ${item.ticket.title}`);
           writeStdout(`  before: ${item.beforeState}`);
           writeStdout(`  after: ${item.afterState}`);

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -760,6 +760,9 @@ describe("writeEvidencePack", () => {
       nextAction: "Route review items to listed owners and attach approval before promotion.",
     });
     expect(fleet.operatorReadback.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(fleet.operatorReadback.approvalIds).toEqual([
+      expect.stringMatching(/^agsr_[0-9a-f]{16}$/),
+    ]);
     expect(fleet.entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -794,6 +797,7 @@ describe("writeEvidencePack", () => {
         route: "security-blocker",
         severity: "high",
         priority: "urgent",
+        approvalId: fleet.operatorReadback.approvalIds[0],
         owner: "affaan-m/risky-repo security owner",
         repository: "affaan-m/risky-repo",
         outputDir: riskyOutputDir,
@@ -813,6 +817,7 @@ describe("writeEvidencePack", () => {
         ]),
         recommendation: "Route to security owner before promotion.",
         ticket: expect.objectContaining({
+          externalId: `agentshield-fleet-review:${fleet.operatorReadback.approvalIds[0]}`,
           title: "AgentShield security-blocker: affaan-m/risky-repo (1 critical findings)",
           priority: "urgent",
           labels: expect.arrayContaining([
@@ -825,6 +830,7 @@ describe("writeEvidencePack", () => {
         }),
       }),
     ]);
+    expect(fleet.reviewItems[0].ticket.body).toContain(`Approval ID: \`${fleet.operatorReadback.approvalIds[0]}\``);
   });
 
   it("routes current Mini Shai-Hulud supply-chain incident packs as security blockers", async () => {
@@ -1045,6 +1051,7 @@ describe("writeEvidencePack", () => {
     expect(text.stdout).toContain("high security-blocker affaan-m/risky-repo");
     expect(text.stdout).toContain("owner: affaan-m/risky-repo security owner");
     expect(text.stdout).toContain("priority: urgent");
+    expect(text.stdout).toMatch(/approval: agsr_[0-9a-f]{16}/);
     expect(text.stdout).toContain("ticket: AgentShield security-blocker: affaan-m/risky-repo (1 critical findings)");
     expect(text.stdout).toContain("before: Evidence pack has security blockers: 1 critical findings.");
     expect(text.stdout).toContain("after: Critical and high findings are fixed, accepted by policy, or explicitly routed with owner approval.");
@@ -1067,7 +1074,8 @@ describe("writeEvidencePack", () => {
     });
 
     expect(json.status).toBe(0);
-    expect(JSON.parse(json.stdout)).toMatchObject({
+    const parsedJson = JSON.parse(json.stdout);
+    expect(parsedJson).toMatchObject({
       ok: true,
       requiresAttention: true,
       summary: {
@@ -1088,6 +1096,7 @@ describe("writeEvidencePack", () => {
         ownerCount: 1,
         owners: ["affaan-m/risky-repo security owner"],
         routesRequiringApproval: ["security-blocker"],
+        approvalIds: [expect.stringMatching(/^agsr_[0-9a-f]{16}$/)],
         nextAction: "Route review items to listed owners and attach approval before promotion.",
       },
       reviewItems: [
@@ -1095,6 +1104,7 @@ describe("writeEvidencePack", () => {
           route: "security-blocker",
           severity: "high",
           priority: "urgent",
+          approvalId: expect.stringMatching(/^agsr_[0-9a-f]{16}$/),
           owner: "affaan-m/risky-repo security owner",
           repository: "affaan-m/risky-repo",
           beforeState: "Evidence pack has security blockers: 1 critical findings.",
@@ -1107,6 +1117,7 @@ describe("writeEvidencePack", () => {
           ],
           recommendation: "Route to security owner before promotion.",
           ticket: {
+            externalId: expect.stringMatching(/^agentshield-fleet-review:agsr_[0-9a-f]{16}$/),
             title: "AgentShield security-blocker: affaan-m/risky-repo (1 critical findings)",
             priority: "urgent",
             labels: [
@@ -1119,6 +1130,13 @@ describe("writeEvidencePack", () => {
         },
       ],
     });
-    expect(JSON.parse(json.stdout).operatorReadback.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(parsedJson.operatorReadback.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(parsedJson.reviewItems[0].approvalId).toBe(parsedJson.operatorReadback.approvalIds[0]);
+    expect(parsedJson.reviewItems[0].ticket.externalId).toBe(
+      `agentshield-fleet-review:${parsedJson.reviewItems[0].approvalId}`
+    );
+    expect(parsedJson.reviewItems[0].ticket.body).toContain(
+      `Approval ID: \`${parsedJson.reviewItems[0].approvalId}\``
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add deterministic AgentShield fleet review approval IDs for non-ready evidence packs
- expose Linear/GitHub-App-friendly ticket external IDs and CLI readback lines
- document the approval ID contract in README/API/release draft and rebuild dist

## Validation
- npx vitest run tests/evidence-pack/evidence-pack.test.ts
- npm run typecheck
- npm run lint
- npm test
- npm run build
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deterministic approval IDs to fleet review items and exposes ticket external IDs to enable idempotent GitHub App and Linear sync. Updates CLI, JSON/API, and docs; also expands Mini Shai-Hulud IOC filename patterns.

- **New Features**
  - Generate a stable `approvalId` for each non-ready review item (prefix `agsr_...`) and surface them in `operatorReadback.approvalIds`.
  - Add `ticket.externalId` as `agentshield-fleet-review:<approvalId>` and include approval details in ticket body and CLI output.
  - Update README/API/release notes; expand payload filename IOCs for the Mini Shai-Hulud campaign.

<sup>Written for commit 42c08e298f381a41b5671c7cfb095a6e3b00ce5d. Summary will update on new commits. <a href="https://cubic.dev/pr/affaan-m/agentshield/pull/93?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet inspection output now includes deterministic approval identifiers for improved review tracking and external system synchronization.
  * Review items now display approval IDs; tickets include formatted external IDs for deduplication support.

* **Documentation**
  * Updated API documentation and README with details on new approval ID fields and output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/affaan-m/agentshield/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->