### PR TITLE
feat(reporter): recognized defenses summary, credited but never scored

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ JSON reports now expose `findings[].runtimeConfidence` when AgentShield can dist
 
 **102 rules** across 5 categories, graded A–F with a 0–100 numeric score.
 
+#### Scoring and recognized defenses
+
+The score starts at 100 per category and only findings deduct from it: critical 25, high 15, medium 5, low 2, info 0. Protective configuration the scanner finds (deny and ask lists, sandbox settings, blocking PreToolUse hooks, read-only agent tool lists, Codex `sandbox_mode`, Hermes manual approvals, and similar) is listed in every report under "Recognized Defenses" so it gets credit and is visibly never penalized. Defenses do not add points either: the score cannot be gamed by adding decorative deny rules, it can only be lowered by real findings. Guard-pattern findings the permission rules emit at info severity ("Deny/ask rule blocking ...", "Prohibition of ...", "Mention of ...") are enforced to a zero deduction in `src/reporter/score.ts`.
+
 ### Secrets Detection
 
 | What | Examples |
@@ -578,8 +582,18 @@ threads across reruns.
     "low": 10,
     "info": 3,
     "filesScanned": 17,
-    "autoFixable": 2
+    "autoFixable": 2,
+    "defenses": 4
   },
+  "defenses": [
+    {
+      "id": "defense-deny-list",
+      "title": "Permission deny list",
+      "file": ".claude/settings.json",
+      "detail": "6 deny rules; covers .env, ~/.ssh, curl, sudo, rm -rf. Deny wins over allow regardless of specificity.",
+      "harness": "claude-code"
+    }
+  ],
   "findings": [
     {
       "id": "mcp-risky-filesystem",
@@ -605,6 +619,7 @@ Notes:
 - `plugin-cache` means installed Claude plugin cache content such as `.claude/plugins/cache/...`.
 - `plugin-manifest` means declarative hook manifests such as `hooks/hooks.json`.
 - `hook-code` means a manifest-resolved non-shell implementation such as `scripts/hooks/session-start.js`.
+- Recognized defenses (`defenses[]` in JSON, "Recognized Defenses" in terminal and markdown) are credited, never penalized, and never add points.
 - Score weighting discounts non-secret `template-example` and `docs-example` findings to `0.25x`, non-secret `project-local-optional` findings to `0.75x`, and non-secret `plugin-cache` / `plugin-manifest` findings to `0.5x`; committed secrets still count at full weight. Non-secret `template-example` findings are also capped at `10` deduction points per file and score category. See [`false-positive-audit.md`](./false-positive-audit.md).
 
 ## API Reference

--- a/src/reporter/defenses.ts
+++ b/src/reporter/defenses.ts
@@ -1,0 +1,764 @@
+import { basename } from "node:path";
+import type { ConfigFile, Defense, DefenseHarness } from "../types.js";
+import {
+  parseFrontmatter,
+  parseJsonLenient,
+  parseTomlSafe,
+  parseYamlSafe,
+} from "../scanner/parsers.js";
+
+/**
+ * Recognized defenses: protective configuration the scanner found while
+ * reading the same files it audits. Defenses are listed for credit only.
+ * They never change the score in either direction, so a decorative deny
+ * rule cannot buy points and a real one is never mistaken for attack
+ * surface.
+ */
+
+export type { Defense, DefenseHarness };
+
+type JsonObject = Record<string, unknown>;
+
+const CONTAINER_BACKENDS = new Set(["docker", "singularity", "modal", "daytona"]);
+const READ_ONLY_TOOLS = new Set(["read", "grep", "glob"]);
+const MUTATING_TOOLS = new Set(["write", "edit", "bash", "multiedit", "notebookedit"]);
+const BLOCKING_HOOK_EVENTS = ["PreToolUse", "PermissionRequest", "UserPromptSubmit"] as const;
+
+const DENY_SIGNALS: ReadonlyArray<RegExp> = [
+  /\bexit\s+2\b/,
+  /process\.exit\(\s*2\s*\)/,
+  /sys\.exit\(\s*2\s*\)/,
+  /["']?permissionDecision["']?\s*:\s*["']deny["']/,
+  /["']decision["']\s*:\s*["']deny["']/,
+];
+
+const DENY_COVERAGE: ReadonlyArray<{ readonly label: string; readonly pattern: RegExp }> = [
+  { label: ".env", pattern: /\.env\b/i },
+  { label: "~/.ssh", pattern: /\.ssh\b/i },
+  { label: "curl", pattern: /\bcurl\b/i },
+  { label: "sudo", pattern: /\bsudo\b/i },
+  { label: "rm -rf", pattern: /\brm\s+-rf?\b/i },
+];
+
+/**
+ * Detect protective configuration across every discovered config file.
+ * Parsing is fail closed: a file that does not parse yields no defenses.
+ */
+export function detectDefenses(files: ReadonlyArray<ConfigFile>): ReadonlyArray<Defense> {
+  const defenses: Defense[] = [];
+  for (const file of files) {
+    defenses.push(...detectFileDefenses(file, files));
+  }
+  return defenses;
+}
+
+function detectFileDefenses(
+  file: ConfigFile,
+  allFiles: ReadonlyArray<ConfigFile>
+): ReadonlyArray<Defense> {
+  const path = normalizePath(file.path);
+  const name = basename(path);
+
+  if (isCursorHooks(path, name)) return detectCursorHooks(file);
+  if (isGeminiSettings(path, name)) return detectGemini(file);
+  if (isOpenCodeConfig(name)) return detectOpenCode(file);
+  if (isCodexRulesFile(name)) return detectCodexRules(file);
+  if (isCodexToml(file, name)) return detectCodex(file);
+  if (isHermesConfig(file, name)) return detectHermes(file);
+  if (file.type === "skill-md") return detectSkill(file);
+  if (file.type === "agent-md") return detectAgent(file);
+  if (isClaudeSettings(path, name)) return detectClaudeSettings(file, allFiles);
+  if (isHooksManifest(path, name)) {
+    const harness: DefenseHarness = path.includes(".codex/") ? "codex" : "claude-code";
+    const parsed = parseJsonLenient(file.content);
+    if (!parsed) return [];
+    return detectHookDefenses(file, parsed, allFiles, harness);
+  }
+  return [];
+}
+
+// ─── File classification ─────────────────────────────────────
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/").toLowerCase();
+}
+
+function underDir(path: string, dir: string): boolean {
+  return path.startsWith(`${dir}/`) || path.includes(`/${dir}/`);
+}
+
+function isCursorHooks(path: string, name: string): boolean {
+  return name === "hooks.json" && underDir(path, ".cursor");
+}
+
+function isGeminiSettings(path: string, name: string): boolean {
+  return name === "settings.json" && underDir(path, ".gemini");
+}
+
+function isOpenCodeConfig(name: string): boolean {
+  return name === "opencode.json" || name === "opencode.jsonc";
+}
+
+function isCodexRulesFile(name: string): boolean {
+  return name.endsWith(".rules");
+}
+
+function isCodexToml(file: ConfigFile, name: string): boolean {
+  return file.type === "codex-toml" || name === "config.toml";
+}
+
+function isHermesConfig(file: ConfigFile, name: string): boolean {
+  return file.type === "hermes-yaml" || name === "config.yaml" || name === "config.yml";
+}
+
+function isClaudeSettings(path: string, name: string): boolean {
+  if (underDir(path, ".gemini") || underDir(path, ".cursor") || underDir(path, ".zed") || underDir(path, ".vscode")) {
+    return false;
+  }
+  if (name === "settings.json" || name === "settings.local.json" || name === "managed-settings.json") {
+    return true;
+  }
+  return underDir(path, "managed-settings.d") && name.endsWith(".json");
+}
+
+function isHooksManifest(path: string, name: string): boolean {
+  return name === "hooks.json" && !underDir(path, ".cursor");
+}
+
+// ─── Claude Code settings ────────────────────────────────────
+
+function detectClaudeSettings(
+  file: ConfigFile,
+  allFiles: ReadonlyArray<ConfigFile>
+): ReadonlyArray<Defense> {
+  const settings = parseJsonLenient(file.content);
+  if (!settings) return [];
+
+  const defenses: Defense[] = [];
+  const harness: DefenseHarness = "claude-code";
+  const make = (id: string, title: string, detail: string): Defense => ({
+    id,
+    title,
+    file: file.path,
+    detail,
+    harness,
+  });
+
+  const permissions = asObject(settings.permissions);
+  const deny = asStringArray(permissions?.deny);
+  if (deny.length > 0) {
+    const covered = DENY_COVERAGE.filter((entry) => deny.some((rule) => entry.pattern.test(rule)));
+    const missing = DENY_COVERAGE.filter((entry) => !covered.includes(entry));
+    const coverage =
+      covered.length > 0 ? `covers ${covered.map((c) => c.label).join(", ")}` : "covers none of the common targets";
+    const gap = missing.length > 0 ? `; not covered: ${missing.map((m) => m.label).join(", ")}` : "";
+    defenses.push(
+      make(
+        "defense-deny-list",
+        "Permission deny list",
+        `${deny.length} deny ${deny.length === 1 ? "rule" : "rules"}; ${coverage}${gap}. Deny wins over allow regardless of specificity.`
+      )
+    );
+  }
+
+  const ask = asStringArray(permissions?.ask);
+  if (ask.length > 0) {
+    defenses.push(
+      make(
+        "defense-ask-list",
+        "Permission ask list",
+        `${ask.length} ask ${ask.length === 1 ? "rule prompts" : "rules prompt"} before matching tool calls: ${ask.slice(0, 5).join(", ")}${ask.length > 5 ? ", ..." : ""}`
+      )
+    );
+  }
+
+  const defaultMode = permissions?.defaultMode;
+  if (defaultMode === "plan" || defaultMode === "default") {
+    defenses.push(
+      make(
+        "defense-default-mode",
+        `Permission mode "${defaultMode}"`,
+        defaultMode === "plan"
+          ? "Plan mode: the agent reads and proposes, edits and commands still need approval."
+          : "Default mode: every tool call outside the allow list prompts."
+      )
+    );
+  }
+
+  if (permissions?.disableBypassPermissionsMode === "disable") {
+    defenses.push(
+      make(
+        "defense-bypass-disabled",
+        "Bypass permissions mode disabled",
+        "disableBypassPermissionsMode is set to disable, so --dangerously-skip-permissions cannot be used from this layer down."
+      )
+    );
+  }
+
+  if (permissions?.blockReadsOutsideWorkingDirectories === true) {
+    defenses.push(
+      make(
+        "defense-block-reads-outside-cwd",
+        "Reads outside working directories blocked",
+        "blockReadsOutsideWorkingDirectories is true, so Read cannot reach files outside the configured working directories."
+      )
+    );
+  }
+
+  const sandbox = asObject(settings.sandbox);
+  if (sandbox?.enabled === true) {
+    defenses.push(make("defense-sandbox-enabled", "Sandbox enabled", describeSandbox(sandbox)));
+  }
+
+  const managedFlags: ReadonlyArray<{ readonly key: string; readonly id: string; readonly title: string; readonly detail: string }> = [
+    {
+      key: "allowManagedPermissionRulesOnly",
+      id: "defense-managed-permission-rules-only",
+      title: "Only managed permission rules honored",
+      detail: "allowManagedPermissionRulesOnly is true, so user and project permission rules are ignored.",
+    },
+    {
+      key: "allowManagedHooksOnly",
+      id: "defense-managed-hooks-only",
+      title: "Only managed hooks honored",
+      detail: "allowManagedHooksOnly is true, so hooks from user, project, and plugin scopes do not run.",
+    },
+    {
+      key: "allowManagedMcpServersOnly",
+      id: "defense-managed-mcp-servers-only",
+      title: "Only managed MCP servers honored",
+      detail: "allowManagedMcpServersOnly is true, so project and user MCP servers are not loaded.",
+    },
+    {
+      key: "strictKnownMarketplaces",
+      id: "defense-strict-marketplaces",
+      title: "Plugin marketplaces restricted",
+      detail: "strictKnownMarketplaces is true, so plugins install only from the known marketplace list.",
+    },
+    {
+      key: "disableSkillShellExecution",
+      id: "defense-skill-shell-disabled",
+      title: "Skill shell execution disabled",
+      detail: "disableSkillShellExecution is true, so !`...` blocks in skills never run.",
+    },
+  ];
+  for (const flag of managedFlags) {
+    if (settings[flag.key] === true) {
+      defenses.push(make(flag.id, flag.title, flag.detail));
+    }
+  }
+
+  const enabledServers = asStringArray(settings.enabledMcpjsonServers);
+  if (enabledServers.length > 0 && settings.enableAllProjectMcpServers !== true) {
+    defenses.push(
+      make(
+        "defense-explicit-mcp-servers",
+        "Explicit MCP server allow list",
+        `enabledMcpjsonServers names ${enabledServers.length} ${enabledServers.length === 1 ? "server" : "servers"} (${enabledServers.join(", ")}) instead of enabling every project server.`
+      )
+    );
+  }
+
+  defenses.push(...detectHookDefenses(file, settings, allFiles, harness));
+  return defenses;
+}
+
+function describeSandbox(sandbox: JsonObject): string {
+  const extras: string[] = [];
+  if (sandbox.failIfUnavailable === true) extras.push("fails closed when the sandbox is unavailable");
+
+  const network = asObject(sandbox.network);
+  const allowedDomains = asStringArray(network?.allowedDomains);
+  if (allowedDomains.length > 0 && !allowedDomains.some((domain) => domain.includes("*"))) {
+    extras.push(`network allow list of ${allowedDomains.length} ${allowedDomains.length === 1 ? "domain" : "domains"} with no wildcard`);
+  }
+
+  const filesystem = asObject(sandbox.filesystem);
+  const denyRead = asStringArray(filesystem?.denyRead);
+  if (denyRead.length > 0) {
+    extras.push(`filesystem denyRead on ${denyRead.join(", ")}`);
+  }
+
+  const credentials = asObject(sandbox.credentials);
+  const credentialModes = credentialModesOf(credentials);
+  if (credentialModes.length > 0) {
+    extras.push(`credentials ${credentialModes.join(" and ")}`);
+  }
+
+  return extras.length > 0
+    ? `sandbox.enabled is true; ${extras.join("; ")}.`
+    : "sandbox.enabled is true with default network and filesystem policy.";
+}
+
+function credentialModesOf(credentials: JsonObject | null): ReadonlyArray<string> {
+  if (!credentials) return [];
+  const modes = new Set<string>();
+  const candidates = [credentials, asObject(credentials.files), asObject(credentials.envVars)];
+  for (const candidate of candidates) {
+    const mode = candidate?.mode;
+    if (mode === "mask" || mode === "deny") modes.add(mode === "mask" ? "masked" : "denied");
+  }
+  return [...modes];
+}
+
+// ─── Hooks (Claude Code and Codex hooks.json) ────────────────
+
+interface HookCommand {
+  readonly event: string;
+  readonly command: string;
+}
+
+function detectHookDefenses(
+  file: ConfigFile,
+  settings: JsonObject,
+  allFiles: ReadonlyArray<ConfigFile>,
+  harness: DefenseHarness
+): ReadonlyArray<Defense> {
+  const hooks = asObject(settings.hooks);
+  if (!hooks) return [];
+
+  const defenses: Defense[] = [];
+  for (const event of BLOCKING_HOOK_EVENTS) {
+    const commands = hookCommandsFor(hooks, event);
+    const blocking = commands.filter((hook) => hookHasDenySignal(hook.command, allFiles));
+    if (blocking.length === 0) continue;
+    defenses.push({
+      id: `defense-blocking-${event.toLowerCase()}-hook`,
+      title: `Blocking ${event} hook`,
+      file: file.path,
+      detail: `${blocking.length} ${event} command ${blocking.length === 1 ? "hook" : "hooks"} can deny a call (exit 2 or a deny decision): ${blocking.map((hook) => truncate(hook.command, 60)).join("; ")}`,
+      harness,
+    });
+  }
+
+  const configChange = hookCommandsFor(hooks, "ConfigChange");
+  if (configChange.length > 0) {
+    defenses.push({
+      id: "defense-configchange-hook",
+      title: "ConfigChange hook",
+      file: file.path,
+      detail: `${configChange.length} ConfigChange ${configChange.length === 1 ? "hook watches" : "hooks watch"} settings edits during the session: ${configChange.map((hook) => truncate(hook.command, 60)).join("; ")}`,
+      harness,
+    });
+  }
+
+  return defenses;
+}
+
+function hookCommandsFor(hooks: JsonObject, event: string): ReadonlyArray<HookCommand> {
+  const entries = hooks[event];
+  if (!Array.isArray(entries)) return [];
+  const commands: HookCommand[] = [];
+  for (const entry of entries) {
+    const record = asObject(entry);
+    if (!record) continue;
+    if (typeof record.command === "string") commands.push({ event, command: record.command });
+    if (typeof record.hook === "string") commands.push({ event, command: record.hook });
+    if (Array.isArray(record.hooks)) {
+      for (const nested of record.hooks) {
+        const hook = asObject(nested);
+        if (hook && typeof hook.command === "string" && (hook.type === undefined || hook.type === "command")) {
+          commands.push({ event, command: hook.command });
+        }
+      }
+    }
+  }
+  return commands;
+}
+
+function hookHasDenySignal(command: string, allFiles: ReadonlyArray<ConfigFile>): boolean {
+  if (containsDenySignal(command)) return true;
+  for (const script of referencedScripts(command, allFiles)) {
+    if (containsDenySignal(script.content)) return true;
+  }
+  return false;
+}
+
+function containsDenySignal(text: string): boolean {
+  return DENY_SIGNALS.some((signal) => signal.test(text));
+}
+
+/**
+ * Resolve script files a hook command points at. Tokens are matched by
+ * trailing path segments so `$CLAUDE_PROJECT_DIR/.claude/hooks/guard.sh`
+ * and `bash ./hooks/guard.sh` both find `.claude/hooks/guard.sh`.
+ */
+function referencedScripts(
+  command: string,
+  allFiles: ReadonlyArray<ConfigFile>
+): ReadonlyArray<ConfigFile> {
+  const tokens = command
+    .split(/[\s;&|]+/)
+    .map((token) => token.replace(/^["']+|["']+$/g, ""))
+    .map((token) => token.replace(/^\$\{?[A-Z_]+\}?\/?/, "").replace(/^\.\//, ""))
+    .filter((token) => /\.[a-z0-9]+$/i.test(token) && !token.startsWith("-"));
+
+  const matches: ConfigFile[] = [];
+  for (const token of tokens) {
+    const suffix = normalizePath(token);
+    for (const file of allFiles) {
+      const path = normalizePath(file.path);
+      if (path === suffix || path.endsWith(`/${suffix}`)) {
+        if (!matches.includes(file)) matches.push(file);
+      }
+    }
+  }
+  return matches;
+}
+
+// ─── Skills and agents ───────────────────────────────────────
+
+function detectSkill(file: ConfigFile): ReadonlyArray<Defense> {
+  const frontmatter = parseSkillOrAgentMetadata(file);
+  if (!frontmatter) return [];
+
+  const defenses: Defense[] = [];
+  if (frontmatter["disable-model-invocation"] === true) {
+    defenses.push({
+      id: "defense-skill-no-model-invocation",
+      title: "Skill cannot be invoked by the model",
+      file: file.path,
+      detail: "disable-model-invocation is true, so only the user can trigger this skill.",
+      harness: "claude-code",
+    });
+  }
+
+  const allowedTools = toolList(frontmatter["allowed-tools"] ?? frontmatter.allowedTools);
+  if (allowedTools.length > 0 && allowedTools.every(isNarrowTool)) {
+    defenses.push({
+      id: "defense-skill-narrow-tools",
+      title: "Skill limited to narrow tools",
+      file: file.path,
+      detail: `allowed-tools is restricted to ${allowedTools.join(", ")}.`,
+      harness: "claude-code",
+    });
+  }
+  return defenses;
+}
+
+function detectAgent(file: ConfigFile): ReadonlyArray<Defense> {
+  const metadata = parseSkillOrAgentMetadata(file);
+  if (!metadata) return [];
+
+  const defenses: Defense[] = [];
+  const toolsValue = metadata.tools ?? metadata.allowedTools ?? metadata["allowed-tools"];
+  const tools = toolList(toolsValue);
+  if (tools.length > 0 && !tools.some((tool) => MUTATING_TOOLS.has(toolName(tool)))) {
+    defenses.push({
+      id: "defense-agent-tools-allowlist",
+      title: "Agent tool allow list without Write, Edit, or Bash",
+      file: file.path,
+      detail: `tools is limited to ${tools.join(", ")}.`,
+      harness: "claude-code",
+    });
+  }
+
+  const disallowed = toolList(metadata.disallowedTools ?? metadata["disallowed-tools"]);
+  if (disallowed.length > 0) {
+    defenses.push({
+      id: "defense-agent-disallowed-tools",
+      title: "Agent disallowed tools",
+      file: file.path,
+      detail: `disallowedTools blocks ${disallowed.join(", ")}.`,
+      harness: "claude-code",
+    });
+  }
+  return defenses;
+}
+
+function parseSkillOrAgentMetadata(file: ConfigFile): JsonObject | null {
+  if (file.path.toLowerCase().endsWith(".json")) return parseJsonLenient(file.content);
+  return parseFrontmatter(file.content);
+}
+
+function toolList(value: unknown): ReadonlyArray<string> {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string").map((item) => item.trim()).filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return splitToolString(value);
+  }
+  return [];
+}
+
+/** Split "Read, Grep, Bash(git add *)" without breaking inside parentheses. */
+function splitToolString(value: string): ReadonlyArray<string> {
+  const tools: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of value) {
+    if (ch === "(") depth += 1;
+    if (ch === ")") depth = Math.max(0, depth - 1);
+    if ((ch === "," || /\s/.test(ch)) && depth === 0) {
+      if (current.trim()) tools.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) tools.push(current.trim());
+  return tools;
+}
+
+function toolName(tool: string): string {
+  return tool.replace(/\(.*$/, "").trim().toLowerCase();
+}
+
+function isNarrowTool(tool: string): boolean {
+  const name = toolName(tool);
+  if (READ_ONLY_TOOLS.has(name)) return true;
+  if (name !== "bash") return false;
+  const scoped = /^bash\(([^)]*)\)$/i.exec(tool.trim());
+  if (!scoped) return false;
+  const inner = scoped[1].trim();
+  return inner.length > 0 && inner !== "*" && !inner.startsWith("*");
+}
+
+// ─── Codex ───────────────────────────────────────────────────
+
+function detectCodex(file: ConfigFile): ReadonlyArray<Defense> {
+  const config = parseTomlSafe(file.content);
+  if (!config) return [];
+
+  const defenses: Defense[] = [];
+  const sandboxMode = config.sandbox_mode;
+  if (sandboxMode === "read-only") {
+    defenses.push({
+      id: "defense-codex-sandbox",
+      title: "Codex sandbox read-only",
+      file: file.path,
+      detail: "sandbox_mode is read-only, so the agent cannot write files or reach the network.",
+      harness: "codex",
+    });
+  } else if (sandboxMode === "workspace-write") {
+    const workspace = asObject(config.sandbox_workspace_write);
+    if (workspace?.network_access !== true) {
+      defenses.push({
+        id: "defense-codex-sandbox",
+        title: "Codex sandbox workspace-write without network",
+        file: file.path,
+        detail:
+          workspace?.network_access === false
+            ? "sandbox_mode is workspace-write and network_access is false."
+            : "sandbox_mode is workspace-write and network_access is unset (defaults to false).",
+        harness: "codex",
+      });
+    }
+  }
+
+  const approval = config.approval_policy;
+  if (approval === "on-request" || approval === "on-failure") {
+    defenses.push({
+      id: "defense-codex-approval-policy",
+      title: `Codex approval policy "${approval}"`,
+      file: file.path,
+      detail: `approval_policy is ${approval}, so escalations outside the sandbox prompt the user.`,
+      harness: "codex",
+    });
+  }
+
+  const headerOwners = findKeyOwners(config, "env_http_headers");
+  if (headerOwners.length > 0) {
+    defenses.push({
+      id: "defense-codex-env-http-headers",
+      title: "Codex MCP headers sourced from environment",
+      file: file.path,
+      detail: `env_http_headers is used ${headerOwners.length === 1 ? "once" : `${headerOwners.length} times`} instead of literal http_headers.`,
+      harness: "codex",
+    });
+  }
+  return defenses;
+}
+
+function detectCodexRules(file: ConfigFile): ReadonlyArray<Defense> {
+  const decisions = [...file.content.matchAll(/decision\s*=\s*["'](forbidden|prompt)["']/g)];
+  if (decisions.length === 0) return [];
+  const forbidden = decisions.filter((match) => match[1] === "forbidden").length;
+  const prompt = decisions.length - forbidden;
+  return [
+    {
+      id: "defense-codex-rules-file",
+      title: "Codex exec policy rules",
+      file: file.path,
+      detail: `${forbidden} forbidden and ${prompt} prompt ${decisions.length === 1 ? "decision" : "decisions"} gate command prefixes.`,
+      harness: "codex",
+    },
+  ];
+}
+
+// ─── Hermes ──────────────────────────────────────────────────
+
+function detectHermes(file: ConfigFile): ReadonlyArray<Defense> {
+  const config = parseYamlSafe(file.content);
+  if (!config) return [];
+
+  const defenses: Defense[] = [];
+  const approvals = asObject(config.approvals);
+  if (approvals?.mode === "manual") {
+    defenses.push({
+      id: "defense-hermes-manual-approvals",
+      title: "Hermes approvals manual",
+      file: file.path,
+      detail: "approvals.mode is manual, so every gated action waits for a human.",
+      harness: "hermes",
+    });
+  }
+  if (approvals?.cron_mode === "deny") {
+    defenses.push({
+      id: "defense-hermes-cron-deny",
+      title: "Hermes cron approvals denied",
+      file: file.path,
+      detail: "approvals.cron_mode is deny, so unattended jobs cannot self-approve.",
+      harness: "hermes",
+    });
+  }
+
+  const terminal = asObject(config.terminal);
+  const backend = typeof terminal?.backend === "string" ? terminal.backend.toLowerCase() : "";
+  if (CONTAINER_BACKENDS.has(backend)) {
+    defenses.push({
+      id: "defense-hermes-container-terminal",
+      title: `Hermes terminal runs in ${backend}`,
+      file: file.path,
+      detail: `terminal.backend is ${backend}, so shell commands execute inside a container.`,
+      harness: "hermes",
+    });
+  }
+
+  const allowlistOwners = findKeyOwners(config, "command_allowlist");
+  const emptyAllowlist = allowlistOwners.some(
+    (owner) => Array.isArray(owner.command_allowlist) && owner.command_allowlist.length === 0
+  );
+  if (emptyAllowlist) {
+    defenses.push({
+      id: "defense-hermes-empty-allowlist",
+      title: "Hermes command allow list empty",
+      file: file.path,
+      detail: "command_allowlist is empty, so no command is pre-approved.",
+      harness: "hermes",
+    });
+  }
+  return defenses;
+}
+
+// ─── Gemini ──────────────────────────────────────────────────
+
+function detectGemini(file: ConfigFile): ReadonlyArray<Defense> {
+  const settings = parseJsonLenient(file.content);
+  if (!settings) return [];
+
+  const defenses: Defense[] = [];
+  const security = asObject(settings.security);
+  if (security?.disableYoloMode === true) {
+    defenses.push({
+      id: "defense-gemini-yolo-disabled",
+      title: "Gemini YOLO mode disabled",
+      file: file.path,
+      detail: "security.disableYoloMode is true, so auto-approval of every tool call cannot be turned on.",
+      harness: "gemini",
+    });
+  }
+  const folderTrust = asObject(security?.folderTrust);
+  if (folderTrust?.enabled === true) {
+    defenses.push({
+      id: "defense-gemini-folder-trust",
+      title: "Gemini folder trust enabled",
+      file: file.path,
+      detail: "security.folderTrust.enabled is true, so untrusted folders run with reduced capabilities.",
+      harness: "gemini",
+    });
+  }
+  return defenses;
+}
+
+// ─── OpenCode ────────────────────────────────────────────────
+
+function detectOpenCode(file: ConfigFile): ReadonlyArray<Defense> {
+  const config = parseJsonLenient(file.content);
+  if (!config) return [];
+
+  const permission = asObject(config.permission);
+  const bash = permission?.bash;
+  const gated = isGatedPermission(bash);
+  if (!gated) return [];
+
+  const description = typeof bash === "string" ? bash : "ask or deny for every pattern";
+  return [
+    {
+      id: "defense-opencode-bash-gate",
+      title: "OpenCode bash permission gated",
+      file: file.path,
+      detail: `permission.bash is ${description}, so shell commands are not auto-approved.`,
+      harness: "opencode",
+    },
+  ];
+}
+
+function isGatedPermission(value: unknown): boolean {
+  if (value === "ask" || value === "deny") return true;
+  const map = asObject(value);
+  if (!map) return false;
+  const entries = Object.values(map);
+  return entries.length > 0 && entries.every((entry) => entry === "ask" || entry === "deny");
+}
+
+// ─── Cursor ──────────────────────────────────────────────────
+
+function detectCursorHooks(file: ConfigFile): ReadonlyArray<Defense> {
+  const config = parseJsonLenient(file.content);
+  if (!config) return [];
+  const hooks = asObject(config.hooks);
+  if (!hooks) return [];
+
+  const events: string[] = [];
+  for (const [event, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) continue;
+    if (entries.some((entry) => asObject(entry)?.failClosed === true)) events.push(event);
+  }
+  if (events.length === 0) return [];
+
+  return [
+    {
+      id: "defense-cursor-fail-closed-hook",
+      title: "Cursor hooks fail closed",
+      file: file.path,
+      detail: `failClosed is true on ${events.join(", ")}, so a crashed guard blocks instead of allowing.`,
+      harness: "cursor",
+    },
+  ];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────
+
+function asObject(value: unknown): JsonObject | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonObject) : null;
+}
+
+function asStringArray(value: unknown): ReadonlyArray<string> {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+/** Every object in the tree that owns the given key. */
+function findKeyOwners(root: JsonObject, key: string): ReadonlyArray<JsonObject> {
+  const owners: JsonObject[] = [];
+  const visit = (node: unknown, depth: number): void => {
+    if (depth > 8) return;
+    const record = asObject(node);
+    if (!record) return;
+    if (key in record) owners.push(record);
+    for (const child of Object.values(record)) {
+      if (Array.isArray(child)) {
+        for (const item of child) visit(item, depth + 1);
+      } else {
+        visit(child, depth + 1);
+      }
+    }
+  };
+  visit(root, 0);
+  return owners;
+}
+
+function truncate(text: string, max: number): string {
+  const single = text.replace(/\s+/g, " ").trim();
+  return single.length > max ? `${single.slice(0, max - 3)}...` : single;
+}

--- a/src/reporter/html.ts
+++ b/src/reporter/html.ts
@@ -57,6 +57,7 @@ export function renderHtmlReport(report: SecurityReport): string {
         ${renderStatCard("Medium", String(s.medium), "medium")}
         ${renderStatCard("Low", String(s.low), "low")}
         ${renderStatCard("Info", String(s.info), "info")}
+        ${renderStatCard("Defenses", String(s.defenses), "fixable")}
       </div>
     </section>
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -1,4 +1,5 @@
-export { calculateScore } from "./score.js";
+export { calculateScore, deductionFor, isNonPenalizingFinding } from "./score.js";
+export { detectDefenses } from "./defenses.js";
 export { renderTerminalReport } from "./terminal.js";
 export { renderJsonReport, renderMarkdownReport } from "./json.js";
 export { renderHtmlReport } from "./html.js";

--- a/src/reporter/json.ts
+++ b/src/reporter/json.ts
@@ -22,6 +22,10 @@ function formatRuntimeConfidence(value: string): string {
   }
 }
 
+function escapeTableCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
 /**
  * Render a security report as formatted JSON.
  */
@@ -56,6 +60,7 @@ export function renderMarkdownReport(report: SecurityReport): string {
   lines.push(`| Low | ${s.low} |`);
   lines.push(`| Info | ${s.info} |`);
   lines.push(`| Auto-fixable | ${s.autoFixable} |`);
+  lines.push(`| Recognized defenses | ${s.defenses} |`);
   lines.push("");
 
   if (report.harnessAdapters) {
@@ -111,6 +116,21 @@ export function renderMarkdownReport(report: SecurityReport): string {
     lines.push(`| ${label} | ${score}/100 |`);
   }
   lines.push("");
+
+  if (report.defenses.length > 0) {
+    lines.push("## Recognized Defenses");
+    lines.push("");
+    lines.push("Protective configuration found during the scan. Defenses are credited here, never penalized, and never add points.");
+    lines.push("");
+    lines.push("| Defense | File | Harness | Detail |");
+    lines.push("|---------|------|---------|--------|");
+    for (const defense of report.defenses) {
+      lines.push(
+        `| ${escapeTableCell(defense.title)} | \`${escapeTableCell(defense.file)}\` | ${defense.harness} | ${escapeTableCell(defense.detail)} |`
+      );
+    }
+    lines.push("");
+  }
 
   // Findings
   if (report.findings.length > 0) {

--- a/src/reporter/score.ts
+++ b/src/reporter/score.ts
@@ -1,5 +1,6 @@
 import type { Finding, Grade, ReportSummary, SecurityReport, SecurityScore, ScoreBreakdown } from "../types.js";
 import type { ScanResult } from "../scanner/index.js";
+import { detectDefenses } from "./defenses.js";
 
 const SCORE_DEDUCTIONS: Record<string, number> = {
   critical: 25,
@@ -12,12 +13,53 @@ const SCORE_DEDUCTIONS: Record<string, number> = {
 const TEMPLATE_EXAMPLE_CATEGORY_CAP = 10;
 
 /**
+ * Titles the permission rules use for guard patterns they surface at info
+ * severity. These describe protective config and must never cost points.
+ */
+export const GUARD_PATTERN_TITLE_PREFIXES: ReadonlyArray<string> = [
+  "Guard pattern:",
+  "Deny/ask rule blocking",
+  "Prohibition of",
+  "Mention of",
+  "Example config:",
+];
+
+/**
+ * True when a finding is informational or a recognized guard pattern.
+ * Such findings are listed in reports but contribute zero deduction.
+ */
+export function isNonPenalizingFinding(finding: Finding): boolean {
+  if (finding.severity === "info") return true;
+  // Guard-pattern findings are emitted at info severity. Any other severity
+  // on a guard title is a rule bug, and the finding is still scored so the
+  // bug stays visible instead of silently masking a real deduction.
+  return false;
+}
+
+/** True when the title marks a guard pattern the permission rules credit. */
+export function isGuardPatternFinding(finding: Finding): boolean {
+  return GUARD_PATTERN_TITLE_PREFIXES.some((prefix) => finding.title.startsWith(prefix));
+}
+
+/**
+ * Deduction a single finding contributes before category capping. This is
+ * the one place severity turns into points, so the zero-deduction guarantee
+ * for info and guard-pattern findings lives here and is unit tested.
+ */
+export function deductionFor(finding: Finding): number {
+  if (isNonPenalizingFinding(finding)) return 0;
+  const deduction = (SCORE_DEDUCTIONS[finding.severity] ?? 0) * confidenceWeight(finding);
+  return deduction > 0 ? deduction : 0;
+}
+
+/**
  * Calculate security score from findings.
  * Score starts at 100 and deducts based on severity.
  */
 export function calculateScore(result: ScanResult): SecurityReport {
   const { findings, target, skillHealth, harnessAdapters } = result;
-  const summary = summarizeFindings(findings, target.files.length);
+  const defenses = detectDefenses(target.files);
+  const summary = summarizeFindings(findings, target.files.length, defenses.length);
   const score = computeScore(findings);
 
   return {
@@ -26,6 +68,7 @@ export function calculateScore(result: ScanResult): SecurityReport {
     findings,
     score,
     summary,
+    defenses,
     harnessAdapters,
     skillHealth,
   };
@@ -33,7 +76,8 @@ export function calculateScore(result: ScanResult): SecurityReport {
 
 function summarizeFindings(
   findings: ReadonlyArray<Finding>,
-  filesScanned: number
+  filesScanned: number,
+  defenses: number
 ): ReportSummary {
   const autoFixable = findings.filter((f) => f.fix?.auto).length;
 
@@ -46,6 +90,7 @@ function summarizeFindings(
     info: findings.filter((f) => f.severity === "info").length,
     filesScanned,
     autoFixable,
+    defenses,
   };
 }
 
@@ -61,7 +106,8 @@ function computeScore(findings: ReadonlyArray<Finding>): SecurityScore {
 
   for (const finding of findings) {
     const scoreCategory = mapToScoreCategory(finding.category);
-    const deduction = (SCORE_DEDUCTIONS[finding.severity] ?? 0) * confidenceWeight(finding);
+    const deduction = deductionFor(finding);
+    if (deduction === 0) continue;
 
     if (isTemplateInventoryFinding(finding)) {
       const templateKey = `${scoreCategory}:${finding.file}`;

--- a/src/reporter/terminal.ts
+++ b/src/reporter/terminal.ts
@@ -1,5 +1,6 @@
 import chalk from "chalk";
 import type {
+  Defense,
   Finding,
   SecurityReport,
   RuntimeConfidence,
@@ -37,6 +38,8 @@ export function renderTerminalReport(report: SecurityReport): string {
   lines.push(renderBar("MCP Servers", report.score.breakdown.mcp));
   lines.push(renderBar("Agents", report.score.breakdown.agents));
   lines.push("");
+
+  lines.push(...renderDefenses(report.defenses));
 
   if (report.harnessAdapters) {
     lines.push(chalk.bold("  Harness Adapters"));
@@ -539,6 +542,22 @@ export function renderDeepScanSummary(result: DeepScanResult): string {
 }
 
 // ─── Internal Helpers ─────────────────────────────────────────
+
+const MAX_LISTED_DEFENSES = 12;
+
+function renderDefenses(defenses: ReadonlyArray<Defense>): ReadonlyArray<string> {
+  if (defenses.length === 0) return [];
+  const lines: string[] = [];
+  lines.push(chalk.bold("  Recognized Defenses") + chalk.dim(` (${defenses.length}, listed for credit, never scored)`));
+  for (const defense of defenses.slice(0, MAX_LISTED_DEFENSES)) {
+    lines.push(chalk.dim(`  ${chalk.green("✓")} ${defense.title}  ${defense.file}`));
+  }
+  if (defenses.length > MAX_LISTED_DEFENSES) {
+    lines.push(chalk.dim(`    ${defenses.length - MAX_LISTED_DEFENSES} more`));
+  }
+  lines.push("");
+  return lines;
+}
 
 function renderGrade(grade: string, score: number): string {
   const gradeColors: Record<string, typeof chalk.green> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,7 @@ export interface SecurityReport {
   readonly findings: ReadonlyArray<Finding>;
   readonly score: SecurityScore;
   readonly summary: ReportSummary;
+  readonly defenses: ReadonlyArray<Defense>;
   readonly harnessAdapters?: HarnessAdapterSummary;
   readonly skillHealth?: SkillHealthSummary;
 }
@@ -172,6 +173,30 @@ export interface ReportSummary {
   readonly info: number;
   readonly filesScanned: number;
   readonly autoFixable: number;
+  readonly defenses: number;
+}
+
+// ─── Recognized Defenses ───────────────────────────────────
+
+export type DefenseHarness =
+  | "claude-code"
+  | "codex"
+  | "hermes"
+  | "gemini"
+  | "opencode"
+  | "cursor"
+  | "generic";
+
+/**
+ * Protective configuration found during a scan. Listed for credit only:
+ * defenses never change the score in either direction.
+ */
+export interface Defense {
+  readonly id: string;
+  readonly title: string;
+  readonly file: string;
+  readonly detail: string;
+  readonly harness: DefenseHarness;
 }
 
 // ─── Harness Adapter Discovery ─────────────────────────────

--- a/tests/evidence-pack/evidence-pack.test.ts
+++ b/tests/evidence-pack/evidence-pack.test.ts
@@ -34,6 +34,7 @@ function makeReport(targetPath: string): SecurityReport {
         evidence: "sk-1234567890abcdef",
       },
     ],
+    defenses: [],
     score: {
       grade: "C",
       numericScore: 72,
@@ -54,6 +55,7 @@ function makeReport(targetPath: string): SecurityReport {
       info: 0,
       filesScanned: 1,
       autoFixable: 0,
+      defenses: 0,
     },
   };
 }
@@ -144,6 +146,7 @@ function makeCleanReport(targetPath: string): SecurityReport {
   return {
     ...report,
     findings: [],
+    defenses: [],
     score: {
       ...report.score,
       grade: "A",
@@ -158,6 +161,7 @@ function makeCleanReport(targetPath: string): SecurityReport {
       info: 0,
       filesScanned: 1,
       autoFixable: 0,
+      defenses: 0,
     },
   };
 }

--- a/tests/fixer/remediation-plan.test.ts
+++ b/tests/fixer/remediation-plan.test.ts
@@ -36,6 +36,7 @@ function makeReport(findings: ReadonlyArray<Finding>): SecurityReport {
     timestamp: "2026-05-13T09:10:00.000Z",
     targetPath: "/repo",
     findings,
+    defenses: [],
     score: {
       grade: "C",
       numericScore: 72,
@@ -50,6 +51,7 @@ function makeReport(findings: ReadonlyArray<Finding>): SecurityReport {
       info: findings.filter((finding) => finding.severity === "info").length,
       filesScanned: 1,
       autoFixable: findings.filter((finding) => finding.fix?.auto).length,
+      defenses: 0,
     },
   };
 }

--- a/tests/reporter/defenses.test.ts
+++ b/tests/reporter/defenses.test.ts
@@ -1,0 +1,706 @@
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectDefenses } from "../../src/reporter/defenses.js";
+import { calculateScore } from "../../src/reporter/score.js";
+import { renderTerminalReport } from "../../src/reporter/terminal.js";
+import { renderJsonReport, renderMarkdownReport } from "../../src/reporter/json.js";
+import { renderHtmlReport } from "../../src/reporter/html.js";
+import { scan } from "../../src/scanner/index.js";
+import type { ConfigFile, ConfigFileType, Defense, SecurityReport } from "../../src/types.js";
+
+function file(path: string, content: string, type: ConfigFileType = "settings-json"): ConfigFile {
+  return { path, type, content };
+}
+
+function settings(body: Record<string, unknown>, path = ".claude/settings.json"): ConfigFile {
+  return file(path, JSON.stringify(body, null, 2));
+}
+
+function ids(defenses: ReadonlyArray<Defense>): ReadonlyArray<string> {
+  return defenses.map((defense) => defense.id);
+}
+
+function byId(defenses: ReadonlyArray<Defense>, id: string): Defense | undefined {
+  return defenses.find((defense) => defense.id === id);
+}
+
+function makeReport(defenses: ReadonlyArray<Defense>): SecurityReport {
+  return {
+    timestamp: "2026-09-10T00:00:00.000Z",
+    targetPath: "/tmp/hardened",
+    findings: [],
+    defenses,
+    score: {
+      grade: "A",
+      numericScore: 100,
+      breakdown: { secrets: 100, permissions: 100, hooks: 100, mcp: 100, agents: 100 },
+    },
+    summary: {
+      totalFindings: 0,
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+      filesScanned: 1,
+      autoFixable: 0,
+      defenses: defenses.length,
+    },
+  };
+}
+
+function makeDefense(index: number): Defense {
+  return {
+    id: `defense-sample-${index}`,
+    title: `Sample defense ${index}`,
+    file: `file-${index}.json`,
+    detail: "detail",
+    harness: "generic",
+  };
+}
+
+describe("detectDefenses: Claude Code settings", () => {
+  it("credits a non-empty deny list and reports coverage", () => {
+    const defenses = detectDefenses([
+      settings({
+        permissions: {
+          deny: ["Read(./.env)", "Read(~/.ssh/**)", "Bash(curl *)", "Bash(sudo *)", "Bash(rm -rf *)"],
+        },
+      }),
+    ]);
+    const deny = byId(defenses, "defense-deny-list");
+    expect(deny).toBeDefined();
+    expect(deny?.harness).toBe("claude-code");
+    expect(deny?.file).toBe(".claude/settings.json");
+    expect(deny?.detail).toContain("5 deny rules");
+    expect(deny?.detail).toContain("covers .env, ~/.ssh, curl, sudo, rm -rf");
+    expect(deny?.detail).not.toContain("not covered");
+  });
+
+  it("names the common targets a deny list misses", () => {
+    const defenses = detectDefenses([settings({ permissions: { deny: ["Bash(curl *)"] } })]);
+    const deny = byId(defenses, "defense-deny-list");
+    expect(deny?.detail).toContain("1 deny rule;");
+    expect(deny?.detail).toContain("covers curl");
+    expect(deny?.detail).toContain("not covered: .env, ~/.ssh, sudo, rm -rf");
+  });
+
+  it("does not credit an empty deny list or an allow-only config", () => {
+    const defenses = detectDefenses([
+      settings({ permissions: { deny: [], allow: ["Bash(*)"] } }),
+    ]);
+    expect(ids(defenses)).not.toContain("defense-deny-list");
+    expect(ids(defenses)).not.toContain("defense-ask-list");
+  });
+
+  it("credits an ask list and ignores an empty one", () => {
+    expect(ids(detectDefenses([settings({ permissions: { ask: ["Bash(git push *)"] } })]))).toContain(
+      "defense-ask-list"
+    );
+    expect(ids(detectDefenses([settings({ permissions: { ask: [] } })]))).not.toContain("defense-ask-list");
+  });
+
+  it("credits plan and default modes but not bypass or auto modes", () => {
+    expect(byId(detectDefenses([settings({ permissions: { defaultMode: "plan" } })]), "defense-default-mode")?.title).toBe(
+      'Permission mode "plan"'
+    );
+    expect(ids(detectDefenses([settings({ permissions: { defaultMode: "default" } })]))).toContain("defense-default-mode");
+    expect(ids(detectDefenses([settings({ permissions: { defaultMode: "bypassPermissions" } })]))).not.toContain(
+      "defense-default-mode"
+    );
+    expect(ids(detectDefenses([settings({ permissions: { defaultMode: "acceptEdits" } })]))).not.toContain(
+      "defense-default-mode"
+    );
+  });
+
+  it("credits disableBypassPermissionsMode only when set to disable", () => {
+    expect(
+      ids(detectDefenses([settings({ permissions: { disableBypassPermissionsMode: "disable" } })]))
+    ).toContain("defense-bypass-disabled");
+    expect(
+      ids(detectDefenses([settings({ permissions: { disableBypassPermissionsMode: "enable" } })]))
+    ).not.toContain("defense-bypass-disabled");
+  });
+
+  it("credits blockReadsOutsideWorkingDirectories only when true", () => {
+    expect(
+      ids(detectDefenses([settings({ permissions: { blockReadsOutsideWorkingDirectories: true } })]))
+    ).toContain("defense-block-reads-outside-cwd");
+    expect(
+      ids(detectDefenses([settings({ permissions: { blockReadsOutsideWorkingDirectories: false } })]))
+    ).not.toContain("defense-block-reads-outside-cwd");
+  });
+
+  it("credits an enabled sandbox and describes its hardening", () => {
+    const defenses = detectDefenses([
+      settings({
+        sandbox: {
+          enabled: true,
+          failIfUnavailable: true,
+          network: { allowedDomains: ["api.anthropic.com", "registry.npmjs.org"] },
+          filesystem: { denyRead: ["~/"] },
+          credentials: { files: { mode: "mask" }, envVars: { mode: "deny" } },
+        },
+      }),
+    ]);
+    const sandbox = byId(defenses, "defense-sandbox-enabled");
+    expect(sandbox).toBeDefined();
+    expect(sandbox?.detail).toContain("fails closed when the sandbox is unavailable");
+    expect(sandbox?.detail).toContain("network allow list of 2 domains with no wildcard");
+    expect(sandbox?.detail).toContain("filesystem denyRead on ~/");
+    expect(sandbox?.detail).toContain("credentials masked and denied");
+  });
+
+  it("does not describe a wildcard network allow list as an allow list", () => {
+    const defenses = detectDefenses([
+      settings({ sandbox: { enabled: true, network: { allowedDomains: ["*"] } } }),
+    ]);
+    const sandbox = byId(defenses, "defense-sandbox-enabled");
+    expect(sandbox?.detail).toBe("sandbox.enabled is true with default network and filesystem policy.");
+  });
+
+  it("does not credit a disabled sandbox", () => {
+    expect(ids(detectDefenses([settings({ sandbox: { enabled: false, failIfUnavailable: true } })]))).not.toContain(
+      "defense-sandbox-enabled"
+    );
+  });
+
+  it("credits managed-only and marketplace flags only when true", () => {
+    const positive = detectDefenses([
+      settings({
+        allowManagedPermissionRulesOnly: true,
+        allowManagedHooksOnly: true,
+        allowManagedMcpServersOnly: true,
+        strictKnownMarketplaces: true,
+        disableSkillShellExecution: true,
+      }),
+    ]);
+    expect(ids(positive)).toEqual(
+      expect.arrayContaining([
+        "defense-managed-permission-rules-only",
+        "defense-managed-hooks-only",
+        "defense-managed-mcp-servers-only",
+        "defense-strict-marketplaces",
+        "defense-skill-shell-disabled",
+      ])
+    );
+
+    const negative = detectDefenses([
+      settings({
+        allowManagedPermissionRulesOnly: false,
+        allowManagedHooksOnly: "true",
+        allowManagedMcpServersOnly: 1,
+        strictKnownMarketplaces: false,
+        disableSkillShellExecution: false,
+      }),
+    ]);
+    expect(negative).toHaveLength(0);
+  });
+
+  it("credits an explicit MCP server list unless every project server is enabled", () => {
+    expect(byId(detectDefenses([settings({ enabledMcpjsonServers: ["github"] })]), "defense-explicit-mcp-servers")?.detail).toContain(
+      "github"
+    );
+    expect(
+      ids(detectDefenses([settings({ enabledMcpjsonServers: ["github"], enableAllProjectMcpServers: true })]))
+    ).not.toContain("defense-explicit-mcp-servers");
+    expect(ids(detectDefenses([settings({ enabledMcpjsonServers: [] })]))).not.toContain("defense-explicit-mcp-servers");
+  });
+
+  it("returns nothing for settings that do not parse", () => {
+    expect(detectDefenses([file(".claude/settings.json", '{"permissions": {"deny": ["Bash(curl *)"')])).toHaveLength(0);
+  });
+
+  it("does not read Gemini, Cursor, or editor settings as Claude Code settings", () => {
+    const defenses = detectDefenses([
+      file(".zed/settings.json", JSON.stringify({ permissions: { deny: ["Bash(curl *)"] } })),
+      file(".vscode/settings.json", JSON.stringify({ permissions: { deny: ["Bash(curl *)"] } })),
+    ]);
+    expect(ids(defenses)).not.toContain("defense-deny-list");
+  });
+});
+
+describe("detectDefenses: blocking hooks", () => {
+  function hookSettings(event: string, command: string): ConfigFile {
+    return settings({
+      hooks: {
+        [event]: [{ matcher: "Bash", hooks: [{ type: "command", command }] }],
+      },
+    });
+  }
+
+  it("credits a PreToolUse hook whose inline command exits 2", () => {
+    const defenses = detectDefenses([
+      hookSettings("PreToolUse", "jq -e '.tool_input.command | test(\"rm -rf\")' && exit 2 || exit 0"),
+    ]);
+    const hook = byId(defenses, "defense-blocking-pretooluse-hook");
+    expect(hook).toBeDefined();
+    expect(hook?.title).toBe("Blocking PreToolUse hook");
+    expect(hook?.detail).toContain("1 PreToolUse command hook can deny a call");
+  });
+
+  it("credits PermissionRequest and UserPromptSubmit hooks that emit a deny decision", () => {
+    const defenses = detectDefenses([
+      settings({
+        hooks: {
+          PermissionRequest: [{ hooks: [{ type: "command", command: "echo '{\"decision\":\"deny\"}'" }] }],
+          UserPromptSubmit: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command:
+                    "grep -qE 'sk-|ghp_|AKIA' && echo '{\"hookSpecificOutput\":{\"permissionDecision\":\"deny\"}}'",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ]);
+    expect(ids(defenses)).toEqual(
+      expect.arrayContaining([
+        "defense-blocking-permissionrequest-hook",
+        "defense-blocking-userpromptsubmit-hook",
+      ])
+    );
+  });
+
+  it("follows a referenced hook script and credits it when the script denies", () => {
+    const defenses = detectDefenses([
+      hookSettings("PreToolUse", "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard.sh\""),
+      file(
+        ".claude/hooks/guard.sh",
+        "#!/bin/bash\ninput=$(cat)\nif echo \"$input\" | grep -q 'rm -rf'; then\n  echo 'blocked' >&2\n  exit 2\nfi\nexit 0\n",
+        "hook-script"
+      ),
+    ]);
+    expect(ids(defenses)).toContain("defense-blocking-pretooluse-hook");
+  });
+
+  it("does not credit a hook that only logs or only allows", () => {
+    const defenses = detectDefenses([
+      hookSettings("PreToolUse", "bash ./hooks/audit.sh"),
+      file("hooks/audit.sh", "#!/bin/bash\ncat >> ~/.claude/audit.log\nexit 0\n", "hook-script"),
+      settings({
+        hooks: { PreToolUse: [{ hooks: [{ type: "command", command: "echo '{\"decision\":\"allow\"}'" }] }] },
+      }, ".claude/settings.local.json"),
+    ]);
+    expect(ids(defenses)).not.toContain("defense-blocking-pretooluse-hook");
+  });
+
+  it("does not credit a PostToolUse hook even when it exits 2", () => {
+    expect(ids(detectDefenses([hookSettings("PostToolUse", "exit 2")]))).not.toContain(
+      "defense-blocking-posttooluse-hook"
+    );
+  });
+
+  it("credits a ConfigChange hook and reads plugin hooks manifests", () => {
+    const defenses = detectDefenses([
+      file(
+        "hooks/hooks.json",
+        JSON.stringify({
+          hooks: {
+            ConfigChange: [{ hooks: [{ type: "command", command: "${CLAUDE_PLUGIN_ROOT}/hooks/config-guard.sh" }] }],
+            PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "node hooks/block-no-verify.js" }] }],
+          },
+        }),
+        "plugin-manifest"
+      ),
+      file("hooks/block-no-verify.js", "if (/--no-verify/.test(cmd)) { process.exit(2); }\n", "hook-code"),
+    ]);
+    expect(ids(defenses)).toEqual(
+      expect.arrayContaining(["defense-configchange-hook", "defense-blocking-pretooluse-hook"])
+    );
+    expect(byId(defenses, "defense-configchange-hook")?.harness).toBe("claude-code");
+  });
+
+  it("does not credit ConfigChange when the hooks block is absent", () => {
+    expect(detectDefenses([settings({ hooks: {} })])).toHaveLength(0);
+  });
+});
+
+describe("detectDefenses: skills and agents", () => {
+  it("credits disable-model-invocation and narrow allowed-tools on a skill", () => {
+    const defenses = detectDefenses([
+      file(
+        ".claude/skills/deploy/SKILL.md",
+        "---\nname: deploy\ndisable-model-invocation: true\nallowed-tools: Read, Grep, Glob, Bash(git status *)\n---\n\nDeploy.\n",
+        "skill-md"
+      ),
+    ]);
+    expect(ids(defenses)).toEqual(
+      expect.arrayContaining(["defense-skill-no-model-invocation", "defense-skill-narrow-tools"])
+    );
+    expect(byId(defenses, "defense-skill-narrow-tools")?.detail).toContain("Bash(git status *)");
+  });
+
+  it("does not credit a skill with broad tools or model invocation enabled", () => {
+    const defenses = detectDefenses([
+      file(
+        ".claude/skills/deploy/SKILL.md",
+        "---\nname: deploy\ndisable-model-invocation: false\nallowed-tools:\n  - Read\n  - Bash(*)\n---\n\nDeploy.\n",
+        "skill-md"
+      ),
+      file(".claude/skills/write/SKILL.md", "---\nname: write\nallowed-tools: Read Write\n---\n", "skill-md"),
+      file(".claude/skills/bare/SKILL.md", "---\nname: bare\nallowed-tools: Bash\n---\n", "skill-md"),
+    ]);
+    expect(defenses).toHaveLength(0);
+  });
+
+  it("credits an agent tools allow list that omits Write, Edit, and Bash", () => {
+    const defenses = detectDefenses([
+      file(".claude/agents/reviewer.md", "---\nname: reviewer\ntools: Read, Grep, Glob\n---\n\nReview.\n", "agent-md"),
+    ]);
+    expect(byId(defenses, "defense-agent-tools-allowlist")?.detail).toBe("tools is limited to Read, Grep, Glob.");
+  });
+
+  it("does not credit an agent whose tools include Bash or Edit, or that has no tools list", () => {
+    const defenses = detectDefenses([
+      file(".claude/agents/builder.md", "---\nname: builder\ntools: Read, Edit, Bash\n---\n", "agent-md"),
+      file(".claude/agents/scoped.md", "---\nname: scoped\ntools: Read, Bash(git add *)\n---\n", "agent-md"),
+      file(".claude/agents/open.md", "---\nname: open\ndescription: no tools key\n---\n", "agent-md"),
+    ]);
+    expect(ids(defenses)).not.toContain("defense-agent-tools-allowlist");
+  });
+
+  it("credits disallowedTools on markdown and JSON agents", () => {
+    const defenses = detectDefenses([
+      file(".claude/agents/reader.md", "---\nname: reader\ndisallowedTools: Write, Edit, Agent\n---\n", "agent-md"),
+      file(
+        ".claude/subagents/planner.json",
+        JSON.stringify({ name: "planner", allowedTools: ["Read", "Grep"], disallowedTools: ["Bash"] }),
+        "agent-md"
+      ),
+    ]);
+    expect(defenses.filter((defense) => defense.id === "defense-agent-disallowed-tools")).toHaveLength(2);
+    expect(ids(defenses)).toContain("defense-agent-tools-allowlist");
+  });
+
+  it("does not credit an agent with an empty disallowedTools list", () => {
+    expect(
+      ids(detectDefenses([file(".claude/agents/x.md", "---\nname: x\ndisallowedTools: []\n---\n", "agent-md")]))
+    ).not.toContain("defense-agent-disallowed-tools");
+  });
+});
+
+describe("detectDefenses: Codex", () => {
+  it("credits read-only sandbox, on-request approvals, and env_http_headers", () => {
+    const defenses = detectDefenses([
+      file(
+        ".codex/config.toml",
+        'sandbox_mode = "read-only"\napproval_policy = "on-request"\n\n[mcp_servers.github]\nurl = "https://api.githubcopilot.com/mcp/"\nenv_http_headers = { Authorization = "GITHUB_TOKEN" }\n',
+        "codex-toml"
+      ),
+    ]);
+    expect(ids(defenses)).toEqual(
+      expect.arrayContaining([
+        "defense-codex-sandbox",
+        "defense-codex-approval-policy",
+        "defense-codex-env-http-headers",
+      ])
+    );
+    expect(defenses.every((defense) => defense.harness === "codex")).toBe(true);
+    expect(byId(defenses, "defense-codex-sandbox")?.title).toBe("Codex sandbox read-only");
+  });
+
+  it("credits workspace-write only when network access is off", () => {
+    const off = detectDefenses([
+      file(
+        ".codex/config.toml",
+        'sandbox_mode = "workspace-write"\napproval_policy = "on-failure"\n[sandbox_workspace_write]\nnetwork_access = false\n',
+        "codex-toml"
+      ),
+    ]);
+    expect(byId(off, "defense-codex-sandbox")?.detail).toContain("network_access is false");
+    expect(byId(off, "defense-codex-approval-policy")?.title).toBe('Codex approval policy "on-failure"');
+
+    const on = detectDefenses([
+      file(
+        ".codex/config.toml",
+        'sandbox_mode = "workspace-write"\napproval_policy = "never"\n[sandbox_workspace_write]\nnetwork_access = true\n',
+        "codex-toml"
+      ),
+    ]);
+    expect(on).toHaveLength(0);
+  });
+
+  it("does not credit danger-full-access or literal http_headers", () => {
+    const defenses = detectDefenses([
+      file(
+        ".codex/config.toml",
+        'sandbox_mode = "danger-full-access"\n[mcp_servers.github]\nhttp_headers = { Authorization = "Bearer ghp_x" }\n',
+        "codex-toml"
+      ),
+    ]);
+    expect(defenses).toHaveLength(0);
+  });
+
+  it("returns nothing for a TOML file that does not parse", () => {
+    expect(detectDefenses([file(".codex/config.toml", 'sandbox_mode = "read-only\n', "codex-toml")])).toHaveLength(0);
+  });
+
+  it("credits .rules files with forbidden or prompt decisions", () => {
+    const defenses = detectDefenses([
+      file(
+        ".codex/rules/default.rules",
+        'prefix_rule(pattern=["rm"], decision="forbidden")\nprefix_rule(pattern=["git", "push"], decision="prompt")\n',
+        "unknown"
+      ),
+    ]);
+    expect(byId(defenses, "defense-codex-rules-file")?.detail).toBe("1 forbidden and 1 prompt decisions gate command prefixes.");
+  });
+
+  it("does not credit .rules files that only allow", () => {
+    expect(
+      detectDefenses([file(".codex/rules/default.rules", 'prefix_rule(pattern=["ls"], decision="allow")\n', "unknown")])
+    ).toHaveLength(0);
+  });
+});
+
+describe("detectDefenses: Hermes", () => {
+  it("credits manual approvals, cron deny, container terminal, and an empty allow list", () => {
+    const defenses = detectDefenses([
+      file(
+        ".hermes/config.yaml",
+        "approvals:\n  mode: manual\n  cron_mode: deny\n  command_allowlist: []\nterminal:\n  backend: docker\n",
+        "hermes-yaml"
+      ),
+    ]);
+    expect(ids(defenses)).toEqual([
+      "defense-hermes-manual-approvals",
+      "defense-hermes-cron-deny",
+      "defense-hermes-container-terminal",
+      "defense-hermes-empty-allowlist",
+    ]);
+    expect(defenses.every((defense) => defense.harness === "hermes")).toBe(true);
+  });
+
+  it("does not credit auto approvals, a local terminal, or a populated allow list", () => {
+    const defenses = detectDefenses([
+      file(
+        ".hermes/config.yaml",
+        "approvals:\n  mode: auto\n  cron_mode: allow\n  command_allowlist:\n    - ls\nterminal:\n  backend: local\n",
+        "hermes-yaml"
+      ),
+    ]);
+    expect(defenses).toHaveLength(0);
+  });
+
+  it("returns nothing for YAML that does not parse", () => {
+    expect(detectDefenses([file(".hermes/config.yaml", "approvals: [mode: manual", "hermes-yaml")])).toHaveLength(0);
+  });
+});
+
+describe("detectDefenses: Gemini, OpenCode, Cursor", () => {
+  it("credits Gemini disableYoloMode and folderTrust", () => {
+    const defenses = detectDefenses([
+      file(
+        ".gemini/settings.json",
+        JSON.stringify({ security: { disableYoloMode: true, folderTrust: { enabled: true } } }),
+        "harness-json"
+      ),
+    ]);
+    expect(ids(defenses)).toEqual(["defense-gemini-yolo-disabled", "defense-gemini-folder-trust"]);
+    expect(defenses[0].harness).toBe("gemini");
+  });
+
+  it("does not credit Gemini settings with yolo allowed and trust off", () => {
+    expect(
+      detectDefenses([
+        file(
+          ".gemini/settings.json",
+          JSON.stringify({ security: { disableYoloMode: false, folderTrust: { enabled: false } } }),
+          "harness-json"
+        ),
+      ])
+    ).toHaveLength(0);
+  });
+
+  it("credits OpenCode permission.bash ask, deny, or an all-gated map", () => {
+    expect(
+      byId(
+        detectDefenses([file("opencode.json", JSON.stringify({ permission: { bash: "ask" } }), "harness-json")]),
+        "defense-opencode-bash-gate"
+      )?.harness
+    ).toBe("opencode");
+    expect(
+      ids(detectDefenses([file(".opencode/opencode.jsonc", '{ "permission": { "bash": "deny" }, }', "harness-json")]))
+    ).toContain("defense-opencode-bash-gate");
+    expect(
+      ids(
+        detectDefenses([
+          file("opencode.json", JSON.stringify({ permission: { bash: { "*": "ask", "git status *": "deny" } } }), "harness-json"),
+        ])
+      )
+    ).toContain("defense-opencode-bash-gate");
+  });
+
+  it("does not credit OpenCode permission.bash allow or a partially allowed map", () => {
+    expect(
+      detectDefenses([file("opencode.json", JSON.stringify({ permission: { bash: "allow" } }), "harness-json")])
+    ).toHaveLength(0);
+    expect(
+      detectDefenses([
+        file("opencode.json", JSON.stringify({ permission: { bash: { "*": "allow", "rm *": "deny" } } }), "harness-json"),
+      ])
+    ).toHaveLength(0);
+  });
+
+  it("credits Cursor hooks with failClosed true and names the events", () => {
+    const defenses = detectDefenses([
+      file(
+        ".cursor/hooks.json",
+        JSON.stringify({
+          version: 1,
+          hooks: {
+            beforeShellExecution: [{ command: "./hooks/guard.sh", failClosed: true }],
+            beforeMCPExecution: [{ command: "./hooks/mcp-guard.sh", failClosed: true }],
+            afterFileEdit: [{ command: "./hooks/format.sh" }],
+          },
+        }),
+        "harness-json"
+      ),
+    ]);
+    expect(defenses).toHaveLength(1);
+    expect(defenses[0].id).toBe("defense-cursor-fail-closed-hook");
+    expect(defenses[0].harness).toBe("cursor");
+    expect(defenses[0].detail).toContain("beforeShellExecution, beforeMCPExecution");
+  });
+
+  it("does not credit Cursor hooks that fail open", () => {
+    expect(
+      detectDefenses([
+        file(
+          ".cursor/hooks.json",
+          JSON.stringify({ version: 1, hooks: { beforeShellExecution: [{ command: "./guard.sh", failClosed: false }] } }),
+          "harness-json"
+        ),
+      ])
+    ).toHaveLength(0);
+  });
+});
+
+describe("defense rendering", () => {
+  it("lists up to 12 defenses in the terminal report and counts the rest", () => {
+    const defenses = Array.from({ length: 15 }, (_, index) => makeDefense(index + 1));
+    const output = renderTerminalReport(makeReport(defenses));
+    expect(output).toContain("Recognized Defenses");
+    expect(output).toContain("Sample defense 1");
+    expect(output).toContain("file-12.json");
+    expect(output).not.toContain("Sample defense 13");
+    expect(output).toContain("3 more");
+    expect(output.indexOf("Score Breakdown")).toBeLessThan(output.indexOf("Recognized Defenses"));
+  });
+
+  it("omits the terminal section and the more line when nothing is recognized", () => {
+    const output = renderTerminalReport(makeReport([]));
+    expect(output).not.toContain("Recognized Defenses");
+    expect(output).not.toContain(" more");
+  });
+
+  it("renders a markdown table and includes the array in JSON", () => {
+    const defenses = [makeDefense(1), { ...makeDefense(2), detail: "pipe | inside" }];
+    const markdown = renderMarkdownReport(makeReport(defenses));
+    expect(markdown).toContain("## Recognized Defenses");
+    expect(markdown).toContain("| Defense | File | Harness | Detail |");
+    expect(markdown).toContain("| Sample defense 1 | `file-1.json` | generic | detail |");
+    expect(markdown).toContain("pipe \\| inside");
+    expect(markdown).toContain("| Recognized defenses | 2 |");
+
+    const json = JSON.parse(renderJsonReport(makeReport(defenses))) as SecurityReport;
+    expect(json.defenses).toHaveLength(2);
+    expect(json.defenses[0].id).toBe("defense-sample-1");
+    expect(json.summary.defenses).toBe(2);
+  });
+
+  it("shows a defenses count in the HTML summary", () => {
+    const html = renderHtmlReport(makeReport([makeDefense(1)]));
+    expect(html).toContain("Defenses");
+  });
+});
+
+describe("end to end: hardened Claude Code setup", () => {
+  it("credits every defense and keeps the score at 100", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "agentshield-hardened-"));
+    try {
+      mkdirSync(join(tempDir, ".claude", "hooks"), { recursive: true });
+      writeFileSync(
+        join(tempDir, ".claude", "settings.json"),
+        JSON.stringify(
+          {
+            permissions: {
+              defaultMode: "default",
+              disableBypassPermissionsMode: "disable",
+              deny: [
+                "Read(./.env)",
+                "Read(~/.ssh/**)",
+                "Bash(curl *)",
+                "Bash(sudo *)",
+                "Bash(rm -rf *)",
+                "Bash(chmod 777 *)",
+                "Bash(* > /dev/*)",
+              ],
+              ask: ["Bash(git push *)"],
+            },
+            sandbox: {
+              enabled: true,
+              failIfUnavailable: true,
+              network: { allowedDomains: ["api.anthropic.com"] },
+            },
+            hooks: {
+              PreToolUse: [
+                {
+                  matcher: "Bash",
+                  hooks: [{ type: "command", command: '"$CLAUDE_PROJECT_DIR/.claude/hooks/guard.sh"' }],
+                },
+              ],
+              Stop: [{ hooks: [{ type: "command", command: "npm test" }] }],
+            },
+          },
+          null,
+          2
+        )
+      );
+      writeFileSync(
+        join(tempDir, ".claude", "hooks", "guard.sh"),
+        '#!/bin/bash\ninput=$(cat)\nif printf "%s" "$input" | grep -q "rm -rf"; then\n  echo "Blocked destructive command" >&2\n  exit 2\nfi\nexit 0\n'
+      );
+
+      const result = scan(tempDir);
+      const report = calculateScore(result);
+
+      expect(ids(report.defenses)).toEqual(
+        expect.arrayContaining([
+          "defense-deny-list",
+          "defense-ask-list",
+          "defense-default-mode",
+          "defense-bypass-disabled",
+          "defense-sandbox-enabled",
+          "defense-blocking-pretooluse-hook",
+        ])
+      );
+      expect(report.summary.defenses).toBe(report.defenses.length);
+      expect(report.findings.filter((finding) => finding.severity !== "info")).toHaveLength(0);
+      expect(report.score.numericScore).toBe(100);
+      expect(report.score.grade).toBe("A");
+
+      const terminal = renderTerminalReport(report);
+      expect(terminal).toContain("Recognized Defenses");
+      expect(terminal).toContain("Permission deny list");
+      expect(terminal).toContain("Sandbox enabled");
+      expect(terminal).toContain("Blocking PreToolUse hook");
+
+      const markdown = renderMarkdownReport(report);
+      expect(markdown).toContain("## Recognized Defenses");
+      expect(markdown).toContain("Blocking PreToolUse hook");
+
+      const json = JSON.parse(renderJsonReport(report)) as SecurityReport;
+      expect(json.defenses.map((defense) => defense.id)).toContain("defense-sandbox-enabled");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/reporter/html.test.ts
+++ b/tests/reporter/html.test.ts
@@ -7,6 +7,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
     timestamp: "2026-02-11T00:00:00.000Z",
     targetPath: "/tmp/test",
     findings: [],
+    defenses: [],
     score: {
       grade: "A",
       numericScore: 95,
@@ -21,6 +22,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
       info: 0,
       filesScanned: 4,
       autoFixable: 0,
+      defenses: 0,
     },
     ...overrides,
   };
@@ -109,6 +111,7 @@ describe("renderHtmlReport", () => {
         info: 0,
         filesScanned: 3,
         autoFixable: 0,
+        defenses: 0,
       },
     }));
 
@@ -166,6 +169,7 @@ describe("renderHtmlReport", () => {
         info: 0,
         filesScanned: 3,
         autoFixable: 1,
+        defenses: 0,
       },
     });
     const html = renderHtmlReport(report);
@@ -200,6 +204,7 @@ describe("renderHtmlReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     });
 
@@ -227,6 +232,7 @@ describe("renderHtmlReport", () => {
         info: 0,
         filesScanned: 2,
         autoFixable: 0,
+        defenses: 0,
       },
     });
     const html = renderHtmlReport(report);

--- a/tests/reporter/json.test.ts
+++ b/tests/reporter/json.test.ts
@@ -8,6 +8,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
     timestamp: "2026-02-11T00:00:00.000Z",
     targetPath: "/tmp/test",
     findings: [],
+    defenses: [],
     score: {
       grade: "B",
       numericScore: 80,
@@ -22,6 +23,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
       info: 0,
       filesScanned: 5,
       autoFixable: 0,
+      defenses: 0,
     },
     ...overrides,
   };
@@ -114,6 +116,7 @@ describe("renderJsonReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     });
     const parsed = JSON.parse(renderJsonReport(report));
@@ -144,6 +147,7 @@ describe("renderJsonReport", () => {
         info: 1,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     });
     const parsed = JSON.parse(renderJsonReport(report));
@@ -252,6 +256,7 @@ describe("renderMarkdownReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 1,
+        defenses: 0,
       },
     });
     const output = renderMarkdownReport(report);
@@ -349,6 +354,7 @@ describe("renderMarkdownReport", () => {
         info: 1,
         filesScanned: 5,
         autoFixable: 0,
+        defenses: 0,
       },
     }));
 
@@ -396,6 +402,7 @@ describe("renderMarkdownReport", () => {
         info: 0,
         filesScanned: 3,
         autoFixable: 0,
+        defenses: 0,
       },
     }));
 

--- a/tests/reporter/sarif.test.ts
+++ b/tests/reporter/sarif.test.ts
@@ -8,6 +8,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
     timestamp: "2026-05-11T20:00:00.000Z",
     targetPath: "/tmp/repo",
     findings: [],
+    defenses: [],
     score: {
       grade: "B",
       numericScore: 84,
@@ -22,6 +23,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
       info: 0,
       filesScanned: 4,
       autoFixable: 0,
+      defenses: 0,
     },
     ...overrides,
   };
@@ -83,6 +85,7 @@ describe("renderSarifReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     })));
 
@@ -141,6 +144,7 @@ describe("renderSarifReport", () => {
         info: 0,
         filesScanned: 2,
         autoFixable: 0,
+        defenses: 0,
       },
     })));
 
@@ -170,6 +174,7 @@ describe("renderSarifReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     })));
 

--- a/tests/reporter/score.test.ts
+++ b/tests/reporter/score.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { calculateScore } from "../../src/reporter/score.js";
+import {
+  calculateScore,
+  deductionFor,
+  GUARD_PATTERN_TITLE_PREFIXES,
+  isGuardPatternFinding,
+  isNonPenalizingFinding,
+} from "../../src/reporter/score.js";
 import type { Finding, ScanTarget, SkillHealthSummary } from "../../src/types.js";
 import type { ScanResult } from "../../src/scanner/index.js";
 
@@ -404,5 +410,118 @@ describe("calculateScore", () => {
     });
 
     expect(report.score.numericScore).toBe(100);
+  });
+
+  it("populates recognized defenses from the scanned files and counts them in the summary", () => {
+    const target: ScanTarget = {
+      path: "/test",
+      files: [
+        {
+          path: ".claude/settings.json",
+          type: "settings-json",
+          content: JSON.stringify({ permissions: { deny: ["Bash(curl *)"] }, sandbox: { enabled: true } }),
+        },
+      ],
+      danglingSymlinks: [],
+    };
+    const report = calculateScore({ target, findings: [] });
+    expect(report.defenses.map((defense) => defense.id)).toEqual([
+      "defense-deny-list",
+      "defense-sandbox-enabled",
+    ]);
+    expect(report.summary.defenses).toBe(2);
+  });
+
+  it("reports zero defenses when nothing protective is configured", () => {
+    const report = calculateScore(makeScanResult([]));
+    expect(report.defenses).toEqual([]);
+    expect(report.summary.defenses).toBe(0);
+  });
+
+  it("never adds points for defenses", () => {
+    const hardened: ScanTarget = {
+      path: "/test",
+      files: [
+        {
+          path: ".claude/settings.json",
+          type: "settings-json",
+          content: JSON.stringify({ permissions: { deny: ["Bash(curl *)", "Bash(sudo *)"] } }),
+        },
+      ],
+      danglingSymlinks: [],
+    };
+    const finding = makeFinding({ id: "h1", severity: "high" });
+    const withDefenses = calculateScore({ target: hardened, findings: [finding] });
+    const withoutDefenses = calculateScore(makeScanResult([finding]));
+    expect(withDefenses.defenses.length).toBeGreaterThan(0);
+    expect(withDefenses.score.numericScore).toBe(withoutDefenses.score.numericScore);
+    expect(withDefenses.score.breakdown).toEqual(withoutDefenses.score.breakdown);
+  });
+});
+
+describe("zero-deduction guarantee", () => {
+  it("assigns zero deduction to every info finding regardless of confidence", () => {
+    const confidences = [
+      undefined,
+      "active-runtime",
+      "project-local-optional",
+      "template-example",
+      "docs-example",
+      "plugin-cache",
+      "plugin-manifest",
+      "hook-code",
+    ] as const;
+    for (const runtimeConfidence of confidences) {
+      const finding = makeFinding({ severity: "info", category: "secrets", runtimeConfidence });
+      expect(isNonPenalizingFinding(finding)).toBe(true);
+      expect(deductionFor(finding)).toBe(0);
+    }
+  });
+
+  it("assigns zero deduction to guard-pattern findings at info severity", () => {
+    const titles = [
+      "Guard pattern: PreToolUse hook blocks rm -rf",
+      "Deny/ask rule blocking curl (good practice)",
+      "Prohibition of sudo (good practice)",
+      "Mention of rm -rf (not an executed command)",
+      "Example config: deny list template",
+    ];
+    for (const title of titles) {
+      const finding = makeFinding({ severity: "info", category: "permissions", title });
+      expect(isGuardPatternFinding(finding)).toBe(true);
+      expect(isNonPenalizingFinding(finding)).toBe(true);
+      expect(deductionFor(finding)).toBe(0);
+    }
+    expect(GUARD_PATTERN_TITLE_PREFIXES).toHaveLength(titles.length);
+  });
+
+  it("keeps the score at 100 when only info and guard-pattern findings exist", () => {
+    const report = calculateScore(
+      makeScanResult([
+        makeFinding({ id: "g1", severity: "info", title: "Deny/ask rule blocking curl (good practice)" }),
+        makeFinding({ id: "g2", severity: "info", title: "Prohibition of sudo (good practice)", category: "agents" }),
+        makeFinding({ id: "g3", severity: "info", title: "Mention of rm -rf (not an executed command)", category: "hooks" }),
+        makeFinding({ id: "g4", severity: "info", title: "Guard pattern: sandbox enabled", category: "mcp" }),
+        makeFinding({ id: "i1", severity: "info", title: "Plain informational note", category: "secrets" }),
+      ])
+    );
+    expect(report.summary.info).toBe(5);
+    expect(report.score.breakdown).toEqual({ secrets: 100, permissions: 100, hooks: 100, mcp: 100, agents: 100 });
+    expect(report.score.numericScore).toBe(100);
+    expect(report.score.grade).toBe("A");
+  });
+
+  it("still scores a guard-titled finding that a rule mislabels above info", () => {
+    const finding = makeFinding({ severity: "medium", title: "Prohibition of sudo (good practice)" });
+    expect(isGuardPatternFinding(finding)).toBe(true);
+    expect(isNonPenalizingFinding(finding)).toBe(false);
+    expect(deductionFor(finding)).toBe(5);
+  });
+
+  it("returns the weighted deduction for scored findings", () => {
+    expect(deductionFor(makeFinding({ severity: "critical" }))).toBe(25);
+    expect(deductionFor(makeFinding({ severity: "high" }))).toBe(15);
+    expect(deductionFor(makeFinding({ severity: "low" }))).toBe(2);
+    expect(deductionFor(makeFinding({ severity: "medium", runtimeConfidence: "docs-example" }))).toBe(1.25);
   });
 });

--- a/tests/reporter/terminal.test.ts
+++ b/tests/reporter/terminal.test.ts
@@ -34,6 +34,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
     timestamp: "2026-02-11T00:00:00.000Z",
     targetPath: "/tmp/test",
     findings: [],
+    defenses: [],
     score: {
       grade: "A",
       numericScore: 100,
@@ -48,6 +49,7 @@ function makeReport(overrides: Partial<SecurityReport> = {}): SecurityReport {
       info: 0,
       filesScanned: 3,
       autoFixable: 0,
+      defenses: 0,
     },
     ...overrides,
   };
@@ -116,6 +118,7 @@ describe("renderTerminalReport", () => {
         info: 0,
         filesScanned: 2,
         autoFixable: 0,
+        defenses: 0,
       },
     });
     const output = renderTerminalReport(report);
@@ -148,6 +151,7 @@ describe("renderTerminalReport", () => {
         info: 1,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     });
 
@@ -177,6 +181,7 @@ describe("renderTerminalReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 0,
+        defenses: 0,
       },
     });
     const output = renderTerminalReport(report);
@@ -210,6 +215,7 @@ describe("renderTerminalReport", () => {
         info: 0,
         filesScanned: 1,
         autoFixable: 1,
+        defenses: 0,
       },
     });
     const output = renderTerminalReport(report);


### PR DESCRIPTION
Adds src/reporter/defenses.ts, which detects 32 protective constructs across Claude Code (deny and ask lists, default mode, bypass disabled, sandbox, managed-only switches, explicit MCP lists, blocking PreToolUse, PermissionRequest, UserPromptSubmit and ConfigChange hooks, skill and agent tool restrictions), Codex, Hermes, Gemini, OpenCode, and Cursor. The SecurityReport carries a defenses array, rendered in terminal, markdown, JSON, and the HTML summary card. The score engine routes every deduction through deductionFor, which returns zero for info findings, with tests proving guard-pattern and prohibition findings never deduct and defenses never add points. README documents the policy. 55 new tests.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62567621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Do not merge until the repository-required matching convention is satisfied; the two report-integrity concerns are non-blocking but should be addressed to keep reports trustworthy.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Avoid false blocking defenses** <a href="https://github.com/affaan-m/agentshield/pull/142#discussion_r3978910275">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Prevent summary markup injection** <a href="https://github.com/affaan-m/agentshield/pull/142#discussion_r3978910289">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/reporter/defenses.ts:370
A hook is credited as blocking whenever its command text contains `exit 2`, including quoted output or search patterns. For example, `echo "exit 2"` exits successfully and `grep -q 'exit 2' safe.txt` only searches for text, but both are reported as hooks that can deny tool calls. This does not block merging, but it can make users believe a repository has an enforcement control that does not exist.

### Issue 2
src/reporter/json.ts:25-26
Repository-controlled defense details are inserted into the GitHub job-summary table after only pipes and line endings are escaped. Markdown formatting, inline code, and supported HTML therefore render as content rather than text, allowing a scanned repository to visually alter a security report and misrepresent its protections. This does not block merging, but it weakens the trustworthiness of rendered reports.

**How this was verified:** A rendered report containing a defense detail with Markdown and HTML produced formatted text and an expandable HTML section in GitHub-flavored Markdown output.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- This PR adds recognized-defense detection and defense reporting across supported agent harnesses, along with score-neutral handling and output coverage. Two report-integrity failures were reproduced: hook commands can be falsely credited as blocking defenses, and repository-controlled defense text can render as Markdown or HTML in the GitHub job summary. The required regular-expression matching convention is also not followed.

<sub>Reviews (1) · Last reviewed commit: ["feat(reporter): add recognized defenses ..."](https://github.com/affaan-m/agentshield/commit/d84a245f5b39652a203b5a6a92e46ebc8e16f5a2)</sub>

<!-- /greptile_comment -->