### PR TITLE
docs: add FAQ section to README (lands #97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -912,6 +912,96 @@ AgentShield is available through multiple channels:
 | **ECC Plugin** | Claude Code users via the ECC skill ecosystem | Install through [Everything Claude Code](https://github.com/affaan-m/everything-claude-code) |
 | **ECC Tools GitHub App** | Integrated scanning across your GitHub org | Install at [github.com/apps/ecc-tools](https://github.com/apps/ecc-tools) |
 | **ECC Tools Pro** | GitHub App with automated repo analysis, Stripe billing ($19/seat/mo) | [Install](https://github.com/apps/ecc-tools) |
+## FAQ
+
+### What is AgentShield?
+
+AgentShield is a **security auditor for AI agent configurations**. It scans Claude Code setups for hardcoded secrets, permission misconfigs, hook injection, MCP server risks, and agent prompt injection vectors.
+
+| Feature | Description |
+|---------|-------------|
+| **Security Auditor** | Scans `.claude/` directory for vulnerabilities |
+| **Multiple Surfaces** | CLI, GitHub Action, GitHub App integration |
+| **Auto-Fix** | Replaces hardcoded secrets with env var references |
+| **Graded Reports** | Security score (0-100) with findings breakdown |
+| **Opus Pipeline** | Three-agent adversarial analysis with Anthropic API |
+| **Evidence Pack** | Portable audit bundle for compliance |
+
+### What can AgentShield detect?
+
+| Category | Examples |
+|----------|----------|
+| **Secrets** | Hardcoded API keys, tokens, private keys, connection strings |
+| **Permissions** | Overly permissive allow rules like `Bash(*)` |
+| **Hooks** | Hook injection vectors, unsafe hooks |
+| **MCP Servers** | MCP server risks, malicious MCP configs |
+| **Agents** | Agent prompt injection vectors |
+
+### How to get started?
+
+**Quick Start (no install):**
+```bash
+npx ecc-agentshield scan
+```
+
+**Install globally:**
+```bash
+npm install -g ecc-agentshield
+agentshield scan
+```
+
+**Auto-fix safe issues:**
+```bash
+agentshield scan --fix
+```
+
+### What output formats are available?
+
+| Format | Use Case |
+|--------|----------|
+| **Default** | Terminal graded security report |
+| **JSON** | CI pipelines and automation |
+| **HTML** | Executive security report |
+| **Evidence Pack** | Portable audit bundle for compliance |
+
+### What is the Opus Pipeline?
+
+The Opus Pipeline is a **three-agent adversarial analysis** that runs on Claude Opus through the Anthropic API:
+1. **Attacker**: hunts for exploitable weaknesses in the scanned config
+2. **Defender**: proposes concrete hardening for each weakness
+3. **Auditor**: reconciles both views into a ranked risk assessment
+
+**Usage:**
+```bash
+agentshield scan --opus --stream
+```
+
+### What is MiniClaw?
+
+MiniClaw is a **sandboxed agent runtime** included with AgentShield:
+- **Prompt Router**: Strips 12+ injection pattern categories
+- **Tool Whitelist**: Safe/Guarded/Restricted tiers
+- **Sandbox**: Isolated filesystem, path traversal blocked
+- **HTTP API**: REST endpoints for session management
+
+### Is AgentShield free and open source?
+
+Yes! AgentShield is **MIT licensed** and free to use. Built at the Claude Code Hackathon (Cerebral Valley x Anthropic, Feb 2026).
+
+### How to contribute?
+
+Contributions welcome! Check the [repository](https://github.com/affaan-m/agentshield) for issues and pull requests. See [CONTRIBUTING.md](./CONTRIBUTING.md) for guidelines.
+
+### Where to get help?
+
+| Resource | Link |
+|----------|------|
+| **Repository** | [github.com/affaan-m/agentshield](https://github.com/affaan-m/agentshield) |
+| **npm Package** | [npmjs.com/package/ecc-agentshield](https://www.npmjs.com/package/ecc-agentshield) |
+| **Changelog** | [CHANGELOG.md](./CHANGELOG.md) |
+| **Everything Claude Code** | [github.com/affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) |
+| **Twitter** | [@affaanmustafa](https://x.com/affaanmustafa) |
+
 ## License
 
 MIT


### PR DESCRIPTION
Lands the FAQ contributed by meichuanyi in #97, rebased onto current main and placed before the License section instead of after the closing footer. Edits: the Opus pipeline agents are named as they exist in src/opus (Attacker, Defender, Auditor), the model reference no longer pins a version, the secrets row lists what the rules actually cover, and punctuation follows the repo style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive FAQ section covering AgentShield’s purpose, detection capabilities, getting started, output formats, agent pipeline, MiniClaw, licensing, contributions, and support resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62559632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Safe to merge because the confirmed issues affect documentation accuracy rather than runtime behavior.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Clarify Auto\-Fix Scope** <a href="https://github.com/affaan-m/agentshield/pull/128#discussion_r3978657000">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**List All Output Formats** <a href="https://github.com/affaan-m/agentshield/pull/128#discussion_r3978657021">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
README.md:925
This says Auto-Fix replaces hardcoded secrets with environment-variable references, but general hardcoded-secret findings are not auto-fixable. That replacement is limited to hardcoded MCP environment values, while other automatic fixes may remove unsafe content. The current wording may leave users expecting detected API keys and tokens to be rewritten automatically.

```suggestion
| **Auto-Fix** | Applies verified safe fixes to supported findings |
```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 2
README.md:960-965
This table omits the supported Markdown and SARIF formats and presents Evidence Pack as a format even though it uses the separate `--evidence-pack <dir>` option. Readers looking for PR reports or GitHub code-scanning integration may conclude those formats are unavailable or try the unsupported `--format evidence-pack` value.

```suggestion
| Format | Use Case |
|--------|----------|
| **Terminal** | Default graded security report |
| **JSON** | CI pipelines and automation |
| **Markdown** | Documentation and pull request reports |
| **HTML** | Executive security report |
| **SARIF** | GitHub code scanning integration |

Evidence Packs are portable audit bundles generated separately with `--evidence-pack <dir>`.
```

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- The FAQ adds useful product guidance, but two descriptions do not match the current CLI behavior: Auto-Fix is broader than the supported automatic secret replacement, and the reporting table omits available formats while presenting Evidence Pack as one. These documentation issues are non-blocking, so the change is safe to merge, though updating the README will prevent incorrect user expectations.

<sub>Reviews (1) · Last reviewed commit: ["docs: add FAQ section to README"](https://github.com/affaan-m/agentshield/commit/42f8586cbcaaf93fc25bece27a427e6f5080bc57)</sub>

<!-- /greptile_comment -->