### PR TITLE
fix(permissions): normalize allow entries and report shadowing prefix rules

### DIFF
--- a/src/rules/permission-entries.ts
+++ b/src/rules/permission-entries.ts
@@ -1,0 +1,103 @@
+/**
+ * Normalized view of a Claude Code permission rule such as `Bash(npm run build:*)`.
+ *
+ * Claude Code accepts several spellings for the same grant: `Bash(cmd:*)`
+ * (the prefix form the approval prompt writes), `Bash(cmd *)`, `Bash(cmd)`,
+ * and commands spelled with an absolute path. Rules that reason about what an
+ * allow entry grants must compare the normalized shape, not the raw string.
+ */
+export interface ParsedPermissionEntry {
+  /** Tool name, for example `Bash`, `Write`, `Read`. */
+  readonly tool: string;
+  /** The raw entry as written in settings. */
+  readonly raw: string;
+  /** The text inside the parentheses, trimmed. */
+  readonly spec: string;
+  /** First command token with any directory prefix removed, lowercased. */
+  readonly command: string;
+  /** Remaining tokens after the command, joined by single spaces. */
+  readonly args: string;
+  /** `command` plus `args`, the prefix this entry grants. Empty for `Bash(*)`. */
+  readonly prefix: string;
+  /** True when the entry ends in a wildcard (`:*`, ` *`, or is exactly `*`). */
+  readonly wildcard: boolean;
+}
+
+export function parsePermissionEntry(entry: string): ParsedPermissionEntry | null {
+  const match = entry.match(/^([A-Za-z]+)\((.*)\)$/s);
+  if (!match) return null;
+
+  const tool = match[1];
+  const spec = match[2].trim();
+
+  // Only Bash entries carry a command line. Other tools take a path or glob
+  // pattern, which is kept verbatim; only the bare `*` counts as a wildcard.
+  if (tool !== "Bash") {
+    const blanket = spec === "*";
+    return { tool, raw: entry, spec, command: "", args: "", prefix: blanket ? "" : spec, wildcard: blanket };
+  }
+
+  let body = spec;
+  let wildcard = false;
+  if (body === "*") {
+    body = "";
+    wildcard = true;
+  } else if (body.endsWith(":*")) {
+    body = body.slice(0, -2);
+    wildcard = true;
+  } else if (/\s\*$/.test(body)) {
+    body = body.replace(/\s\*$/, "");
+    wildcard = true;
+  }
+
+  const tokens = body.trim().split(/\s+/).filter(Boolean);
+  const rawCommand = tokens[0] ?? "";
+  const command = rawCommand.replace(/^.*[\\/]/, "").toLowerCase();
+  const args = tokens.slice(1).join(" ");
+  const prefix = [command, ...tokens.slice(1)].filter(Boolean).join(" ");
+
+  return { tool, raw: entry, spec, command, args, prefix, wildcard };
+}
+
+/**
+ * Canonical spelling used by pattern-based checks: the command is reduced to
+ * its basename and the `:*` and ` *` wildcard forms collapse to ` *`.
+ * `Bash(/opt/homebrew/bin/node -e:*)` becomes `Bash(node -e *)`.
+ */
+export function normalizePermissionEntry(entry: string): string {
+  const parsed = parsePermissionEntry(entry);
+  if (!parsed) return entry;
+  if (parsed.prefix === "" && parsed.wildcard) return `${parsed.tool}(*)`;
+  return `${parsed.tool}(${parsed.prefix}${parsed.wildcard ? " *" : ""})`;
+}
+
+/**
+ * True when `covering` grants at least everything `covered` grants: same tool,
+ * `covering` ends in a wildcard, and its prefix is a token-boundary prefix of
+ * the covered entry's prefix. `Bash(*)` covers every Bash entry.
+ */
+export function entryCovers(covering: ParsedPermissionEntry, covered: ParsedPermissionEntry): boolean {
+  if (covering.raw === covered.raw) return false;
+  if (covering.tool !== covered.tool) return false;
+  if (!covering.wildcard) return false;
+  if (covering.prefix === "") return true;
+  if (covered.prefix === covering.prefix) return true;
+  return covered.prefix.startsWith(`${covering.prefix} `);
+}
+
+/**
+ * Other allow entries that already grant everything `entry` grants.
+ */
+export function findCoveringEntries(
+  entry: string,
+  allEntries: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const covered = parsePermissionEntry(entry);
+  if (!covered) return [];
+  const covering: string[] = [];
+  for (const candidate of allEntries) {
+    const parsed = parsePermissionEntry(candidate);
+    if (parsed && entryCovers(parsed, covered)) covering.push(candidate);
+  }
+  return covering;
+}

--- a/src/rules/permissions.ts
+++ b/src/rules/permissions.ts
@@ -2,6 +2,11 @@ import { statSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { homedir } from "node:os";
 import type { ConfigFile, Finding, Rule } from "../types.js";
+import {
+  findCoveringEntries,
+  normalizePermissionEntry,
+  parsePermissionEntry,
+} from "./permission-entries.js";
 
 function isHookManifestConfig(file: ConfigFile, config: unknown): boolean {
   if (!/(^|\/)hooks\/[^/]+\.json$/i.test(file.path)) return false;
@@ -26,7 +31,13 @@ const OVERLY_PERMISSIVE: ReadonlyArray<{
     suggestion: "Bash(git *), Bash(npm *), Bash(node *)",
   },
   {
-    pattern: /^Bash\(sudo\s/,
+    pattern: /^Bash\((?:bash|sh|zsh|fish|dash|ksh|csh|tcsh|pwsh|powershell|cmd)(?:\s|\))/,
+    description: "Shell interpreter allowed: any command can run through it, equivalent to Bash(*)",
+    severity: "critical",
+    suggestion: "Remove shell interpreter grants; allow the specific commands instead",
+  },
+  {
+    pattern: /^Bash\((?:sudo|su|doas)(?:\s|\))/,
     description: "Sudo access allowed — agent can escalate privileges",
     severity: "critical",
     suggestion: "Remove sudo permissions entirely",
@@ -44,73 +55,73 @@ const OVERLY_PERMISSIVE: ReadonlyArray<{
     suggestion: "Edit(src/*), Edit(tests/*)",
   },
   {
-    pattern: /^Bash\(rm\s/,
+    pattern: /^Bash\(rm(?:\s|\))/,
     description: "Delete operations explicitly allowed in Bash",
     severity: "high",
     suggestion: "Move rm commands to deny list instead",
   },
   {
-    pattern: /^Bash\(curl\s/,
+    pattern: /^Bash\(curl(?:\s|\))/,
     description: "Unrestricted curl access — agent can make arbitrary HTTP requests",
     severity: "medium",
     suggestion: "Restrict to specific domains or move to deny list",
   },
   {
-    pattern: /^Bash\(wget\s/,
+    pattern: /^Bash\(wget(?:\s|\))/,
     description: "Unrestricted wget access — agent can download arbitrary files",
     severity: "medium",
     suggestion: "Restrict to specific domains or move to deny list",
   },
   {
-    pattern: /^Bash\(chmod\s/,
+    pattern: /^Bash\(chmod(?:\s|\))/,
     description: "chmod access — agent can change file permissions",
     severity: "medium",
     suggestion: "Move chmod to deny list to prevent permission escalation",
   },
   {
-    pattern: /^Bash\(chown\s/,
+    pattern: /^Bash\(chown(?:\s|\))/,
     description: "chown access — agent can change file ownership",
     severity: "high",
     suggestion: "Move chown to deny list to prevent ownership takeover",
   },
   {
-    pattern: /^Bash\(ssh\s/,
+    pattern: /^Bash\(ssh(?:\s|\))/,
     description: "SSH access — agent can connect to remote systems",
     severity: "high",
     suggestion: "Remove SSH permissions to prevent lateral movement",
   },
   {
-    pattern: /^Bash\(nc\s|^Bash\(netcat\s/,
+    pattern: /^Bash\((?:nc|ncat|netcat|socat)(?:\s|\))/,
     description: "Netcat access — can open network connections for exfiltration or reverse shells",
     severity: "high",
     suggestion: "Remove netcat permissions entirely",
   },
   {
-    pattern: /^Bash\(python\s|^Bash\(python3\s|^Bash\(node\s/,
+    pattern: /^Bash\((?:python|python3|python2|node|nodejs|ruby|perl|php|deno|bun|tsx|ts-node)(?:\s|\))/,
     description: "Interpreter access — agent can run arbitrary code via scripting language",
     severity: "high",
     suggestion: "Restrict to specific scripts: Bash(node scripts/build.js)",
   },
   {
-    pattern: /^Bash\(docker\s/,
+    pattern: /^Bash\((?:docker|podman|nerdctl)(?:\s|\))/,
     description: "Docker access — containers can escape to host, mount filesystems, and access host network",
     severity: "high",
     suggestion: "Remove docker permissions or restrict to read-only: Bash(docker ps)",
   },
   {
-    pattern: /^Bash\(kill\s|^Bash\(pkill\s|^Bash\(killall\s/,
+    pattern: /^Bash\((?:kill|pkill|killall)(?:\s|\))/,
     description: "Process killing — agent can terminate system processes",
     severity: "medium",
     suggestion: "Move process killing to deny list",
   },
   {
-    pattern: /^Bash\(eval\s/,
+    pattern: /^Bash\(eval(?:\s|\))/,
     description: "eval access — agent can execute arbitrary code via shell eval",
     severity: "critical",
     suggestion: "Remove eval permissions; use explicit commands instead",
   },
   {
-    pattern: /^Bash\(exec\s/,
+    pattern: /^Bash\(exec(?:\s|\))/,
     description: "exec access — agent can replace the current process with arbitrary commands",
     severity: "critical",
     suggestion: "Remove exec permissions; use explicit commands instead",
@@ -274,8 +285,9 @@ function hasDynamicShellBehavior(command: string): boolean {
 }
 
 function isScopedInterpreterScriptAllowEntry(entry: string): boolean {
-  const command = getBashPermissionCommand(entry);
-  if (!command) return false;
+  const parsed = parsePermissionEntry(entry);
+  if (!parsed || parsed.tool !== "Bash" || parsed.wildcard) return false;
+  const command = parsed.prefix;
   if (!/^(?:python|python3|node)\s+/i.test(command)) return false;
   if (hasDynamicShellBehavior(command)) return false;
   if (/\s(?:-c|-e|-i|-m|-p|-r|--eval|--print|--require)\b/.test(command)) return false;
@@ -377,8 +389,9 @@ export const permissionRules: ReadonlyArray<Rule> = [
           continue;
         }
 
+        const normalizedEntry = normalizePermissionEntry(entry);
         for (const check of OVERLY_PERMISSIVE) {
-          if (check.pattern.test(entry)) {
+          if (check.pattern.test(normalizedEntry)) {
             findings.push({
               id: `permissions-permissive-${entry}`,
               severity: check.severity,
@@ -416,6 +429,53 @@ export const permissionRules: ReadonlyArray<Rule> = [
         }
       }
 
+      return findings;
+    },
+  },
+  {
+    id: "permissions-shadowed-allow",
+    name: "Allow Rule Shadowed by Broader Prefix Rule",
+    description: "Finds allow entries that are fully covered by a broader prefix rule, so narrowing or removing them changes nothing",
+    severity: "medium",
+    category: "permissions",
+    check(file: ConfigFile): ReadonlyArray<Finding> {
+      if (file.type !== "settings-json") return [];
+
+      const perms = parsePermissionLists(file.content);
+      if (!perms) return [];
+
+      const shadowedByCovering = new Map<string, string[]>();
+      for (const entry of perms.allow) {
+        for (const covering of findCoveringEntries(entry, perms.allow)) {
+          const list = shadowedByCovering.get(covering) ?? [];
+          if (!list.includes(entry)) list.push(entry);
+          shadowedByCovering.set(covering, list);
+        }
+      }
+
+      const findings: Finding[] = [];
+      for (const [covering, shadowed] of shadowedByCovering) {
+        const parsed = parsePermissionEntry(covering);
+        const isBlanket = parsed !== null && parsed.prefix === "";
+        findings.push({
+          id: `permissions-shadowed-allow-${covering}`,
+          severity: isBlanket ? "high" : "medium",
+          category: "permissions",
+          title: `Broad allow rule shadows ${shadowed.length} narrower rule(s): ${covering}`,
+          description:
+            `"${covering}" is a prefix rule that already grants everything ${shadowed
+              .map((entry) => `"${entry}"`)
+              .join(", ")} grant(s). Tightening or removing the narrower entries does not reduce what the agent can run while "${covering}" remains. Narrow the broad rule to the specific subcommands you need.`,
+          file: file.path,
+          evidence: covering,
+          fix: {
+            description: "Replace the broad prefix rule with the specific narrower rules it shadows",
+            before: covering,
+            after: shadowed.join(", "),
+            auto: false,
+          },
+        });
+      }
       return findings;
     },
   },
@@ -554,7 +614,7 @@ export const permissionRules: ReadonlyArray<Rule> = [
               severity: "info",
               category: "permissions",
               title: `Deny/ask rule blocking ${match[0]} (good practice)`,
-              description: `Found "${match[0]}" inside a permissions deny/ask rule. This is correct — the rule prevents the agent from using this flag.`,
+              description: `Found "${match[0]}" inside a permissions deny/ask rule. This is correct: the rule prevents the agent from using this flag.`,
               file: file.path,
               line: findLineNumber(file.content, idx),
               evidence: match[0],
@@ -717,6 +777,17 @@ export const permissionRules: ReadonlyArray<Rule> = [
                 auto: false,
               },
             });
+            for (const covering of findCoveringEntries(entry, perms.allow)) {
+              findings.push({
+                id: `permissions-destructive-git-covering-${findings.length}`,
+                severity: "high",
+                category: "permissions",
+                title: `Prefix rule also allows the destructive git command: ${covering}`,
+                description: `The allow entry "${covering}" permits everything "${entry}" permits, so removing "${entry}" alone changes nothing. Narrow "${covering}" as well.`,
+                file: file.path,
+                evidence: covering,
+              });
+            }
             break;
           }
         }
@@ -963,6 +1034,17 @@ export const permissionRules: ReadonlyArray<Rule> = [
               file: file.path,
               evidence: entry,
             });
+            for (const covering of findCoveringEntries(entry, perms.allow)) {
+              findings.push({
+                id: `permissions-env-access-covering-${findings.length}`,
+                severity: "high",
+                category: "permissions",
+                title: `Prefix rule also grants env access: ${covering}`,
+                description: `The allow entry "${covering}" is a prefix rule that permits everything "${entry}" permits, so removing "${entry}" alone changes nothing. Narrow "${covering}" as well.`,
+                file: file.path,
+                evidence: covering,
+              });
+            }
             break;
           }
         }
@@ -1012,8 +1094,9 @@ export const permissionRules: ReadonlyArray<Rule> = [
       ];
 
       for (const entry of perms.allow) {
+        const normalizedEntry = normalizePermissionEntry(entry);
         for (const { pattern, description } of networkPatterns) {
-          if (pattern.test(entry)) {
+          if (pattern.test(normalizedEntry)) {
             findings.push({
               id: `permissions-unrestricted-network-${findings.length}`,
               severity: "high",

--- a/tests/rules/permission-entries.test.ts
+++ b/tests/rules/permission-entries.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  entryCovers,
+  findCoveringEntries,
+  normalizePermissionEntry,
+  parsePermissionEntry,
+} from "../../src/rules/permission-entries.js";
+
+describe("parsePermissionEntry", () => {
+  it("parses the colon prefix form", () => {
+    const parsed = parsePermissionEntry("Bash(npm run build:*)");
+    expect(parsed).toMatchObject({ tool: "Bash", command: "npm", args: "run build", prefix: "npm run build", wildcard: true });
+  });
+
+  it("parses the space wildcard form and path-spelled commands", () => {
+    const parsed = parsePermissionEntry("Bash(/opt/homebrew/bin/node -e *)");
+    expect(parsed).toMatchObject({ command: "node", args: "-e", prefix: "node -e", wildcard: true });
+  });
+
+  it("parses exact entries without a wildcard", () => {
+    const parsed = parsePermissionEntry("Bash(git status)");
+    expect(parsed).toMatchObject({ prefix: "git status", wildcard: false });
+  });
+
+  it("parses the blanket entry", () => {
+    expect(parsePermissionEntry("Bash(*)")).toMatchObject({ prefix: "", wildcard: true });
+  });
+
+  it("returns null for malformed entries", () => {
+    expect(parsePermissionEntry("Bash")).toBeNull();
+  });
+});
+
+describe("normalizePermissionEntry", () => {
+  it.each([
+    ["Bash(sudo:*)", "Bash(sudo *)"],
+    ["Bash(/usr/bin/sudo mv *)", "Bash(sudo mv *)"],
+    ["Bash(rm)", "Bash(rm)"],
+    ["Bash(*)", "Bash(*)"],
+    ["Write(src/*)", "Write(src/*)"],
+    ["Read(*)", "Read(*)"],
+  ])("normalizes %s to %s", (input, expected) => {
+    expect(normalizePermissionEntry(input)).toBe(expected);
+  });
+});
+
+describe("entryCovers", () => {
+  const p = (entry: string) => parsePermissionEntry(entry)!;
+
+  it("covers a longer prefix at a token boundary", () => {
+    expect(entryCovers(p("Bash(vercel:*)"), p("Bash(vercel env:*)"))).toBe(true);
+    expect(entryCovers(p("Bash(vercel:*)"), p("Bash(vercel env pull)"))).toBe(true);
+  });
+
+  it("does not cover a different command that shares a prefix string", () => {
+    expect(entryCovers(p("Bash(git:*)"), p("Bash(github:*)"))).toBe(false);
+  });
+
+  it("requires a wildcard on the covering entry", () => {
+    expect(entryCovers(p("Bash(vercel)"), p("Bash(vercel env:*)"))).toBe(false);
+  });
+
+  it("never reports an entry as covering itself", () => {
+    expect(entryCovers(p("Bash(vercel:*)"), p("Bash(vercel:*)"))).toBe(false);
+  });
+
+  it("does not cross tools", () => {
+    expect(entryCovers(p("Read(*)"), p("Bash(cat x)"))).toBe(false);
+  });
+});
+
+describe("findCoveringEntries", () => {
+  it("lists every covering entry", () => {
+    const all = ["Bash(*)", "Bash(vercel:*)", "Bash(vercel env:*)", "Bash(git status)"];
+    expect(findCoveringEntries("Bash(vercel env:*)", all)).toEqual(["Bash(*)", "Bash(vercel:*)"]);
+    expect(findCoveringEntries("Bash(*)", all)).toEqual([]);
+  });
+});

--- a/tests/rules/permissions.test.ts
+++ b/tests/rules/permissions.test.ts
@@ -375,6 +375,67 @@ describe("permissionRules", () => {
       expect(noVerifyFindings[0].severity).toBe("critical");
     });
 
+    it("flags the broadest colon-form grants (issue #115)", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: {
+          allow: [
+            "Bash(sudo:*)",
+            "Bash(rm:*)",
+            "Bash(bash:*)",
+            "Bash(zsh *)",
+            "Bash(/opt/homebrew/bin/node:*)",
+            "Bash(/opt/homebrew/bin/node -e *)",
+            "Bash(sudo mv *)",
+          ],
+        },
+      }));
+      const findings = runAllPermRules(file).filter((f) => f.id.startsWith("permissions-permissive-"));
+      const bySeverity = (entry: string) => findings.find((f) => f.evidence === entry)?.severity;
+      expect(bySeverity("Bash(sudo:*)")).toBe("critical");
+      expect(bySeverity("Bash(rm:*)")).toBe("high");
+      expect(bySeverity("Bash(bash:*)")).toBe("critical");
+      expect(bySeverity("Bash(zsh *)")).toBe("critical");
+      expect(bySeverity("Bash(/opt/homebrew/bin/node:*)")).toBe("high");
+      expect(bySeverity("Bash(/opt/homebrew/bin/node -e *)")).toBe("high");
+      expect(bySeverity("Bash(sudo mv *)")).toBe("critical");
+    });
+
+    it("still allows a scoped interpreter script spelled with a path", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: { allow: ["Bash(/usr/local/bin/node scripts/build.js)"] },
+      }));
+      const findings = runAllPermRules(file).filter((f) => f.id.startsWith("permissions-permissive-"));
+      expect(findings).toHaveLength(0);
+    });
+
+    it("reports the covering prefix rule when a narrower env grant is shadowed (issue #116)", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: { allow: ["Bash(vercel:*)", "Bash(vercel env:*)"] },
+      }));
+      const findings = runAllPermRules(file);
+      const envFindings = findings.filter((f) => f.id.startsWith("permissions-env-access"));
+      expect(envFindings.map((f) => f.evidence).sort()).toEqual(["Bash(vercel env:*)", "Bash(vercel:*)"]);
+      const shadow = findings.find((f) => f.id === "permissions-shadowed-allow-Bash(vercel:*)");
+      expect(shadow?.severity).toBe("medium");
+      expect(shadow?.description).toContain('"Bash(vercel env:*)"');
+    });
+
+    it("treats Bash(*) as covering every Bash entry", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: { allow: ["Bash(*)", "Bash(git status)"] },
+      }));
+      const shadow = runAllPermRules(file).find((f) => f.id === "permissions-shadowed-allow-Bash(*)");
+      expect(shadow?.severity).toBe("high");
+    });
+
+    it("does not report shadowing for unrelated or exact entries", () => {
+      const file = makeSettings(JSON.stringify({
+        permissions: { allow: ["Bash(git status)", "Bash(npm run build:*)", "Bash(npm run test:*)"] },
+      }));
+      const shadows = runAllPermRules(file).filter((f) => f.id.startsWith("permissions-shadowed-allow"));
+      expect(shadows).toHaveLength(0);
+    });
+
     it("skips non-settings files for permission rules", () => {
       const file: ConfigFile = { path: "agent.md", type: "agent-md", content: "Bash(*)" };
       const findings = runAllPermRules(file);


### PR DESCRIPTION
Fixes #115: colon-form and path-spelled allow entries (Bash(sudo:*), Bash(rm:*), Bash(bash:*), Bash(/opt/homebrew/bin/node -e *)) are normalized before matching and now flag at the expected severity. Shell interpreters are critical, su and doas join sudo, and ruby, perl, php, deno, bun, podman, socat join their groups.

Fixes #116: a new permissions-shadowed-allow rule reports a prefix rule that already covers narrower entries, and the env, network, and destructive git rules also emit a finding against the covering prefix rule, so deleting the narrow entry alone no longer looks like an improvement.

New src/rules/permission-entries.ts with parser, normalizer, and coverage helpers. 27 new tests. Full gate green locally: 1919 tests.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62561374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 2/5</h2>

The PR is not yet safe to merge because valid scoped permission configurations can produce false medium- or high-severity findings that affect scanner and CI gate results.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Equivalent rules shadow each other** <a href="https://github.com/affaan-m/agentshield/pull/130#discussion_r3978743243">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Scoped interpreters trigger false positives** <a href="https://github.com/affaan-m/agentshield/pull/130#discussion_r3978743253">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Path\-spelled Docker grants misclassified** <a href="https://github.com/affaan-m/agentshield/pull/130/files#diff-629153bbe50aeb77c4c291e1a318f1d12358eaed2c709b2f770113bb76c9aa31R309">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/rules/permission-entries.ts:80
When an allow list contains equivalent wildcard spellings such as `Bash(git:*)` and `Bash(git *)`, both parse to the same wildcard prefix, but this raw-string comparison treats them as different entries. Each entry therefore covers the other, producing two false shadowing findings whose suggested replacements are equivalent to the original grants. This does not narrow permissions or clear the finding and can fail scans gated at medium severity.

### Issue 2
src/rules/permissions.ts:291
The expanded matcher includes `python2`, `nodejs`, `ruby`, `perl`, `php`, `deno`, `bun`, `tsx`, and `ts-node`, but this scoped-script exemption still recognizes only `python`, `python3`, and `node`. An exact grant such as `Bash(ruby scripts/build.rb)` is therefore reported as high-severity arbitrary interpreter access even though it is restricted to a concrete script. This differs from equivalent Node and Python grants and can incorrectly fail high-severity scan gates.

### Issue 3
src/rules/permissions.ts:309
This exemption checks the unnormalized command, while the dangerous-container matcher later checks its normalized form. A read-only grant such as `Bash(/usr/bin/docker ps)` fails the raw `^docker` check, normalizes to `Bash(docker ps)`, and is then incorrectly reported at high severity despite being equivalent to the explicitly exempted inventory command.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- Normalizes colon-form, wildcard, and absolute-path Bash entries before selected permission checks.
- Adds shell, interpreter, privilege-escalation, networking, and container command classifications.
- Adds a shadowed-allow rule and reports covering prefixes alongside environment, network, and destructive-git findings.
- Adds targeted parser and permission-rule regression tests.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Permission allow entry] --> B[Parse entry]
  B --> C{Scoped safe exemption?}
  C -->|Yes| D[Skip generic permissive finding]
  C -->|No| E[Normalize command and wildcard]
  E --> F[Match dangerous command patterns]
  B --> G[Compare normalized prefix shape]
  G --> H[Find broader wildcard entries]
  H --> I[Emit shadowing and covering-prefix findings]
```
</details>

<sub>Reviews (1) · Last reviewed commit: ["fix(permissions): normalize allow entrie..."](https://github.com/affaan-m/agentshield/commit/ccffd78eaa4da0ae544403472362b9fe830dc427)</sub>

<!-- /greptile_comment -->