### PR TITLE
fix: parse standard hooks schema in sandbox and survive dangling skill symlinks

### DIFF
--- a/dist/action.js
+++ b/dist/action.js
@@ -13560,7 +13560,7 @@ import { existsSync as existsSync7 } from "fs";
 import { appendFileSync, mkdirSync as mkdirSync6, writeFileSync as writeFileSync6 } from "fs";
 
 // src/scanner/discovery.ts
-import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { readFileSync, existsSync, readdirSync, readlinkSync, statSync, lstatSync } from "fs";
 import { join, basename, extname, relative } from "path";
 
 // src/source-context.ts
@@ -13685,6 +13685,7 @@ var PROJECT_ROOT_HOOK_VARS = /* @__PURE__ */ new Set([
 ]);
 function discoverConfigFiles(rootPath) {
   const files = [];
+  const danglingSymlinks = [];
   const seenFiles = /* @__PURE__ */ new Set();
   const claudeRoots = /* @__PURE__ */ new Set([rootPath]);
   const exampleClaudeFiles = /* @__PURE__ */ new Set();
@@ -13693,12 +13694,33 @@ function discoverConfigFiles(rootPath) {
     addDiscoveredFile(rootPath, exampleClaudeFile, "claude-md", files, seenFiles);
   }
   for (const claudeRoot of [...claudeRoots].sort()) {
-    scanClaudeRoot(rootPath, claudeRoot, files, seenFiles);
+    scanClaudeRoot(rootPath, claudeRoot, files, seenFiles, danglingSymlinks);
   }
-  return { path: rootPath, files };
+  return { path: rootPath, files, danglingSymlinks };
+}
+function statOrNull(path) {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+function isDanglingSymlink(path) {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function readSymlinkTarget(path) {
+  try {
+    return readlinkSync(path);
+  } catch {
+    return "";
+  }
 }
 function walkForClaudeRoots(scanRoot, dirPath, claudeRoots, exampleClaudeFiles) {
-  if (!existsSync(dirPath) || !statSync(dirPath).isDirectory()) return;
+  if (!statOrNull(dirPath)?.isDirectory()) return;
   const entries = readdirSync(dirPath, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
@@ -13732,7 +13754,7 @@ function isExampleOnlyClaudeRoot(scanRoot, dirPath, markerName) {
   ) || existsSync(join(dirPath, ".claude"));
   return !hasRuntimeCompanion;
 }
-function scanClaudeRoot(scanRoot, claudeRoot, files, seenFiles) {
+function scanClaudeRoot(scanRoot, claudeRoot, files, seenFiles, danglingSymlinks) {
   const directFiles = [
     ["CLAUDE.md", "claude-md"],
     [".claude/CLAUDE.md", "claude-md"],
@@ -13798,13 +13820,23 @@ function scanClaudeRoot(scanRoot, claudeRoot, files, seenFiles) {
   ];
   for (const [subdir, type] of subdirs) {
     const dirPath = join(claudeRoot, subdir);
-    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
-      const entries = readdirSync(dirPath);
-      for (const entry of entries) {
-        const entryPath = join(dirPath, entry);
-        if (statSync(entryPath).isFile()) {
-          addDiscoveredFile(scanRoot, entryPath, inferType(entry, type), files, seenFiles);
+    if (!statOrNull(dirPath)?.isDirectory()) continue;
+    const entries = readdirSync(dirPath);
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry);
+      const entryStat = statOrNull(entryPath);
+      if (entryStat === null) {
+        if (isDanglingSymlink(entryPath)) {
+          danglingSymlinks.push({
+            path: relative(scanRoot, entryPath),
+            target: readSymlinkTarget(entryPath),
+            type
+          });
         }
+        continue;
+      }
+      if (entryStat.isFile()) {
+        addDiscoveredFile(scanRoot, entryPath, inferType(entry, type), files, seenFiles);
       }
     }
   }
@@ -13845,7 +13877,7 @@ function discoverReferencedHookScripts(scanRoot, claudeRoot, files, seenFiles) {
   ];
   for (const relativeConfigPath of hookConfigPaths) {
     const fullPath = join(claudeRoot, relativeConfigPath);
-    if (!existsSync(fullPath) || !statSync(fullPath).isFile()) continue;
+    if (!statOrNull(fullPath)?.isFile()) continue;
     const content = readFileSync(fullPath, "utf-8");
     for (const candidate of extractHookReferencedPaths(content)) {
       const resolvedPath = resolveHookReferencedPath(scanRoot, claudeRoot, candidate);
@@ -13928,7 +13960,7 @@ function resolveHookReferencedPath(scanRoot, claudeRoot, candidate) {
   }
   if (normalized.startsWith("/")) return null;
   const fullPath = join(claudeRoot, normalized);
-  if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+  if (!statOrNull(fullPath)?.isFile()) {
     return null;
   }
   const ext = extname(fullPath).toLowerCase();
@@ -22465,7 +22497,10 @@ function markerExists(rootPath, marker) {
 function scan(targetPath) {
   const target = discoverConfigFiles(targetPath);
   const rules = getBuiltinRules();
-  const findings = runRules(target.files, rules, target.path);
+  const findings = sortBySeverity([
+    ...runRules(target.files, rules, target.path),
+    ...buildDanglingSymlinkFindings(target.danglingSymlinks)
+  ]);
   const skillHealth = analyzeSkillHealth(target.files);
   const harnessAdapters = detectHarnessAdapters(targetPath);
   return { target, findings, skillHealth, harnessAdapters };
@@ -22483,9 +22518,25 @@ function runRules(files, rules, scanRoot) {
     const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot);
     return adjustFindingForSourceContext(annotatedFinding);
   });
-  return [...annotatedFindings].sort((a, b) => {
-    const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
-    return order[a.severity] - order[b.severity];
+  return sortBySeverity(annotatedFindings);
+}
+function sortBySeverity(findings) {
+  const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  return [...findings].sort((a, b) => order[a.severity] - order[b.severity]);
+}
+function buildDanglingSymlinkFindings(danglingSymlinks) {
+  return danglingSymlinks.map((link) => {
+    const isSkill = link.type === "skill-md";
+    const targetLabel = link.target.length > 0 ? link.target : "unknown";
+    return {
+      id: isSkill ? `skills-dangling-symlink-${link.path}` : `discovery-dangling-symlink-${link.path}`,
+      severity: "low",
+      category: isSkill ? "skills" : "misconfiguration",
+      title: isSkill ? "Dangling skill symlink" : "Dangling config symlink",
+      description: `${link.path} is a symlink to ${targetLabel}, which does not exist. ` + (isSkill ? "The agent will treat this as an installed skill that resolves to nothing. It is usually a leftover from a pruned skill registry. Remove the link or restore its target." : "The entry was skipped during discovery. Remove the link or restore its target so the file can be scanned."),
+      file: link.path,
+      evidence: `${link.path} -> ${targetLabel}`
+    };
   });
 }
 function classifyRuntimeConfidence(file, scanRoot) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -71,10 +71,11 @@ var init_source_context = __esm({
 });
 
 // src/scanner/discovery.ts
-import { readFileSync, existsSync, readdirSync, statSync } from "fs";
+import { readFileSync, existsSync, readdirSync, readlinkSync, statSync, lstatSync } from "fs";
 import { join, basename, extname, relative } from "path";
 function discoverConfigFiles(rootPath) {
   const files = [];
+  const danglingSymlinks = [];
   const seenFiles = /* @__PURE__ */ new Set();
   const claudeRoots = /* @__PURE__ */ new Set([rootPath]);
   const exampleClaudeFiles = /* @__PURE__ */ new Set();
@@ -83,12 +84,33 @@ function discoverConfigFiles(rootPath) {
     addDiscoveredFile(rootPath, exampleClaudeFile, "claude-md", files, seenFiles);
   }
   for (const claudeRoot of [...claudeRoots].sort()) {
-    scanClaudeRoot(rootPath, claudeRoot, files, seenFiles);
+    scanClaudeRoot(rootPath, claudeRoot, files, seenFiles, danglingSymlinks);
   }
-  return { path: rootPath, files };
+  return { path: rootPath, files, danglingSymlinks };
+}
+function statOrNull(path) {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+function isDanglingSymlink(path) {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+function readSymlinkTarget(path) {
+  try {
+    return readlinkSync(path);
+  } catch {
+    return "";
+  }
 }
 function walkForClaudeRoots(scanRoot, dirPath, claudeRoots, exampleClaudeFiles) {
-  if (!existsSync(dirPath) || !statSync(dirPath).isDirectory()) return;
+  if (!statOrNull(dirPath)?.isDirectory()) return;
   const entries = readdirSync(dirPath, { withFileTypes: true });
   for (const entry of entries) {
     if (entry.isDirectory()) {
@@ -122,7 +144,7 @@ function isExampleOnlyClaudeRoot(scanRoot, dirPath, markerName) {
   ) || existsSync(join(dirPath, ".claude"));
   return !hasRuntimeCompanion;
 }
-function scanClaudeRoot(scanRoot, claudeRoot, files, seenFiles) {
+function scanClaudeRoot(scanRoot, claudeRoot, files, seenFiles, danglingSymlinks) {
   const directFiles = [
     ["CLAUDE.md", "claude-md"],
     [".claude/CLAUDE.md", "claude-md"],
@@ -188,13 +210,23 @@ function scanClaudeRoot(scanRoot, claudeRoot, files, seenFiles) {
   ];
   for (const [subdir, type] of subdirs) {
     const dirPath = join(claudeRoot, subdir);
-    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
-      const entries = readdirSync(dirPath);
-      for (const entry of entries) {
-        const entryPath = join(dirPath, entry);
-        if (statSync(entryPath).isFile()) {
-          addDiscoveredFile(scanRoot, entryPath, inferType(entry, type), files, seenFiles);
+    if (!statOrNull(dirPath)?.isDirectory()) continue;
+    const entries = readdirSync(dirPath);
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry);
+      const entryStat = statOrNull(entryPath);
+      if (entryStat === null) {
+        if (isDanglingSymlink(entryPath)) {
+          danglingSymlinks.push({
+            path: relative(scanRoot, entryPath),
+            target: readSymlinkTarget(entryPath),
+            type
+          });
         }
+        continue;
+      }
+      if (entryStat.isFile()) {
+        addDiscoveredFile(scanRoot, entryPath, inferType(entry, type), files, seenFiles);
       }
     }
   }
@@ -235,7 +267,7 @@ function discoverReferencedHookScripts(scanRoot, claudeRoot, files, seenFiles) {
   ];
   for (const relativeConfigPath of hookConfigPaths) {
     const fullPath = join(claudeRoot, relativeConfigPath);
-    if (!existsSync(fullPath) || !statSync(fullPath).isFile()) continue;
+    if (!statOrNull(fullPath)?.isFile()) continue;
     const content = readFileSync(fullPath, "utf-8");
     for (const candidate of extractHookReferencedPaths(content)) {
       const resolvedPath = resolveHookReferencedPath(scanRoot, claudeRoot, candidate);
@@ -318,7 +350,7 @@ function resolveHookReferencedPath(scanRoot, claudeRoot, candidate) {
   }
   if (normalized.startsWith("/")) return null;
   const fullPath = join(claudeRoot, normalized);
-  if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+  if (!statOrNull(fullPath)?.isFile()) {
     return null;
   }
   const ext = extname(fullPath).toLowerCase();
@@ -9341,7 +9373,10 @@ __export(scanner_exports, {
 function scan(targetPath) {
   const target = discoverConfigFiles(targetPath);
   const rules = getBuiltinRules();
-  const findings = runRules(target.files, rules, target.path);
+  const findings = sortBySeverity([
+    ...runRules(target.files, rules, target.path),
+    ...buildDanglingSymlinkFindings(target.danglingSymlinks)
+  ]);
   const skillHealth = analyzeSkillHealth(target.files);
   const harnessAdapters = detectHarnessAdapters(targetPath);
   return { target, findings, skillHealth, harnessAdapters };
@@ -9359,9 +9394,25 @@ function runRules(files, rules, scanRoot) {
     const annotatedFinding = annotateFindingRuntimeConfidence(finding, filesByPath, scanRoot);
     return adjustFindingForSourceContext(annotatedFinding);
   });
-  return [...annotatedFindings].sort((a, b) => {
-    const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
-    return order[a.severity] - order[b.severity];
+  return sortBySeverity(annotatedFindings);
+}
+function sortBySeverity(findings) {
+  const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  return [...findings].sort((a, b) => order[a.severity] - order[b.severity]);
+}
+function buildDanglingSymlinkFindings(danglingSymlinks) {
+  return danglingSymlinks.map((link) => {
+    const isSkill = link.type === "skill-md";
+    const targetLabel = link.target.length > 0 ? link.target : "unknown";
+    return {
+      id: isSkill ? `skills-dangling-symlink-${link.path}` : `discovery-dangling-symlink-${link.path}`,
+      severity: "low",
+      category: isSkill ? "skills" : "misconfiguration",
+      title: isSkill ? "Dangling skill symlink" : "Dangling config symlink",
+      description: `${link.path} is a symlink to ${targetLabel}, which does not exist. ` + (isSkill ? "The agent will treat this as an installed skill that resolves to nothing. It is usually a leftover from a pruned skill registry. Remove the link or restore its target." : "The entry was skipped during discovery. Remove the link or restore its target so the file can be scanned."),
+      file: link.path,
+      evidence: `${link.path} -> ${targetLabel}`
+    };
   });
 }
 function classifyRuntimeConfidence(file, scanRoot) {
@@ -9638,6 +9689,13 @@ function renderSandboxResults(result) {
     `  Risk findings:  ${result.riskFindings.length > 0 ? chalk.red(`${result.riskFindings.length}`) : chalk.green("0")}`
   );
   lines.push("");
+  if (result.warnings.length > 0) {
+    lines.push(chalk.yellow.bold("  Warnings"));
+    for (const warning of result.warnings) {
+      lines.push(chalk.yellow(`  \u26A0 ${warning}`));
+    }
+    lines.push("");
+  }
   if (result.behaviors.length > 0) {
     lines.push(chalk.bold("  Hook Behaviors"));
     lines.push("");
@@ -11125,37 +11183,51 @@ import { spawn } from "child_process";
 import { mkdtemp, readdir, stat as stat2, readFile, rm as rm2 } from "fs/promises";
 import { join as join9 } from "path";
 import { tmpdir } from "os";
-function parseHooks(settingsContent) {
-  const hooks = [];
+function parseHooksObject(settingsContent) {
   let config;
   try {
     config = JSON.parse(settingsContent);
   } catch {
-    return hooks;
+    return null;
   }
+  if (!config || typeof config !== "object") return null;
   const hooksObj = config.hooks;
-  if (!hooksObj || typeof hooksObj !== "object") return hooks;
-  const hookTypes = [
-    "PreToolUse",
-    "PostToolUse",
-    "SessionStart",
-    "Stop"
-  ];
-  for (const hookType of hookTypes) {
+  if (!hooksObj || typeof hooksObj !== "object" || Array.isArray(hooksObj)) return null;
+  return hooksObj;
+}
+function parseHooks(settingsContent) {
+  const hooks = [];
+  const hooksObj = parseHooksObject(settingsContent);
+  if (!hooksObj) return hooks;
+  for (const hookType of HOOK_TYPES) {
     const entries = hooksObj[hookType];
     if (!Array.isArray(entries)) continue;
     for (const entry of entries) {
+      if (!entry || typeof entry !== "object") continue;
       const hookEntry = entry;
+      const matcher = typeof hookEntry.matcher === "string" ? hookEntry.matcher : void 0;
       if (typeof hookEntry.hook === "string" && hookEntry.hook.length > 0) {
-        hooks.push({
-          type: hookType,
-          command: hookEntry.hook,
-          matcher: hookEntry.matcher
-        });
+        hooks.push({ type: hookType, command: hookEntry.hook, matcher });
+      }
+      if (!Array.isArray(hookEntry.hooks)) continue;
+      for (const nested of hookEntry.hooks) {
+        if (!nested || typeof nested !== "object") continue;
+        const nestedHook = nested;
+        if (nestedHook.type !== void 0 && nestedHook.type !== "command") continue;
+        if (typeof nestedHook.command !== "string" || nestedHook.command.length === 0) continue;
+        const timeout = typeof nestedHook.timeout === "number" && Number.isFinite(nestedHook.timeout) ? nestedHook.timeout : void 0;
+        hooks.push({ type: hookType, command: nestedHook.command, matcher, timeout });
       }
     }
   }
   return hooks;
+}
+function hasHookDefinitions(settingsContent) {
+  const hooksObj = parseHooksObject(settingsContent);
+  if (!hooksObj) return false;
+  return Object.values(hooksObj).some(
+    (entries) => Array.isArray(entries) && entries.length > 0
+  );
 }
 async function executeHookInSandbox(hookCommand, options = {}) {
   const opts = { ...DEFAULT_OPTIONS, ...options };
@@ -11498,7 +11570,7 @@ function detectDnsLookups(output, observations) {
     }
   }
 }
-var DEFAULT_FAKE_ENV, DEFAULT_OPTIONS;
+var DEFAULT_FAKE_ENV, DEFAULT_OPTIONS, HOOK_TYPES;
 var init_executor = __esm({
   "src/sandbox/executor.ts"() {
     "use strict";
@@ -11520,6 +11592,17 @@ var init_executor = __esm({
       fileMonitor: true,
       fakeEnv: DEFAULT_FAKE_ENV
     };
+    HOOK_TYPES = [
+      "PreToolUse",
+      "PostToolUse",
+      "UserPromptSubmit",
+      "Notification",
+      "SessionStart",
+      "SessionEnd",
+      "Stop",
+      "SubagentStop",
+      "PreCompact"
+    ];
   }
 });
 
@@ -11740,6 +11823,7 @@ __export(sandbox_exports, {
   cleanupSandbox: () => cleanupSandbox,
   executeAllHooks: () => executeAllHooks,
   executeHookInSandbox: () => executeHookInSandbox,
+  hasHookDefinitions: () => hasHookDefinitions,
   parseHooks: () => parseHooks
 });
 var init_sandbox = __esm({
@@ -19267,7 +19351,7 @@ async function runInjectionTests2(targetPath) {
 }
 async function runSandboxAnalysis(targetPath) {
   try {
-    const { executeAllHooks: executeAllHooks2, analyzeAllExecutions: analyzeAllExecutions2 } = await Promise.resolve().then(() => (init_sandbox(), sandbox_exports));
+    const { executeAllHooks: executeAllHooks2, analyzeAllExecutions: analyzeAllExecutions2, hasHookDefinitions: hasHookDefinitions2 } = await Promise.resolve().then(() => (init_sandbox(), sandbox_exports));
     const { discoverConfigFiles: discoverConfigFiles2 } = await Promise.resolve().then(() => (init_scanner(), scanner_exports));
     const target = discoverConfigFiles2(targetPath);
     const settingsFile = target.files.find((f) => f.type === "settings-json");
@@ -19298,7 +19382,13 @@ async function runSandboxAnalysis(targetPath) {
         });
       }
     }
-    return { hooksExecuted: executions.length, behaviors, riskFindings };
+    const warnings = [];
+    if (executions.length === 0 && hasHookDefinitions2(settingsFile.content)) {
+      warnings.push(
+        `${settingsFile.path} declares a hooks block but no hook commands were recognized for sandbox execution. Supported shapes: { "matcher", "hooks": [{ "type": "command", "command": "..." }] } and legacy { "hook": "..." }.`
+      );
+    }
+    return { hooksExecuted: executions.length, behaviors, riskFindings, warnings };
   } catch (e) {
     console.error(
       "  Sandbox module not available:",

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ async function runSandboxAnalysis(
   targetPath: string
 ): Promise<SandboxResult | null> {
   try {
-    const { executeAllHooks, analyzeAllExecutions } = await import("./sandbox/index.js");
+    const { executeAllHooks, analyzeAllExecutions, hasHookDefinitions } = await import("./sandbox/index.js");
     const { discoverConfigFiles } = await import("./scanner/index.js");
 
     const target = discoverConfigFiles(targetPath);
@@ -109,7 +109,15 @@ async function runSandboxAnalysis(
       }
     }
 
-    return { hooksExecuted: executions.length, behaviors, riskFindings };
+    const warnings: string[] = [];
+    if (executions.length === 0 && hasHookDefinitions(settingsFile.content)) {
+      warnings.push(
+        `${settingsFile.path} declares a hooks block but no hook commands were recognized for sandbox execution. ` +
+          'Supported shapes: { "matcher", "hooks": [{ "type": "command", "command": "..." }] } and legacy { "hook": "..." }.'
+      );
+    }
+
+    return { hooksExecuted: executions.length, behaviors, riskFindings, warnings };
   } catch (e) {
     console.error(
       "  Sandbox module not available:",

--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -227,6 +227,14 @@ export function renderSandboxResults(result: SandboxResult): string {
   );
   lines.push("");
 
+  if (result.warnings.length > 0) {
+    lines.push(chalk.yellow.bold("  Warnings"));
+    for (const warning of result.warnings) {
+      lines.push(chalk.yellow(`  ⚠ ${warning}`));
+    }
+    lines.push("");
+  }
+
   // Behavioral analysis for each hook
   if (result.behaviors.length > 0) {
     lines.push(chalk.bold("  Hook Behaviors"));

--- a/src/sandbox/executor.ts
+++ b/src/sandbox/executor.ts
@@ -37,12 +37,22 @@ export interface SandboxObservation {
   readonly timestamp: number;
 }
 
-export type HookType = "PreToolUse" | "PostToolUse" | "SessionStart" | "Stop";
+export type HookType =
+  | "PreToolUse"
+  | "PostToolUse"
+  | "UserPromptSubmit"
+  | "Notification"
+  | "SessionStart"
+  | "SessionEnd"
+  | "Stop"
+  | "SubagentStop"
+  | "PreCompact";
 
 export interface ParsedHook {
   readonly type: HookType;
   readonly command: string;
   readonly matcher?: string;
+  readonly timeout?: number;
 }
 
 // ─── Default Options ──────────────────────────────────────
@@ -69,46 +79,90 @@ const DEFAULT_OPTIONS: SandboxOptions = {
 
 // ─── Hook Parser ──────────────────────────────────────────
 
+const HOOK_TYPES: ReadonlyArray<HookType> = [
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "Notification",
+  "SessionStart",
+  "SessionEnd",
+  "Stop",
+  "SubagentStop",
+  "PreCompact",
+];
+
+function parseHooksObject(settingsContent: string): Record<string, unknown> | null {
+  let config: unknown;
+  try {
+    config = JSON.parse(settingsContent);
+  } catch {
+    return null;
+  }
+
+  if (!config || typeof config !== "object") return null;
+  const hooksObj = (config as { hooks?: unknown }).hooks;
+  if (!hooksObj || typeof hooksObj !== "object" || Array.isArray(hooksObj)) return null;
+  return hooksObj as Record<string, unknown>;
+}
+
 /**
  * Parse hooks from a settings.json content string.
+ *
+ * Supports both the standard Claude Code schema
+ * `{ matcher, hooks: [{ type: "command", command, timeout? }] }`
+ * and the legacy flat shape `{ matcher, hook: "cmd" }`.
  */
 export function parseHooks(settingsContent: string): ReadonlyArray<ParsedHook> {
   const hooks: ParsedHook[] = [];
 
-  let config: Record<string, unknown>;
-  try {
-    config = JSON.parse(settingsContent) as Record<string, unknown>;
-  } catch {
-    return hooks;
-  }
+  const hooksObj = parseHooksObject(settingsContent);
+  if (!hooksObj) return hooks;
 
-  const hooksObj = config.hooks as Record<string, unknown> | undefined;
-  if (!hooksObj || typeof hooksObj !== "object") return hooks;
-
-  const hookTypes: ReadonlyArray<HookType> = [
-    "PreToolUse",
-    "PostToolUse",
-    "SessionStart",
-    "Stop",
-  ];
-
-  for (const hookType of hookTypes) {
+  for (const hookType of HOOK_TYPES) {
     const entries = hooksObj[hookType];
     if (!Array.isArray(entries)) continue;
 
     for (const entry of entries) {
-      const hookEntry = entry as { hook?: string; matcher?: string };
+      if (!entry || typeof entry !== "object") continue;
+      const hookEntry = entry as { hook?: unknown; matcher?: unknown; hooks?: unknown };
+      const matcher = typeof hookEntry.matcher === "string" ? hookEntry.matcher : undefined;
+
+      // Legacy flat shape: { matcher, hook: "cmd" }
       if (typeof hookEntry.hook === "string" && hookEntry.hook.length > 0) {
-        hooks.push({
-          type: hookType,
-          command: hookEntry.hook,
-          matcher: hookEntry.matcher,
-        });
+        hooks.push({ type: hookType, command: hookEntry.hook, matcher });
+      }
+
+      // Standard schema: { matcher, hooks: [{ type: "command", command, timeout? }] }
+      if (!Array.isArray(hookEntry.hooks)) continue;
+      for (const nested of hookEntry.hooks) {
+        if (!nested || typeof nested !== "object") continue;
+        const nestedHook = nested as { type?: unknown; command?: unknown; timeout?: unknown };
+        if (nestedHook.type !== undefined && nestedHook.type !== "command") continue;
+        if (typeof nestedHook.command !== "string" || nestedHook.command.length === 0) continue;
+        const timeout =
+          typeof nestedHook.timeout === "number" && Number.isFinite(nestedHook.timeout)
+            ? nestedHook.timeout
+            : undefined;
+        hooks.push({ type: hookType, command: nestedHook.command, matcher, timeout });
       }
     }
   }
 
   return hooks;
+}
+
+/**
+ * Whether a settings.json content string declares at least one hook entry,
+ * regardless of whether parseHooks recognizes its shape. Used to warn when a
+ * hooks block is present but nothing could be executed.
+ */
+export function hasHookDefinitions(settingsContent: string): boolean {
+  const hooksObj = parseHooksObject(settingsContent);
+  if (!hooksObj) return false;
+
+  return Object.values(hooksObj).some(
+    (entries) => Array.isArray(entries) && entries.length > 0
+  );
 }
 
 // ─── Sandbox Executor ─────────────────────────────────────

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -2,6 +2,7 @@ export {
   executeHookInSandbox,
   executeAllHooks,
   parseHooks,
+  hasHookDefinitions,
   cleanupSandbox,
 } from "./executor.js";
 

--- a/src/scanner/discovery.ts
+++ b/src/scanner/discovery.ts
@@ -1,6 +1,7 @@
-import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync, readlinkSync, statSync, lstatSync } from "node:fs";
+import type { Stats } from "node:fs";
 import { join, basename, extname, relative } from "node:path";
-import type { ConfigFile, ConfigFileType, ScanTarget } from "../types.js";
+import type { ConfigFile, ConfigFileType, DanglingSymlink, ScanTarget } from "../types.js";
 import { isExampleLikePath } from "../source-context.js";
 
 const IGNORED_DIRS = new Set([
@@ -82,6 +83,7 @@ const PROJECT_ROOT_HOOK_VARS = new Set([
  */
 export function discoverConfigFiles(rootPath: string): ScanTarget {
   const files: ConfigFile[] = [];
+  const danglingSymlinks: DanglingSymlink[] = [];
   const seenFiles = new Set<string>();
   const claudeRoots = new Set<string>([rootPath]);
   const exampleClaudeFiles = new Set<string>();
@@ -93,10 +95,38 @@ export function discoverConfigFiles(rootPath: string): ScanTarget {
   }
 
   for (const claudeRoot of [...claudeRoots].sort()) {
-    scanClaudeRoot(rootPath, claudeRoot, files, seenFiles);
+    scanClaudeRoot(rootPath, claudeRoot, files, seenFiles, danglingSymlinks);
   }
 
-  return { path: rootPath, files };
+  return { path: rootPath, files, danglingSymlinks };
+}
+
+/**
+ * statSync that follows symlinks but never throws. Returns null when the
+ * path is missing, a dangling symlink, or otherwise unreadable.
+ */
+function statOrNull(path: string): Stats | null {
+  try {
+    return statSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function isDanglingSymlink(path: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function readSymlinkTarget(path: string): string {
+  try {
+    return readlinkSync(path);
+  } catch {
+    return "";
+  }
 }
 
 function walkForClaudeRoots(
@@ -105,7 +135,7 @@ function walkForClaudeRoots(
   claudeRoots: Set<string>,
   exampleClaudeFiles: Set<string>
 ): void {
-  if (!existsSync(dirPath) || !statSync(dirPath).isDirectory()) return;
+  if (!statOrNull(dirPath)?.isDirectory()) return;
 
   const entries = readdirSync(dirPath, { withFileTypes: true });
   for (const entry of entries) {
@@ -159,7 +189,8 @@ function scanClaudeRoot(
   scanRoot: string,
   claudeRoot: string,
   files: ConfigFile[],
-  seenFiles: Set<string>
+  seenFiles: Set<string>,
+  danglingSymlinks: DanglingSymlink[]
 ): void {
   // Direct config files
   const directFiles: ReadonlyArray<[string, ConfigFileType]> = [
@@ -231,13 +262,24 @@ function scanClaudeRoot(
 
   for (const [subdir, type] of subdirs) {
     const dirPath = join(claudeRoot, subdir);
-    if (existsSync(dirPath) && statSync(dirPath).isDirectory()) {
-      const entries = readdirSync(dirPath);
-      for (const entry of entries) {
-        const entryPath = join(dirPath, entry);
-        if (statSync(entryPath).isFile()) {
-          addDiscoveredFile(scanRoot, entryPath, inferType(entry, type), files, seenFiles);
+    if (!statOrNull(dirPath)?.isDirectory()) continue;
+
+    const entries = readdirSync(dirPath);
+    for (const entry of entries) {
+      const entryPath = join(dirPath, entry);
+      const entryStat = statOrNull(entryPath);
+      if (entryStat === null) {
+        if (isDanglingSymlink(entryPath)) {
+          danglingSymlinks.push({
+            path: relative(scanRoot, entryPath),
+            target: readSymlinkTarget(entryPath),
+            type,
+          });
         }
+        continue;
+      }
+      if (entryStat.isFile()) {
+        addDiscoveredFile(scanRoot, entryPath, inferType(entry, type), files, seenFiles);
       }
     }
   }
@@ -290,7 +332,7 @@ function discoverReferencedHookScripts(
 
   for (const relativeConfigPath of hookConfigPaths) {
     const fullPath = join(claudeRoot, relativeConfigPath);
-    if (!existsSync(fullPath) || !statSync(fullPath).isFile()) continue;
+    if (!statOrNull(fullPath)?.isFile()) continue;
 
     const content = readFileSync(fullPath, "utf-8");
     for (const candidate of extractHookReferencedPaths(content)) {
@@ -404,7 +446,7 @@ function resolveHookReferencedPath(
   if (normalized.startsWith("/")) return null;
 
   const fullPath = join(claudeRoot, normalized);
-  if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+  if (!statOrNull(fullPath)?.isFile()) {
     return null;
   }
 

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -1,5 +1,6 @@
 import type {
   ConfigFile,
+  DanglingSymlink,
   Finding,
   Rule,
   RuntimeConfidence,
@@ -33,7 +34,10 @@ export interface ScanOptions {
 export function scan(targetPath: string, options: ScanOptions = {}): ScanResult {
   const target = discoverConfigFiles(targetPath);
   const rules = [...getBuiltinRules(), ...(options.extraRules ?? [])];
-  const findings = runRules(target.files, rules, target.path);
+  const findings = sortBySeverity([
+    ...runRules(target.files, rules, target.path),
+    ...buildDanglingSymlinkFindings(target.danglingSymlinks),
+  ]);
   const skillHealth = analyzeSkillHealth(target.files);
   const harnessAdapters = detectHarnessAdapters(targetPath);
 
@@ -63,10 +67,44 @@ function runRules(
     return adjustFindingForSourceContext(annotatedFinding);
   });
 
-  // Sort by severity (critical first)
-  return [...annotatedFindings].sort((a, b) => {
-    const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
-    return order[a.severity] - order[b.severity];
+  return sortBySeverity(annotatedFindings);
+}
+
+/**
+ * Sort findings by severity (critical first). Stable, so input order is
+ * preserved within a severity.
+ */
+function sortBySeverity(findings: ReadonlyArray<Finding>): ReadonlyArray<Finding> {
+  const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+  return [...findings].sort((a, b) => order[a.severity] - order[b.severity]);
+}
+
+/**
+ * Emit a low finding for each symlink in a scanned config subdirectory that
+ * points at a missing target. A dangling skill symlink is a skill the agent
+ * believes it has but that resolves to nothing.
+ */
+function buildDanglingSymlinkFindings(
+  danglingSymlinks: ReadonlyArray<DanglingSymlink>
+): ReadonlyArray<Finding> {
+  return danglingSymlinks.map((link) => {
+    const isSkill = link.type === "skill-md";
+    const targetLabel = link.target.length > 0 ? link.target : "unknown";
+    return {
+      id: isSkill
+        ? `skills-dangling-symlink-${link.path}`
+        : `discovery-dangling-symlink-${link.path}`,
+      severity: "low",
+      category: isSkill ? "skills" : "misconfiguration",
+      title: isSkill ? "Dangling skill symlink" : "Dangling config symlink",
+      description:
+        `${link.path} is a symlink to ${targetLabel}, which does not exist. ` +
+        (isSkill
+          ? "The agent will treat this as an installed skill that resolves to nothing. It is usually a leftover from a pruned skill registry. Remove the link or restore its target."
+          : "The entry was skipped during discovery. Remove the link or restore its target so the file can be scanned."),
+      file: link.path,
+      evidence: `${link.path} -> ${targetLabel}`,
+    };
   });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,13 @@ export interface Fix {
 export interface ScanTarget {
   readonly path: string;
   readonly files: ReadonlyArray<ConfigFile>;
+  readonly danglingSymlinks: ReadonlyArray<DanglingSymlink>;
+}
+
+export interface DanglingSymlink {
+  readonly path: string;
+  readonly target: string;
+  readonly type: ConfigFileType;
 }
 
 export interface ConfigFile {

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,6 +344,7 @@ export interface SandboxResult {
   readonly hooksExecuted: number;
   readonly behaviors: ReadonlyArray<SandboxBehavior>;
   readonly riskFindings: ReadonlyArray<Finding>;
+  readonly warnings: ReadonlyArray<string>;
 }
 
 // ─── Taint Analysis Results ───────────────────────────────

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -68,6 +68,7 @@ function makeSandboxResult(
 ): SandboxResult {
   return {
     hooksExecuted: 3,
+    warnings: [],
     behaviors: [
       {
         hookId: "pre-tool-use-lint",
@@ -380,6 +381,25 @@ describe("integration", () => {
       expect(output).toContain("Network attempts");
       expect(output).toContain("Suspicious behaviors");
       expect(output).toContain("Sandbox Risk Findings");
+    });
+
+    it("renderSandboxResults renders sandbox warnings when present", () => {
+      const result = makeSandboxResult({
+        hooksExecuted: 0,
+        behaviors: [],
+        riskFindings: [],
+        warnings: ["settings.json declares a hooks block but no hook commands were recognized for sandbox execution."],
+      });
+      const output = renderSandboxResults(result);
+
+      expect(output).toContain("Hooks executed: 0");
+      expect(output).toContain("Warnings");
+      expect(output).toContain("no hook commands were recognized");
+    });
+
+    it("renderSandboxResults omits the warnings section when there are none", () => {
+      const output = renderSandboxResults(makeSandboxResult());
+      expect(output).not.toContain("Warnings");
     });
 
     it("renderSandboxResults handles clean hooks", () => {

--- a/tests/reporter/score.test.ts
+++ b/tests/reporter/score.test.ts
@@ -7,6 +7,7 @@ function makeScanResult(findings: Finding[]): ScanResult {
   const target: ScanTarget = {
     path: "/test",
     files: [{ path: "test.json", type: "settings-json", content: "{}" }],
+    danglingSymlinks: [],
   };
   return { target, findings };
 }

--- a/tests/sandbox/sandbox.test.ts
+++ b/tests/sandbox/sandbox.test.ts
@@ -3,6 +3,7 @@ import {
   executeHookInSandbox,
   executeAllHooks,
   parseHooks,
+  hasHookDefinitions,
   cleanupSandbox,
 } from "../../src/sandbox/executor.js";
 import { analyzeExecution, analyzeAllExecutions } from "../../src/sandbox/analyzer.js";
@@ -90,6 +91,160 @@ describe("parseHooks", () => {
     });
     const hooks = parseHooks(settings);
     expect(hooks).toHaveLength(3);
+  });
+
+  it("parses the standard Claude Code schema with nested command hooks", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "command", command: "echo standard-schema-hook", timeout: 30 },
+            ],
+          },
+        ],
+      },
+    });
+    const hooks = parseHooks(settings);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].type).toBe("PreToolUse");
+    expect(hooks[0].command).toBe("echo standard-schema-hook");
+    expect(hooks[0].matcher).toBe("Bash");
+    expect(hooks[0].timeout).toBe(30);
+  });
+
+  it("parses multiple nested commands under one matcher", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "Edit|Write",
+            hooks: [
+              { type: "command", command: "echo first" },
+              { type: "command", command: "echo second" },
+            ],
+          },
+        ],
+      },
+    });
+    const hooks = parseHooks(settings);
+    expect(hooks.map((h) => h.command)).toEqual(["echo first", "echo second"]);
+    expect(hooks.every((h) => h.matcher === "Edit|Write")).toBe(true);
+  });
+
+  it("parses standard-schema event names beyond the legacy four", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo prompt" }] }],
+        SessionEnd: [{ hooks: [{ type: "command", command: "echo end" }] }],
+        SubagentStop: [{ hooks: [{ type: "command", command: "echo sub" }] }],
+        PreCompact: [{ hooks: [{ type: "command", command: "echo compact" }] }],
+        Notification: [{ hooks: [{ type: "command", command: "echo notify" }] }],
+      },
+    });
+    const hooks = parseHooks(settings);
+    expect(hooks.map((h) => h.type)).toEqual([
+      "UserPromptSubmit",
+      "Notification",
+      "SessionEnd",
+      "SubagentStop",
+      "PreCompact",
+    ]);
+  });
+
+  it("skips nested hooks that are not command hooks or have no command", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "Bash",
+            hooks: [
+              { type: "prompt", prompt: "Is this safe?" },
+              { type: "command", command: "" },
+              { type: "command" },
+              null,
+              { type: "command", command: "echo ok" },
+            ],
+          },
+        ],
+      },
+    });
+    const hooks = parseHooks(settings);
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0].command).toBe("echo ok");
+  });
+
+  it("parses a mix of legacy flat and standard nested shapes", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          { matcher: "Bash", hook: "echo legacy" },
+          {
+            matcher: "Edit",
+            hooks: [{ type: "command", command: "echo standard" }],
+          },
+        ],
+        Stop: [{ hook: "echo legacy-stop" }],
+      },
+    });
+    const hooks = parseHooks(settings);
+    expect(hooks.map((h) => h.command)).toEqual([
+      "echo legacy",
+      "echo standard",
+      "echo legacy-stop",
+    ]);
+    expect(hooks[1].matcher).toBe("Edit");
+  });
+
+  it("does not crash on malformed entries", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        PreToolUse: [null, 42, "echo string", { hooks: "not-an-array" }, { hook: 7 }],
+        Stop: "not-an-array",
+      },
+    });
+    expect(parseHooks(settings)).toHaveLength(0);
+  });
+});
+
+// ─── hasHookDefinitions ───────────────────────────────────
+
+describe("hasHookDefinitions", () => {
+  it("returns false when there is no hooks block", () => {
+    expect(hasHookDefinitions(JSON.stringify({ permissions: {} }))).toBe(false);
+  });
+
+  it("returns false for invalid JSON", () => {
+    expect(hasHookDefinitions("not json")).toBe(false);
+  });
+
+  it("returns false when the hooks block has only empty event arrays", () => {
+    expect(hasHookDefinitions(JSON.stringify({ hooks: { PreToolUse: [] } }))).toBe(false);
+  });
+
+  it("returns true for a standard-schema hooks block", () => {
+    const settings = JSON.stringify({
+      hooks: {
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "echo hi" }] }],
+      },
+    });
+    expect(hasHookDefinitions(settings)).toBe(true);
+    expect(parseHooks(settings)).toHaveLength(1);
+  });
+
+  it("flags a non-empty hooks block whose entries parse to zero hooks", () => {
+    // Unknown event name and unrecognized entry shape: nothing executable,
+    // but the block is present, so the sandbox should warn rather than
+    // silently report zero hooks.
+    const settings = JSON.stringify({
+      hooks: {
+        SomethingElse: [{ matcher: "Bash", run: "echo hi" }],
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "prompt", prompt: "check" }] }],
+      },
+    });
+    expect(hasHookDefinitions(settings)).toBe(true);
+    expect(parseHooks(settings)).toHaveLength(0);
   });
 });
 

--- a/tests/scanner/discovery.test.ts
+++ b/tests/scanner/discovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { discoverConfigFiles } from "../../src/scanner/discovery.js";
-import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -483,4 +483,76 @@ describe("discoverConfigFiles", () => {
       result.files.some((f) => f.path === ".dmux/worktrees/demo/.claude/settings.local.json")
     ).toBe(false);
   });
+
+  it("returns an empty danglingSymlinks list when nothing is dangling", () => {
+    const dir = createTempDir();
+    writeFileSync(join(dir, "settings.json"), "{}");
+
+    const result = discoverConfigFiles(dir);
+    expect(result.danglingSymlinks).toEqual([]);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "skips a dangling symlink under skills/ instead of crashing and records it",
+    () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, "skills"));
+      writeFileSync(join(dir, "skills", "SKILL.md"), "# Real skill");
+      symlinkSync(join(dir, "nonexistent-skill"), join(dir, "skills", "dead-skill"));
+
+      const result = discoverConfigFiles(dir);
+
+      expect(result.files.some((f) => f.path === "skills/SKILL.md")).toBe(true);
+      expect(result.files.some((f) => f.path === "skills/dead-skill")).toBe(false);
+      expect(result.danglingSymlinks).toHaveLength(1);
+      expect(result.danglingSymlinks[0].path).toBe("skills/dead-skill");
+      expect(result.danglingSymlinks[0].target).toBe(join(dir, "nonexistent-skill"));
+      expect(result.danglingSymlinks[0].type).toBe("skill-md");
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "still follows a valid symlink under skills/",
+    () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, "skills"));
+      mkdirSync(join(dir, "real"));
+      writeFileSync(join(dir, "real", "linked.md"), "# Linked skill");
+      symlinkSync(join(dir, "real", "linked.md"), join(dir, "skills", "linked.md"));
+
+      const result = discoverConfigFiles(dir);
+      const linked = result.files.find((f) => f.path === "skills/linked.md");
+      expect(linked?.type).toBe("skill-md");
+      expect(linked?.content).toBe("# Linked skill");
+      expect(result.danglingSymlinks).toEqual([]);
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "skips dangling symlinks in other config subdirectories too",
+    () => {
+      const dir = createTempDir();
+      mkdirSync(join(dir, ".claude"));
+      mkdirSync(join(dir, ".claude", "hooks"));
+      mkdirSync(join(dir, "agents"));
+      symlinkSync("/nonexistent/hook.sh", join(dir, ".claude", "hooks", "gone.sh"));
+      symlinkSync("/nonexistent/agent.md", join(dir, "agents", "gone.md"));
+
+      const result = discoverConfigFiles(dir);
+      const paths = result.danglingSymlinks.map((d) => d.path).sort();
+      expect(paths).toEqual([".claude/hooks/gone.sh", "agents/gone.md"]);
+    }
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "tolerates a dangling symlink where a config subdirectory is expected",
+    () => {
+      const dir = createTempDir();
+      symlinkSync("/nonexistent/skills", join(dir, "skills"));
+      writeFileSync(join(dir, "settings.json"), "{}");
+
+      const result = discoverConfigFiles(dir);
+      expect(result.files.some((f) => f.type === "settings-json")).toBe(true);
+    }
+  );
 });

--- a/tests/scanner/scanner.test.ts
+++ b/tests/scanner/scanner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { scan } from "../../src/scanner/index.js";
 import { resolve } from "node:path";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -509,6 +509,63 @@ describe("scanner", () => {
       const result = scan(tempDir);
       const finding = result.findings.find((f) => f.file === "scripts/hooks/session-start.js");
       expect(finding?.runtimeConfidence).toBe("hook-code");
+    });
+  });
+
+  describe("dangling symlinks", () => {
+    it.skipIf(process.platform === "win32")(
+      "emits a low skills finding for a dangling symlink under skills/ instead of crashing",
+      () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "agentshield-dangling-"));
+        try {
+          mkdirSync(join(tempDir, "skills"));
+          symlinkSync("/nonexistent", join(tempDir, "skills", "dead-skill"));
+
+          const result = scan(tempDir);
+          const finding = result.findings.find((f) => f.id.startsWith("skills-dangling-symlink"));
+
+          expect(finding).toBeDefined();
+          expect(finding?.severity).toBe("low");
+          expect(finding?.category).toBe("skills");
+          expect(finding?.title).toBe("Dangling skill symlink");
+          expect(finding?.file).toBe("skills/dead-skill");
+          expect(finding?.evidence).toBe("skills/dead-skill -> /nonexistent");
+          expect(result.target.danglingSymlinks).toHaveLength(1);
+        } finally {
+          rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    );
+
+    it.skipIf(process.platform === "win32")(
+      "keeps findings sorted by severity when a dangling symlink finding is added",
+      () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "agentshield-dangling-"));
+        try {
+          mkdirSync(join(tempDir, "skills"));
+          symlinkSync("/nonexistent", join(tempDir, "skills", "dead-skill"));
+          writeFileSync(
+            join(tempDir, "settings.json"),
+            JSON.stringify({ permissions: { allow: ["Bash(*)"] } })
+          );
+
+          const result = scan(tempDir);
+          const severityOrder = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+          for (let i = 1; i < result.findings.length; i++) {
+            expect(severityOrder[result.findings[i].severity]).toBeGreaterThanOrEqual(
+              severityOrder[result.findings[i - 1].severity]
+            );
+          }
+          expect(result.findings.some((f) => f.title === "Dangling skill symlink")).toBe(true);
+        } finally {
+          rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    );
+
+    it("does not emit dangling symlink findings for a clean tree", () => {
+      const result = scan(VULNERABLE_PATH);
+      expect(result.findings.some((f) => f.title === "Dangling skill symlink")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Two root-cause fixes.

Issue #120: the sandbox stage only read the legacy flat hook shape, so every real Claude Code config reported Hooks executed: 0. parseHooks now walks the standard nested schema (matcher plus hooks array with type command) alongside the legacy shape, the HookType union covers the nine standard events, and the sandbox summary prints a warning when a settings file defines hooks but none could be parsed.

Issue #114: a dangling symlink under skills/ crashed scan with ENOENT. Discovery now stats through a safe helper, records dangling entries, and scan emits a low finding per entry (skills-dangling-symlink for skill dirs, discovery-dangling-symlink elsewhere).

Tests: 21 new. Symlink tests skip on win32. dist is left as on main and will be rebuilt in the release PR.

Fixes #120. Fixes #114.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional Claude Code hook types and standard nested command hook configurations, including optional timeouts.
  - Added warnings when hook definitions are present but no executable hooks are detected.
  - Added detection and reporting of dangling configuration and skill symlinks as low-severity findings.

- **Bug Fixes**
  - Improved resilience when scanning dangling symlinks, malformed hook entries, unsupported hook types, or invalid settings JSON.
  - Preserved handling of valid symlinks while preventing scan interruptions from broken links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62559441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge until per-hook timeout handling and the explicit readonly-array requirement are addressed. The two reporting inaccuracies are non-blocking but should be corrected for reliable scan results.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Honor hook timeouts** <a href="https://github.com/affaan-m/agentshield/pull/127/files#diff-fde1e0620a3b6be5ef271994e78eab2de62bf9066b30262661581f8834b17b81R326">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Report dangling skill directories** <a href="https://github.com/affaan-m/agentshield/pull/127#discussion_r3978668939">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Classify stat failures accurately** <a href="https://github.com/affaan-m/agentshield/pull/127#discussion_r3978668947">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/sandbox/executor.ts:326
Standard hooks retain their configured `timeout`, but execution passes only the global sandbox options. A hook configured for 30 seconds was terminated after the five-second default, so valid longer-running hooks are reported as timed out and their behavior is not fully analyzed.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
src/scanner/discovery.ts:265
A recognized `skills/` or `.claude/skills` directory that is itself a dangling symlink is skipped before dangling links are recorded. This is a non-blocking reporting gap: the scan completes, but produces no dangling-skill finding for this broken configuration, while dangling child links in real skill directories are reported.

### Issue 3
src/scanner/discovery.ts:111-112
This catch block converts every `statSync` failure into a missing target. A self-referential symlink produces `ELOOP`, but is reported as a dangling symlink even though that error does not establish that the target is missing. This is a non-blocking diagnostic error that can direct users toward an incorrect fix.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- This change adds parsing for nested Claude Code hooks and reports several dangling symlink cases. Longer-running hooks ignore their declared timeout and stop after the global default, dangling skill directories are not reported, and symlink-loop errors are described as missing targets. The timeout behavior and the repository’s readonly-array requirement must be resolved before merging.

<sub>Reviews (1) · Last reviewed commit: ["chore: rebuild dist"](https://github.com/affaan-m/agentshield/commit/f919b158b80792a8e7fa7cafe5ecdb219d69d129)</sub>

<!-- /greptile_comment -->