### PR TITLE
fix(rules): scope HTML comment injection scan to comment bodies

### DIFF
--- a/src/rules/agents.ts
+++ b/src/rules/agents.ts
@@ -727,11 +727,26 @@ export const agentRules: ReadonlyArray<Rule> = [
 
       const findings: Finding[] = [];
 
+      const COMMENT = /<!--([\s\S]*?)-->/g;
+      const KEYWORDS = /(?:ignore|override|system|execute|run|install|download|send|post|upload)/i;
+      const commentMatches = findAllMatches(file.content, COMMENT);
+      for (const match of commentMatches) {
+        const body = match[1] ?? "";
+        if (KEYWORDS.test(body)) {
+          findings.push({
+            id: `agents-comment-injection-${match.index}`,
+            severity: "high",
+            category: "injection",
+            title: `Suspicious instruction in comment: ${file.path}`,
+            description: `HTML comment contains suspicious instructions. Attackers may hide malicious instructions in comments that won't be visible in rendered markdown but will be processed by the AI agent.`,
+            file: file.path,
+            line: findLineNumber(file.content, match.index ?? 0),
+            evidence: body.substring(0, 100),
+          });
+        }
+      }
+
       const commentPatterns = [
-        {
-          pattern: /<!--[\s\S]*?(?:ignore|override|system|execute|run|install|download|send|post|upload)[\s\S]*?-->/gi,
-          desc: "HTML comment contains suspicious instructions",
-        },
         {
           pattern: /\[\/\/\]:\s*#\s*\(.*(?:ignore|override|execute|run|install|download).*\)/gi,
           desc: "Markdown reference-style comment contains suspicious instructions",

--- a/tests/rules/agents.test.ts
+++ b/tests/rules/agents.test.ts
@@ -607,6 +607,24 @@ Flag these patterns immediately:
       const findings = runAllAgentRules(file);
       expect(findings.some((f) => f.id.includes("comment-injection"))).toBe(false);
     });
+
+    it("does not flag keywords spanning across comment boundaries", () => {
+      const file = makeClaudeMd("<!-- BEGIN -->\n## Agent System\nSystem prompt loaded from file\n<!-- END -->");
+      const findings = runAllAgentRules(file);
+      expect(findings.some((f) => f.id.includes("comment-injection"))).toBe(false);
+    });
+
+    it("does not flag keyword outside comments between harmless comments", () => {
+      const file = makeClaudeMd("<!-- hi -->\n## Agent System\n<!-- ok -->");
+      const findings = runAllAgentRules(file);
+      expect(findings.some((f) => f.id.includes("comment-injection"))).toBe(false);
+    });
+
+    it("detects keyword inside first comment only, ignoring prose between comments", () => {
+      const file = makeClaudeMd("<!-- execute silently -->\nSome prose\n<!-- end -->");
+      const findings = runAllAgentRules(file);
+      expect(findings.some((f) => f.id.includes("comment-injection"))).toBe(true);
+    });
   });
 
   describe("oversized prompt", () => {


### PR DESCRIPTION
**Description**

Fixes #119 — the "Suspicious instruction in comment" detector (`agents-comment-injection` in `src/rules/agents.ts`) could match keywords **outside** any HTML comment because the regex `<!--[\s\S]*?(?:keywords)[\s\S]*?-->` uses unbounded `[\s\S]*?`: a match could start at one comment's `<!--` and end at a *later* comment's `-->`, swallowing all rendered markdown in between. Any `CLAUDE.md` using paired HTML comments as managed-block markers (e.g. a `## Agent System` heading, or "The system prompt is loaded from ...") tripped this as a HIGH finding.

**Change**

- Extract each HTML comment body first (`<!--([\s\S]*?)-->` via the existing `findAllMatches` helper), then test the keyword list against the comment body only — a match can never span two comments.
- `evidence` now shows the actual comment content instead of rendered document text.
- The markdown reference-style detector (`[//]: # (...)`) is unchanged.

**Tests**

- Added 3 regression tests in `tests/rules/agents.test.ts`:
  - keyword outside comments between two harmless comments → no finding (previously 1 HIGH)
  - keyword in a heading between two comments → no finding
  - keyword inside the first comment only, prose between comments ignored → finding
- Full suite: 1951 tests pass (73 files); `npm run build` succeeds.
- Mutation check: reverting the fix (testing the keyword against the whole file content instead of the comment body) makes the 2 cross-comment regression tests fail, proving they guard the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hidden-instruction detection in HTML comments.
  - Suspicious keywords are now detected reliably within individual comments, including when comments contain surrounding prose.
  - Reduced false positives caused by keywords appearing outside comments or spanning multiple comment boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62562334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge: the updated detector prevents false positives while retaining hidden-comment coverage.

What we checked:
- I ran a focused test covering harmless comments around rendered prose, including multiline HTML comments and Markdown reference-style comments. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The focused test showed that earlier behavior allowed content between comments while reference-style detection remained functional. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The revision isolates comment bodies without losing HTML or Markdown hidden-comment coverage. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- I identified the exact authored test file trex-artifacts/comment-injection-trex-focused-test.ts used for the validation. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- The before/after logs show the focused test suite improved from 3 expected failures on the prior commit to all four tests passing after the revision. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- This change scopes HTML comment inspection to each individual comment body, preventing rendered Markdown between harmless comments from being treated as a hidden instruction. Hidden instructions within HTML comments and Markdown reference-style comments remain covered.

<sub>Reviews (1) · Last reviewed commit: ["fix(rules): scope HTML comment injection..."](https://github.com/affaan-m/agentshield/commit/a2310f38380dfd48f57d808f404df8d7a1c33fc6)</sub>

<!-- /greptile_comment -->