### PR TITLE
fix: treat dangerous flags inside permissions.deny/ask rules as prohibitions, not usages

### DIFF
--- a/src/rules/permissions.ts
+++ b/src/rules/permissions.ts
@@ -150,6 +150,44 @@ function parsePermissionLists(content: string): {
   }
 }
 
+/**
+ * Locate the character spans of every `permissions.deny` and
+ * `permissions.ask` rule value in a settings JSON file. Matches of
+ * dangerous-flag patterns inside these spans are prohibitions (the rule
+ * blocks the flag), not usages. Returns no spans for non-settings files
+ * or unparseable JSON, so callers fail closed (matches stay flagged).
+ */
+function prohibitivePermissionRuleSpans(
+  file: ConfigFile,
+): ReadonlyArray<readonly [number, number]> {
+  if (file.type !== "settings-json") return [];
+
+  let config: unknown;
+  try {
+    config = JSON.parse(file.content);
+  } catch {
+    return [];
+  }
+
+  const perms = (config as { permissions?: { deny?: unknown; ask?: unknown } })
+    ?.permissions;
+  const entries = [
+    ...(Array.isArray(perms?.deny) ? perms.deny : []),
+    ...(Array.isArray(perms?.ask) ? perms.ask : []),
+  ].filter((entry): entry is string => typeof entry === "string");
+
+  const spans: Array<readonly [number, number]> = [];
+  for (const entry of entries) {
+    let from = 0;
+    let at: number;
+    while ((at = file.content.indexOf(entry, from)) !== -1) {
+      spans.push([at, at + entry.length]);
+      from = at + entry.length;
+    }
+  }
+  return spans;
+}
+
 interface ConfigPathValue {
   readonly path: string;
   readonly value: unknown;
@@ -459,6 +497,13 @@ export const permissionRules: ReadonlyArray<Rule> = [
         },
       ];
 
+      // Spans of deny/ask rule values in settings JSON. A dangerous flag
+      // inside a deny or ask rule is prohibitive context: the rule blocks
+      // (or gates) the flag rather than using it. Without this, the rule
+      // flags the scanner's own recommended remediation — adding a deny
+      // list — as CRITICAL (see #102).
+      const prohibitiveSpans = prohibitivePermissionRuleSpans(file);
+
       // Negation words that indicate the pattern is being PROHIBITED, not used
       const negationPatterns = [
         /\bnever\b/i,
@@ -480,6 +525,20 @@ export const permissionRules: ReadonlyArray<Rule> = [
 
         for (const match of matches) {
           const idx = match.index ?? 0;
+
+          if (prohibitiveSpans.some(([start, end]) => idx >= start && idx < end)) {
+            findings.push({
+              id: `permissions-deny-rule-${idx}`,
+              severity: "info",
+              category: "permissions",
+              title: `Deny/ask rule blocking ${match[0]} (good practice)`,
+              description: `Found "${match[0]}" inside a permissions deny/ask rule. This is correct — the rule prevents the agent from using this flag.`,
+              file: file.path,
+              line: findLineNumber(file.content, idx),
+              evidence: match[0],
+            });
+            continue;
+          }
 
           // Check surrounding context (100 chars before) for negation
           const contextStart = Math.max(0, idx - 100);

--- a/tests/rules/permissions.test.ts
+++ b/tests/rules/permissions.test.ts
@@ -247,6 +247,68 @@ describe("permissionRules", () => {
       expect(noVerifyFindings[0].severity).toBe("critical");
     });
 
+    it("downgrades --no-verify inside a permissions.deny rule (#102)", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: {
+          deny: ["Bash(git commit --no-verify:*)", "Bash(git push --no-verify:*)"],
+        },
+      }, null, 2));
+      const findings = runAllPermRules(file);
+      const noVerifyFindings = findings.filter((f) => f.evidence === "--no-verify");
+      expect(noVerifyFindings).toHaveLength(2);
+      for (const finding of noVerifyFindings) {
+        expect(finding.severity).toBe("info");
+        expect(finding.title).toContain("good practice");
+      }
+    });
+
+    it("downgrades --no-verify inside a permissions.ask rule", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: {
+          ask: ["Bash(git commit --no-verify:*)"],
+        },
+      }));
+      const findings = runAllPermRules(file);
+      const noVerifyFindings = findings.filter((f) => f.evidence === "--no-verify");
+      expect(noVerifyFindings).toHaveLength(1);
+      expect(noVerifyFindings[0].severity).toBe("info");
+    });
+
+    it("keeps --no-verify in a permissions.allow rule CRITICAL", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: {
+          allow: ["Bash(git commit --no-verify:*)"],
+          deny: [],
+        },
+      }));
+      const findings = runAllPermRules(file);
+      const noVerifyFindings = findings.filter((f) => f.evidence === "--no-verify");
+      expect(noVerifyFindings).toHaveLength(1);
+      expect(noVerifyFindings[0].severity).toBe("critical");
+    });
+
+    it("downgrades dangerously-skip-permissions inside a deny rule", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: {
+          deny: ["Bash(claude --dangerously-skip-permissions:*)"],
+        },
+      }));
+      const findings = runAllPermRules(file);
+      const skipFindings = findings.filter((f) =>
+        f.evidence?.toLowerCase().includes("dangerously"),
+      );
+      expect(skipFindings).toHaveLength(1);
+      expect(skipFindings[0].severity).toBe("info");
+    });
+
+    it("still flags dangerous flags in deny-rule-shaped text when JSON is invalid (fails closed)", () => {
+      const file = makeSettings('"deny": ["Bash(git commit --no-verify:*)"] not valid json');
+      const findings = runAllPermRules(file);
+      const noVerifyFindings = findings.filter((f) => f.evidence === "--no-verify");
+      expect(noVerifyFindings).toHaveLength(1);
+      expect(noVerifyFindings[0].severity).toBe("critical");
+    });
+
     it("skips non-settings files for permission rules", () => {
       const file: ConfigFile = { path: "agent.md", type: "agent-md", content: "Bash(*)" };
       const findings = runAllPermRules(file);


### PR DESCRIPTION
Fixes #102.

## Problem

The `permissions-dangerous-skip` rule string-matches dangerous flags anywhere in a file. A `permissions.deny` rule whose entire purpose is to **block** a flag — e.g. `"Bash(git commit --no-verify:*)"` — is reported as a CRITICAL "Git hook verification bypass" and zeroes the Permissions category. Since "add a deny list" is the scanner's own remediation for the `permissions-no-deny-list` HIGH finding, following the tool's advice makes the reported posture worse (full feedback loop documented in #102).

## Fix

The rule already downgrades prohibitive context to INFO for negated markdown mentions ("NEVER use --no-verify" → "Prohibition of --no-verify (good practice)"). This PR extends that same treatment to matches whose character span falls inside a `permissions.deny` or `permissions.ask` rule value in settings JSON:

- New helper `prohibitivePermissionRuleSpans()` parses the settings JSON and returns the content spans of every deny/ask rule value. Non-settings files and unparseable JSON return no spans, so matches **fail closed** (stay CRITICAL).
- Matches inside those spans become INFO findings (`Deny/ask rule blocking --no-verify (good practice)`), consistent with the existing negation downgrade.
- Matches inside `permissions.allow` values are unaffected and stay CRITICAL — allowing a dangerous flag is a real finding.

The span check runs before the 100-char negation-context check, so deny entries are classified by their structural position rather than by whatever text happens to precede them.

## Tests

Six new cases in `tests/rules/permissions.test.ts` (95 total, all passing):

- deny rule with `--no-verify` → INFO ×2, not CRITICAL
- ask rule with `--no-verify` → INFO
- **allow** rule with `--no-verify` → stays CRITICAL
- deny rule with `dangerously-skip-permissions` → INFO
- deny-rule-shaped text in invalid JSON → stays CRITICAL (fail-closed)

`npm run typecheck` and `npm run lint` clean.

## Real-world verification

Against the repo that prompted #102 (a `.claude/settings.json` with deny rules blocking `--no-verify`), built from this branch:

- **Before:** 2 CRITICAL findings at `settings.json:8,9`, Permissions 0/100
- **After:** both downgraded to INFO; no CRITICAL findings from the deny list

Related: this is the same context-insensitivity family as #100 (string literals in hook scripts) — this PR deliberately fixes only the structurally-decidable JSON case and doesn't touch the markdown/script heuristics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission rule scanning now intelligently detects when dangerous patterns are already blocked by deny or ask configurations, downgrading severity from critical to informational.

* **Tests**
  * Added comprehensive test coverage for permission rule pattern handling across different configuration types and severity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false-positive where `permissions-dangerous-skip` would flag dangerous flags (e.g. `--no-verify`) found inside `permissions.deny` or `permissions.ask` entries as CRITICAL, even though those entries exist to *block* the flag. A new helper `prohibitivePermissionRuleSpans()` parses the settings JSON, collects the character spans of every deny/ask value, and downgrades any match that falls within those spans to INFO — consistent with the existing negation-word heuristic for markdown prose.

- **New helper `prohibitivePermissionRuleSpans()`** locates deny/ask entry spans in the raw JSON by exact-string `indexOf`; non-settings files and unparseable JSON return no spans so the rule fails closed.
- **Span check runs before the negation-context check**, giving structural position precedence over nearby text heuristics; allow-list matches are explicitly not included in spans and remain CRITICAL.
- **Six new test cases** cover deny, ask, allow, `dangerously-skip-permissions`, and invalid-JSON (fail-closed) scenarios, bringing the suite to 95 tests.

<h3>Confidence Score: 3/5</h3>

The core logic change is sound for the common case, but the span-building strategy can silently suppress a CRITICAL finding when the same entry string appears in both deny and allow — the exact scenario the PR claims is safe.

The prohibitivePermissionRuleSpans helper searches the raw JSON text with indexOf for each deny/ask entry string without constraining the search to the deny/ask array regions. If an identical string also exists in the allow array, the second indexOf hit lands on the allow value and adds it to the prohibitive spans. A dangerous flag inside that allow entry then gets silently downgraded from CRITICAL to INFO — a false negative in a security scanner where the PR's stated invariant breaks. The test suite validates the allow case in isolation but not in the presence of a matching deny entry, leaving this gap undetected.

The span-building loop in src/rules/permissions.ts (lines 180–186) needs a position-aware approach — for example tracking the JSON-parsed offset of each entry rather than using raw content search — to guarantee that allow-list occurrences can never be captured in the prohibitive spans.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/rules/permissions.ts | Adds prohibitivePermissionRuleSpans() to downgrade dangerous-flag findings inside deny/ask entries to INFO; the span-building loop uses verbatim indexOf which can misclassify allow-list occurrences as prohibitive when the same entry string also appears in deny/ask. |
| tests/rules/permissions.test.ts | Adds six targeted test cases covering deny, ask, allow, dangerously-skip-permissions, and invalid-JSON scenarios; missing a case where the same entry string appears in both deny and allow simultaneously. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dangerous flag match found\nin file content] --> B{File is\nsettings-json?}
    B -- No --> E[Check negation\ncontext 100 chars]
    B -- Yes --> C{JSON\nparseable?}
    C -- No --> E
    C -- Yes --> D[Build prohibitiveSpans\nfrom deny + ask entries\nvia indexOf]
    D --> F{match.index\ninside a span?}
    F -- Yes --> G[INFO finding\nDeny/ask rule blocking flag\ngood practice]
    F -- No --> E
    E --> H{Negation word\nin context?}
    H -- Yes --> I[INFO finding\nProhibition — good practice]
    H -- No --> J[CRITICAL finding\nDangerous flag]

    style G fill:#d4edda
    style I fill:#d4edda
    style J fill:#f8d7da
```

<sub>Reviews (1): Last reviewed commit: ["fix: treat dangerous flags inside permis..."](https://github.com/affaan-m/agentshield/commit/45656231e0ad342b80b0563e6daca4858318ec7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37221837)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->