### PR TITLE
docs: OpenFGA agent authorization design note (#106)

### DIFF
--- a/docs/research/openfga-agent-authorization.md
+++ b/docs/research/openfga-agent-authorization.md
@@ -1,0 +1,180 @@
+# OpenFGA for AI agent fine-grained authorization (issue #106)
+
+Status: design note, no scanner changes. Date: 2026-09-10.
+
+## Executive summary
+
+OpenFGA is an Apache-2.0, Zanzibar-inspired relationship-based access control (ReBAC) engine. It stores `user, relation, object` tuples, evaluates them against a typed authorization model, and answers `Check`, `BatchCheck`, `ListObjects`, `ListUsers`, and `Expand` queries. It runs on PostgreSQL 14+ or MySQL 8 (SQLite is beta), ships official SDKs for Go, Node.js, Python, Java, and .NET, and has been used in production by Auth0 FGA since December 2021 (source: github.com/openfga/openfga README).
+
+For the agent problem the issue describes (User to Agent, Agent to Tool/MCP server, Agent to Agent delegation, with conditions on risk tier and environment), ReBAC is the right shape. Conditions (CEL expressions) and contextual tuples cover the ABAC-flavored parts without a second policy language.
+
+Recommendation: adopt OpenFGA as the ReBAC engine inside a Policy Decision Point (PDP) if and when AgentShield grows a runtime enforcement path. Nothing ships in the scanner now. The only near-term, low-cost item is documenting how a scan's allow-list and MCP inventory map to candidate tuples, so a future exporter has a stable contract.
+
+## Why ReBAC fits the agent graph
+
+The three relationships in scope are graph edges, not attribute predicates:
+
+- User to Agent: "alice may run agent:deploy-bot" is a `user` related to an `agent` as `operator`. Team membership makes it transitive (`operator from team`).
+- Agent to Tool / MCP server: "agent:deploy-bot may call tool:github.create_pr" is an `agent` related to a `tool` as `caller`. Tools group under an `mcp_server`, so a grant on the server can flow down to its tools via `from`.
+- Agent to Agent delegation: "agent:planner may delegate to agent:executor" is an `agent` related to an `agent` as `delegate`. Because OpenFGA models this as a relation, the PDP can ask "does the delegate still have `can_invoke` on the tool" instead of trusting inherited scope. This is the exact gap the agentic-authz reference repo calls out: "Agents should not inherit broad human permissions just because they act on a human's behalf."
+
+OpenFGA's docs describe ReBAC as "a superset of RBAC and natively covers ABAC scenarios when attributes are expressed as relationships" (openfga.dev/docs/authorization-concepts). Risk tier and environment are the residual attribute checks; conditions handle them.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    C[Client / agent runtime] -->|tool call + identity| PEP[API gateway PEP]
+    PEP -->|authorize request| PDP[Policy engine PDP]
+    PDP -->|Check / BatchCheck| FGA[(OpenFGA + Postgres)]
+    PDP -->|context: env, risk tier| FGA
+    FGA -->|allowed: true/false| PDP
+    PDP -->|decision + audit record| PEP
+    PEP -->|forward or 403| T[Tool / MCP server]
+    AS[AgentShield scan] -.->|candidate tuples, future| FGA
+```
+
+The PEP only forwards identity and the requested tool operation. The PDP owns the mapping from request to `(user, relation, object, context)`, picks consistency, and writes the audit record. OpenFGA never sees prompts or payloads.
+
+## Worked authorization model
+
+```
+model
+  schema 1.1
+
+type user
+
+type team
+  relations
+    define member: [user]
+    define lead: [user]
+
+type agent
+  relations
+    define owner_team: [team]
+    define operator: [user, team#member] or member from owner_team
+    define delegate: [agent]
+    define can_run: operator
+    define can_delegate_to: delegate
+
+type mcp_server
+  relations
+    define owner_team: [team]
+    define allowed_agent: [agent] or delegate from allowed_agent
+    define can_connect: allowed_agent
+
+type tool
+  relations
+    define server: [mcp_server]
+    define caller: [agent with env_and_tier_ok, agent]
+    define approver: lead from server_owner_team
+    define server_owner_team: owner_team from server
+    define can_invoke: caller or can_connect from server
+
+condition env_and_tier_ok(
+  tuple_env: string, request_env: string,
+  max_tier: int, request_tier: int
+) {
+  tuple_env == request_env && request_tier <= max_tier
+}
+```
+
+Notes:
+
+- `caller: [agent with env_and_tier_ok, agent]` lets a grant carry a condition (env and tier bounds stored with the tuple) or be unconditional. Persisted context on the tuple takes precedence over request context (openfga.dev/docs/modeling/conditions).
+- `allowed_agent ... or delegate from allowed_agent` is how delegation flows: if `agent:planner` is allowed on a server and `agent:executor` is its delegate, executor can connect. The PDP should still require the delegating agent to exist as an explicit tuple; nothing here grants delegation implicitly.
+- Data classification can be added the same way as tier: an `int classification` parameter compared against a tuple bound. UNVERIFIED: the model above has not been run through `fga model validate` or a `store test` file. Do that before anyone relies on it.
+
+## Check and BatchCheck
+
+Single check, with request context for the condition and a contextual tuple asserting the current session's team membership (limit is 100 contextual tuples per request):
+
+```json
+{
+  "authorization_model_id": "01HVMMBCMGZNT3SED4Z17ECXCA",
+  "tuple_key": {
+    "user": "agent:deploy-bot",
+    "relation": "can_invoke",
+    "object": "tool:github.create_pr"
+  },
+  "context": { "request_env": "prod", "request_tier": 2 },
+  "contextual_tuples": {
+    "tuple_keys": [
+      { "user": "user:alice", "relation": "member", "object": "team:platform" }
+    ]
+  },
+  "consistency": "HIGHER_CONSISTENCY"
+}
+```
+
+BatchCheck, used when a PDP pre-filters the tool list an agent is about to be offered (default max 50 checks per request; docs say it is less efficient than parallel `Check` below roughly 10 checks):
+
+```json
+{
+  "authorization_model_id": "01HVMMBCMGZNT3SED4Z17ECXCA",
+  "checks": [
+    {
+      "tuple_key": { "user": "agent:deploy-bot", "relation": "can_invoke", "object": "tool:github.create_pr" },
+      "context": { "request_env": "prod", "request_tier": 2 },
+      "correlation_id": "t1"
+    },
+    {
+      "tuple_key": { "user": "agent:deploy-bot", "relation": "can_invoke", "object": "tool:postgres.query" },
+      "context": { "request_env": "prod", "request_tier": 2 },
+      "correlation_id": "t2"
+    }
+  ]
+}
+```
+
+Consistency: `MINIMIZE_LATENCY` is the default and may serve from cache (caching is off by default). Use `HIGHER_CONSISTENCY` right after a tuple write, for example immediately after a revocation. `ListObjects` answers "which tools can this agent invoke" and is documented as suited to small collections, which matches a per-agent tool inventory.
+
+## How AgentShield could feed this (future)
+
+AgentShield already has the two inputs a tuple exporter needs:
+
+- The scanned `permissions.allow` list and the parsed `mcpServers` map (`src/types.ts`, `McpConfigSchema`). Each allow-list entry maps to a candidate `tool` object and a `caller` tuple; each MCP server maps to an `mcp_server` object with its tools as children.
+- `OrgPolicy` in `src/policy/types.ts` carries `banned_tools`, `banned_mcp_servers`, and `policy_pack`. Banned items should never become tuples; the exporter would emit them as an explicit exclusion list so a reviewer can diff intent against what the graph would grant.
+
+Proposed shape, not built: a `agentshield.tuples.v1` JSON document alongside the existing `agentshield.policy-export.v1` manifest in `src/policy/export.ts`, containing candidate tuples, the source finding IDs, and the scan sha256. Candidate means a human writes them, not the scanner.
+
+Second future item: `promotePolicyPack` in `src/policy/promote.ts` already emits review items before a pack is promoted. A later version could add an `action_required` item that fails unless a `Check(user:<promoter>, can_promote, policy_pack:<id>)` returns `allowed: true`. That keeps promotion authority in the same graph as agent authority. Evidence packs (`src/evidence-pack/index.ts`) would record the `authorization_model_id` and the check result.
+
+## Comparison
+
+Rows other than OpenFGA are from general knowledge of the projects and were not verified against their docs for this note (UNVERIFIED).
+
+| Engine | Model | Conditions / attributes | Fit for agent graph | Notes |
+|---|---|---|---|---|
+| OpenFGA | Zanzibar ReBAC, DSL | CEL conditions, contextual tuples | Strong | CNCF project (UNVERIFIED from the README alone), Postgres/MySQL, five official SDKs |
+| SpiceDB | Zanzibar ReBAC, schema language | Caveats (CEL) | Strong | Different schema syntax, own datastore options, commercial vendor Authzed |
+| Ory Keto | Zanzibar ReBAC, OPL (TypeScript-like) | Limited | Medium | Smaller ecosystem, fewer condition features |
+| Cedar | Policy language, RBAC/ABAC with entity hierarchy | Native | Medium | Policies rather than tuples; good for static rules, weaker for dynamic delegation graphs |
+| OPA / Rego | General policy language | Native | Medium | Needs data pushed in; no built-in relationship graph or reverse queries |
+
+## Pros and cons
+
+Pros: relationship model matches the agent graph directly; delegation is one relation, not a policy rewrite; conditions cover env and tier without a second engine; `ListObjects` gives the "what can this agent touch" view for free; Apache-2.0 and self-hostable.
+
+Cons: another stateful service (Postgres plus OpenFGA) to run; tuple hygiene becomes an operational duty, and stale grants are a new failure mode; the consistency knob is easy to get wrong after revocations; the reference repo is explicitly a demo ("not a drop-in authorization system for production"); AgentShield today is a static scanner with no runtime PEP, so there is nothing to enforce against yet.
+
+## Recommendation
+
+Adopt: OpenFGA as the ReBAC engine behind a PDP, when a runtime enforcement path exists. Model shape as above, validated with `fga model validate` and `store test` before use.
+
+Defer: tuple export from scans, promotion gating on `Check`, and any SDK dependency in this repo. Track each as its own issue once a PEP exists.
+
+Explicitly: nothing ships in the scanner now. This note closes #106 as research.
+
+## References
+
+- https://github.com/openfga/openfga
+- https://openfga.dev/docs/modeling/getting-started
+- https://openfga.dev/docs/modeling/conditions
+- https://openfga.dev/docs/interacting/contextual-tuples
+- https://openfga.dev/docs/interacting/relationship-queries
+- https://openfga.dev/docs/interacting/consistency
+- https://openfga.dev/docs/getting-started/perform-check
+- https://openfga.dev/docs/authorization-concepts
+- https://openfga.dev/docs/modeling/advanced/entitlements
+- https://github.com/Siddhant-K-code/agentic-authz


### PR DESCRIPTION
Design note answering issue #106: why relationship-based access control fits User to Agent, Agent to Tool, and Agent to Agent delegation, a worked OpenFGA DSL model with a risk-tier and environment condition, Check and BatchCheck examples, how a scan's allow-list and MCP inventory could be exported as candidate tuples, and a comparison with SpiceDB, Ory Keto, Cedar, and OPA. Nothing ships in the scanner. Unverified claims are marked as such. Closes #106.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a research note evaluating OpenFGA for future agent authorization.
  * Documented authorization architecture, delegation, risk conditions, consistency behavior, integration considerations, alternatives, and trade-offs.
  * No scanner or SDK behavior changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62559752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge until the invalid OpenFGA model is corrected; the remaining documentation inaccuracies are non-blocking but should be addressed for the note to guide future work accurately.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Use direct tuplesets** <a href="https://github.com/affaan-m/agentshield/pull/129#discussion_r3978681516">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Connect session membership** <a href="https://github.com/affaan-m/agentshield/pull/129#discussion_r3978681533">▶</a>
3. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Parsed representative settings and MCP configuration through the repository schemas\.** <a href="https://github.com/affaan-m/agentshield/pull/129#discussion_r3978682272">▶</a>
4. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Ran the packaged runtime CLI in a fresh temporary workspace before and after installing\.\.\.** <a href="https://github.com/affaan-m/agentshield/pull/129#discussion_r3978682282">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
docs/research/openfga-agent-authorization.md:63-70
The worked model cannot be loaded as OpenFGA schema 1.1. `allowed_agent` is a computed union but is used as the tupleset in `delegate from allowed_agent`; independently, `server_owner_team` is computed but is used as the tupleset in `lead from server_owner_team`. OpenFGA requires relations used after `from` to be direct relations, so readers cannot use either delegation or approver path until the model is restructured.

### Issue 2
docs/research/openfga-agent-authorization.md:101-105
The contextual `user:alice member team:platform` tuple does not affect this `agent:deploy-bot can_invoke tool:github.create_pr` request. In the model, `can_invoke` is reached through `caller` or the server's `can_connect` relation, while this membership only contributes to an agent's `operator` and `can_run` relations. With no caller or server grant, the documented request remains denied, so the example does not demonstrate session-membership authorization. This is non-blocking, but it can mislead implementers about which request data affects access decisions.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

### Issue 3
docs/research/openfga-agent-authorization.md:136
- **Bug**
  - Parsed representative settings and MCP configuration through the repository schemas.
  - The allow list remained strings only, and MCP server records contained launch configuration without identity or child-tool fields.
  - The repository type tests passed, confirming this is the current schema behavior.
- **Cause**
  - T-Rex reproduced this while running the changed behavior, but it did not return a separate root-cause sentence.
- **Fix**
  - Update the changed code so this failing path is handled, then rerun the same T-Rex check to confirm it passes.

### Issue 4
docs/research/openfga-agent-authorization.md:159
- **Bug**
  - Ran the packaged runtime CLI in a fresh temporary workspace before and after installing the hook.
  - The installed hook reached ready status, blocked a denied Bash call before execution, allowed a Read call, and recorded both decisions.
  - The CLI exposed lifecycle commands for installing, removing, checking, and repairing the runtime hook.
- **Cause**
  - T-Rex reproduced this while running the changed behavior, but it did not return a separate root-cause sentence.
- **Fix**
  - Update the changed code so this failing path is handled, then rerun the same T-Rex check to confirm it passes.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- This research note needs corrections before it can be relied on as an implementation guide: its central OpenFGA model cannot be loaded, its contextual-membership Check example does not authorize the stated request, and its exporter and runtime assumptions do not match the current repository.

<sub>Reviews (1) · Last reviewed commit: ["docs: add OpenFGA agent authorization de..."](https://github.com/affaan-m/agentshield/commit/d5511e5e90cfe0f0b5009ea68437c57400b3db09)</sub>

<!-- /greptile_comment -->