### PR TITLE
feat: move LLM analysis to current Claude models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ src/
     index.ts        # Format dispatcher
   opus/
     prompts.ts      # System prompts for Attacker/Defender/Auditor
-    pipeline.ts     # Opus 4.6 three-agent adversarial pipeline
+    pipeline.ts     # Claude Opus three-agent adversarial pipeline
     render.ts       # Opus analysis terminal + markdown rendering
     index.ts        # Pipeline entry point
   miniclaw/
@@ -69,7 +69,7 @@ Grades: A (>=90), B (>=75), C (>=60), D (>=40), F (<40)
 
 ```bash
 agentshield scan [path]              # Static analysis
-agentshield scan --opus              # + Opus 4.6 adversarial pipeline
+agentshield scan --opus              # + Claude Opus adversarial pipeline
 agentshield scan --format json|md    # Output format
 agentshield scan --fix               # Show auto-fix suggestions
 agentshield miniclaw start           # Launch MiniClaw secure agent server

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ agentshield scan --format html > report.html
 # Generate a portable audit bundle
 agentshield scan --evidence-pack ./agentshield-evidence
 
-# Three-agent Opus 4.6 adversarial analysis (requires ANTHROPIC_API_KEY)
+# Three-agent Claude Opus adversarial analysis (requires ANTHROPIC_API_KEY)
 agentshield scan --opus --stream
 
 # Generate a secure baseline config
@@ -402,9 +402,9 @@ Each pattern is a JS regex run against file content; `fileTypes` is optional and
 
 Generates a hardened `.claude/` directory with scoped permissions, safety hooks, and security best practices. Existing files are never overwritten.
 
-### Opus 4.6 Deep Analysis (`--opus`)
+### Claude Opus Deep Analysis (`--opus`)
 
-Three-agent adversarial pipeline powered by Claude Opus 4.6:
+Three-agent adversarial pipeline powered by Claude Opus (claude-opus-5 by default; the injection tester uses claude-sonnet-5):
 
 1. **Red Team (Attacker)** — finds exploitable attack vectors and multi-step chains
 2. **Blue Team (Defender)** — evaluates existing protections and recommends hardening
@@ -454,8 +454,8 @@ agentshield scan --injection --provider orcarouter
 ```
 
 The provider points the Anthropic client at `https://api.orcarouter.ai` and
-uses the gateway's namespaced model ids (e.g. `anthropic/claude-sonnet-4.5`,
-`anthropic/claude-opus-4.6`). The default provider remains Anthropic.
+uses the gateway's namespaced model ids (e.g. `anthropic/claude-sonnet-5`,
+`anthropic/claude-opus-5`). The default provider remains Anthropic.
 
 With `--provider orcarouter` the scanned configuration contents are sent to
 OrcaRouter's API instead of Anthropic's, so do not use it on configs containing
@@ -683,7 +683,7 @@ agentshield scan [options]         Scan configuration directory
   -f, --format <format>            Output: terminal, json, markdown, html, sarif
   -o, --output <path>              Write the primary report output to a file
   --fix                            Auto-apply safe fixes
-  --opus                           Enable Opus 4.6 multi-agent analysis
+  --opus                           Enable Claude Opus multi-agent analysis
   --provider <provider>            LLM provider for --opus/--injection: anthropic or orcarouter
   --stream                         Stream Opus analysis in real-time
   --injection                      Run active prompt injection testing
@@ -858,7 +858,7 @@ src/
 │   └── index.ts          Secure config generator
 └── opus/
     ├── prompts.ts        Attacker/Defender/Auditor system prompts
-    ├── pipeline.ts       Three-agent Opus 4.6 pipeline
+    ├── pipeline.ts       Three-agent Claude Opus pipeline
     └── render.ts         Opus analysis rendering
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,7 @@ program
   .option("-f, --format <format>", "Output format: terminal, json, markdown, html, sarif", "terminal")
   .option("-o, --output <path>", "Write the primary report output to a file")
   .option("--fix", "Auto-apply safe fixes", false)
-  .option("--opus", "Enable Opus 4.6 multi-agent deep analysis", false)
+  .option("--opus", "Enable Claude Opus multi-agent deep analysis", false)
   .option("--provider <provider>", "LLM provider for --opus/--injection analysis: anthropic (default) or orcarouter", "anthropic")
   .option("--stream", "Stream Opus analysis in real-time", false)
   .option("--injection", "Run active prompt injection testing against the config", false)

--- a/src/injection/tester.ts
+++ b/src/injection/tester.ts
@@ -42,7 +42,7 @@ export interface InjectionTestOptions {
 
 // ─── Constants ────────────────────────────────────────────
 
-const MODEL = "claude-sonnet-4-5-20250929";
+const MODEL = "claude-sonnet-5";
 const DEFAULT_BATCH_SIZE = 5;
 const DEFAULT_CONCURRENCY = 2;
 const MAX_TOKENS_PER_CALL = 4096;

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -23,6 +23,8 @@ export const ORCAROUTER_ENV_KEY = "ORCAROUTER_API_KEY";
 /** Model ids the OrcaRouter gateway exposes for the same Anthropic models
  * AgentShield uses by default. The gateway requires the `anthropic/` prefix. */
 const ORCAROUTER_MODELS: Readonly<Record<string, string>> = {
+  "claude-opus-5": "anthropic/claude-opus-5",
+  "claude-sonnet-5": "anthropic/claude-sonnet-5",
   "claude-opus-4-6": "anthropic/claude-opus-4.6",
   "claude-sonnet-4-5-20250929": "anthropic/claude-sonnet-4.5",
 };

--- a/src/opus/pipeline.ts
+++ b/src/opus/pipeline.ts
@@ -30,7 +30,7 @@ import {
   buildAuditorContext,
 } from "./prompts.js";
 
-const MODEL = "claude-opus-4-6";
+const MODEL = "claude-opus-5";
 
 // ─── Opus Pipeline Options ─────────────────────────────────
 

--- a/src/opus/render.ts
+++ b/src/opus/render.ts
@@ -8,7 +8,7 @@ export function renderOpusAnalysis(analysis: OpusAnalysis): string {
   const lines: string[] = [];
 
   lines.push("");
-  lines.push(chalk.bold.magenta("  Opus 4.6 Multi-Agent Security Analysis"));
+  lines.push(chalk.bold.magenta("  Claude Opus Multi-Agent Security Analysis"));
   lines.push(chalk.dim("  Three-perspective adversarial review"));
   lines.push("");
 
@@ -61,7 +61,7 @@ export function renderOpusAnalysis(analysis: OpusAnalysis): string {
   lines.push("");
 
   lines.push(chalk.dim("  ─────────────────────────────────────────"));
-  lines.push(chalk.dim("  Powered by Claude Opus 4.6 — three-agent adversarial analysis"));
+  lines.push(chalk.dim("  Powered by Claude Opus: three-agent adversarial analysis"));
   lines.push("");
 
   return lines.join("\n");
@@ -86,7 +86,7 @@ function renderInlineScore(score: number): string {
 export function renderOpusMarkdown(analysis: OpusAnalysis): string {
   const lines: string[] = [];
 
-  lines.push("## Opus 4.6 Multi-Agent Analysis");
+  lines.push("## Claude Opus Multi-Agent Analysis");
   lines.push("");
 
   lines.push("### Red Team (Attacker Perspective)");

--- a/tests/injection.test.ts
+++ b/tests/injection.test.ts
@@ -390,7 +390,7 @@ describe("Tester Internals", () => {
         id: "msg_123",
         type: "message" as const,
         role: "assistant" as const,
-        model: "claude-sonnet-4-5-20250929",
+        model: "claude-sonnet-5",
         content: [
           {
             type: "tool_use" as const,
@@ -441,7 +441,7 @@ describe("Tester Internals", () => {
         id: "msg_123",
         type: "message" as const,
         role: "assistant" as const,
-        model: "claude-sonnet-4-5-20250929",
+        model: "claude-sonnet-5",
         content: [
           {
             type: "text" as const,
@@ -469,7 +469,7 @@ describe("Tester Internals", () => {
         id: "msg_123",
         type: "message" as const,
         role: "assistant" as const,
-        model: "claude-sonnet-4-5-20250929",
+        model: "claude-sonnet-5",
         content: [
           {
             type: "tool_use" as const,
@@ -510,7 +510,7 @@ describe("Tester Internals", () => {
         id: "msg_123",
         type: "message" as const,
         role: "assistant" as const,
-        model: "claude-sonnet-4-5-20250929",
+        model: "claude-sonnet-5",
         content: [
           {
             type: "tool_use" as const,

--- a/tests/llm/client.test.ts
+++ b/tests/llm/client.test.ts
@@ -11,6 +11,11 @@ afterEach(() => {
 });
 
 describe("resolveModel", () => {
+  it("maps the current default models to their gateway ids", () => {
+    expect(resolveModel("orcarouter", "claude-opus-5")).toBe("anthropic/claude-opus-5");
+    expect(resolveModel("orcarouter", "claude-sonnet-5")).toBe("anthropic/claude-sonnet-5");
+  });
+
   it("returns the default model for the anthropic provider", () => {
     expect(resolveModel("anthropic", "claude-opus-4-6")).toBe("claude-opus-4-6");
     expect(resolveModel("anthropic", "claude-sonnet-4-5-20250929")).toBe(

--- a/tests/opus/render.test.ts
+++ b/tests/opus/render.test.ts
@@ -27,7 +27,7 @@ function makeAnalysis(overrides: Partial<OpusAnalysis> = {}): OpusAnalysis {
 describe("renderOpusAnalysis", () => {
   it("includes header", () => {
     const output = renderOpusAnalysis(makeAnalysis());
-    expect(output).toContain("Opus 4.6 Multi-Agent Security Analysis");
+    expect(output).toContain("Claude Opus Multi-Agent Security Analysis");
   });
 
   it("renders attacker findings", () => {
@@ -80,7 +80,7 @@ describe("renderOpusAnalysis", () => {
 describe("renderOpusMarkdown", () => {
   it("includes markdown heading", () => {
     const output = renderOpusMarkdown(makeAnalysis());
-    expect(output).toContain("## Opus 4.6 Multi-Agent Analysis");
+    expect(output).toContain("## Claude Opus Multi-Agent Analysis");
   });
 
   it("includes all three sections", () => {


### PR DESCRIPTION
The Opus pipeline now defaults to claude-opus-5 and the injection tester to claude-sonnet-5. The OrcaRouter model map covers the new ids and keeps the previous ones. CLI help, report headings, README, and CLAUDE.md no longer pin a model version. Tests updated. Full suite green locally apart from the two heading assertions, which are updated in this commit.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62562180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

What we checked:
- Ran contract-validation by posting to the OrcaRouter /v1/messages endpoint as Opus, defender, and auditor using the API-key header. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Performed the injection evaluation with Claude-Sonnet-5 against the same endpoint and parsed the mocked response using the report_injection_results tool. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated that the contract assertions completed successfully with exit code 0. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- This PR updates the AI-assisted analysis defaults to current Claude model identifiers and adds matching OrcaRouter model mappings. The updated Opus and injection requests were exercised with simulated provider responses and use the expected endpoint, authentication header, model identifiers, and injection tool contract.

<sub>Reviews (1) · Last reviewed commit: ["feat: move LLM analysis to current Claud..."](https://github.com/affaan-m/agentshield/commit/62ff15a6925bd87174e7a0c149fda82093f2c423)</sub>

<!-- /greptile_comment -->